### PR TITLE
Add library for DER-encoding X.509 certificates

### DIFF
--- a/dpe/Cargo.lock
+++ b/dpe/Cargo.lock
@@ -3,5 +3,99 @@
 version = 3
 
 [[package]]
+name = "asn1"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2affba5e62ee09eeba078f01a00c4aed45ac4287e091298eccbb0d4802efbdc5"
+dependencies = [
+ "asn1_derive",
+ "chrono",
+]
+
+[[package]]
+name = "asn1_derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfab79c195875e5aef2bd20b4c8ed8d43ef9610bcffefbbcf66f88f555cc78af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "chrono"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "dpe"
 version = "0.1.0"
+dependencies = [
+ "asn1",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e159d99e6c2b93995d171050271edb50ecc5288fbc7cc17de8fdce4e58c14"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"

--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -9,3 +9,6 @@ dpe_profile_p256_sha256 = []
 dpe_profile_p384_sha384 = []
 
 [dependencies]
+
+[dev-dependencies]
+asn1 = "0.13.0"

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -10,6 +10,7 @@ use response::DpeErrorCode;
 pub mod commands;
 pub mod dpe_instance;
 mod response;
+mod x509;
 
 const MAX_HANDLES: usize = 24;
 #[allow(dead_code)]
@@ -22,6 +23,7 @@ mod profile {
     pub const DPE_PROFILE_CONSTANT: u32 = super::DPE_PROFILE_P256_SHA256;
     pub const TCI_SIZE: usize = 32;
     pub const CDI_SIZE: usize = 32;
+    pub const ECC_INT_SIZE: usize = 32;
 }
 
 #[cfg(feature = "dpe_profile_p384_sha384")]
@@ -29,6 +31,7 @@ mod profile {
     pub const DPE_PROFILE_CONSTANT: u32 = super::DPE_PROFILE_P384_SHA384;
     pub const TCI_SIZE: usize = 48;
     pub const CDI_SIZE: usize = 48;
+    pub const ECC_INT_SIZE: usize = 48;
 }
 
 /// Execute a DPE command.

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -1,0 +1,255 @@
+//! Lightweight X.509 encoding routines for DPE
+//!
+//! DPE requires encoding variable-length certificates. This module provides
+//! this functionality for a no_std environment.
+
+use crate::profile;
+use crate::response::DpeErrorCode;
+
+pub struct EcdsaSignature {
+    r: [u8; profile::ECC_INT_SIZE],
+    s: [u8; profile::ECC_INT_SIZE],
+}
+
+pub struct EcdsaPub {
+    x: [u8; profile::ECC_INT_SIZE],
+    y: [u8; profile::ECC_INT_SIZE],
+}
+
+/// Calculate the number of bytes the ASN.1 size field will be
+fn get_size_width(size: usize) -> Result<usize, DpeErrorCode> {
+    if size <= 127 {
+        Ok(1)
+    } else if size <= 255 {
+        Ok(2)
+    } else if size <= 65535 {
+        Ok(3)
+    } else {
+        Err(DpeErrorCode::InternalError)
+    }
+}
+
+/// Calculate the number of bytes the ASN.1 INTEGER will be
+fn get_integer_bytes_size(integer: &[u8]) -> usize {
+    let mut len = integer.len();
+    for (i, &byte) in integer.iter().enumerate() {
+        if byte == 0 && i != integer.len() - 1 {
+            len -= 1;
+        } else if (byte & 0x80) != 0 {
+            len += 1;
+            break;
+        } else {
+            break;
+        }
+    }
+
+    len
+}
+
+/// Calculate the number of bytes the ASN.1 INTEGER will be
+fn get_integer_size(integer: u32) -> usize {
+    let bytes = integer.to_be_bytes();
+    get_integer_bytes_size(&bytes)
+}
+
+/// Calculate the number of bytes the ASN.1 RelativeDistinguishedName will be
+fn get_rdn_size(cn: &str, serial_number: &str) -> Result<u32, DpeErrorCode> {
+    Err(DpeErrorCode::InternalError)
+}
+
+/// Calculate the number of bytes an ECC AlgorithmIdentifier will be
+fn get_ecc_alg_id_size() -> Result<u32, DpeErrorCode> {
+    Err(DpeErrorCode::InternalError)
+}
+
+/// Calculate the number of bytes an ECC SubjectPublicKeyInfo will be
+fn get_ecdsa_subject_pubkey_info_size(pubkey: EcdsaPub) -> Result<u32, DpeErrorCode> {
+    Err(DpeErrorCode::InternalError)
+}
+
+pub struct X509CertWriter<'a> {
+    certificate: &'a mut [u8],
+    offset: usize,
+}
+
+impl X509CertWriter<'_> {
+    const INTEGER_TAG: u8 = 0x2;
+    const BIT_STRING_TAG: u8 = 0x3;
+    const OCTET_STRING_TAG: u8 = 0x4;
+    const OID_TAG: u8 = 0x6;
+    const SEQUENCE_TAG: u8 = 0x10;
+    const SEQUENCE_OF_TAG: u8 = 0x30;
+
+    pub fn new(cert: &mut [u8]) -> X509CertWriter {
+        X509CertWriter {
+            certificate: cert,
+            offset: 0,
+        }
+    }
+
+    fn encode_byte(&mut self, byte: u8) -> usize {
+        self.certificate[self.offset] = byte;
+        self.offset += 1;
+        1
+    }
+
+    /// DER-encodes the tag field of an ASN.1 type
+    fn encode_tag_field(&mut self, tag: u8) -> usize {
+        self.encode_byte(tag)
+    }
+
+    /// DER-encodes the size field of an ASN.1 type
+    fn encode_size_field(&mut self, size: usize) -> Result<usize, DpeErrorCode> {
+        let size_width = get_size_width(size)?;
+
+        if size_width == 1 {
+            self.encode_byte(size as u8);
+        } else {
+            self.encode_byte(0x80 | (size_width as u8));
+            for i in (0..size_width - 1).rev() {
+                self.encode_byte((size >> i) as u8);
+            }
+        }
+
+        Ok(size_width)
+    }
+
+    /// DER-encodes a big-endian integer buffer as an ASN.1 INTEGER
+    fn encode_integer_bytes(&mut self, integer: &[u8]) -> Result<usize, DpeErrorCode> {
+        let mut bytes_written = self.encode_tag_field(Self::INTEGER_TAG);
+
+        let mut size = get_integer_bytes_size(integer);
+        bytes_written += self.encode_size_field(size)?;
+
+        // Compute where to start reading from integer (strips leading zeros)
+        let integer_offset = integer.len().saturating_sub(size);
+
+        // If size got larger it is because a null byte needs to be prepended
+        if size > integer.len() {
+            bytes_written += self.encode_byte(0);
+            size -= 1;
+        }
+
+        self.certificate[self.offset..self.offset + size]
+            .clone_from_slice(&integer[integer_offset..]);
+
+        bytes_written += size;
+        self.offset += size;
+
+        Ok(bytes_written)
+    }
+
+    /// DER-encodes `integer` as n ASN.1 INTEGER
+    fn encode_integer(&mut self, integer: u64) -> Result<usize, DpeErrorCode> {
+        self.encode_integer_bytes(&integer.to_be_bytes())
+    }
+
+    /// DER-encodes a RelativeDistinguisedName with CommonName and SerialNumber
+    /// fields.
+    fn encode_rdn(&mut self, cn: &str, serial_number: &str) -> Result<u32, DpeErrorCode> {
+        Err(DpeErrorCode::InternalError)
+    }
+
+    /// DER-encodes the AlgorithmIdentifier for the signing algorithm used by
+    /// the DPE profile.
+    ///
+    ///AlgorithmIdentifier  ::=  SEQUENCE  {
+    ///     algorithm   OBJECT IDENTIFIER,
+    ///     parameters  ECParameters
+    ///     }
+    ///
+    /// ECParameters ::= CHOICE {
+    ///       namedCurve         OBJECT IDENTIFIER
+    ///       -- implicitCurve   NULL
+    ///       -- specifiedCurve  SpecifiedECDomain
+    ///     }
+    fn encode_signature_alg_id(&mut self) -> Result<u32, DpeErrorCode> {
+        Err(DpeErrorCode::InternalError)
+    }
+
+    /// Encode SubjectPublicKeyInfo for an ECDSA public key
+    ///
+    /// Returns number of bytes written to `remaining_cert`
+    ///
+    /// SubjectPublicKeyInfo  ::=  SEQUENCE  {
+    ///        algorithm            AlgorithmIdentifier,
+    ///        subjectPublicKey     BIT STRING  }
+    fn encode_ecdsa_subject_pubkey_info(&mut self, pubkey: &EcdsaPub) -> Result<u32, DpeErrorCode> {
+        Err(DpeErrorCode::InternalError)
+    }
+
+    /// ECDSA-Sig-Value ::= SEQUENCE {
+    ///     r  INTEGER,
+    ///     s  INTEGER
+    ///   }
+    fn encode_ecdsa_signature(&mut self, sig: &EcdsaSignature) -> Result<u32, DpeErrorCode> {
+        Err(DpeErrorCode::InternalError)
+    }
+
+    /// Encode an ECDSA X.509 certificate
+    ///
+    /// Returns number of bytes written to `scratch`
+    ///
+    /// Certificate  ::=  SEQUENCE  {
+    ///    tbsCertificate       TBSCertificate,
+    ///    signatureAlgorithm   AlgorithmIdentifier,
+    ///    signatureValue       BIT STRING  }
+    ///
+    /// TBSCertificate  ::=  SEQUENCE  {
+    ///    version         [0]  EXPLICIT Version DEFAULT v1,
+    ///    serialNumber         CertificateSerialNumber,
+    ///    signature            AlgorithmIdentifier,
+    ///    issuer               Name,
+    ///    validity             Validity,
+    ///    subject              Name,
+    ///    subjectPublicKeyInfo SubjectPublicKeyInfo,
+    ///    issuerUniqueID  [1]  IMPLICIT UniqueIdentifier OPTIONAL,
+    ///                         -- If present, version MUST be v2 or v3
+    ///    subjectUniqueID [2]  IMPLICIT UniqueIdentifier OPTIONAL,
+    ///                         -- If present, version MUST be v2 or v3
+    ///    extensions      [3]  EXPLICIT Extensions OPTIONAL
+    ///                         -- If present, version MUST be v3
+    ///    }
+    pub fn encode_ecdsa_certificate(
+        &mut self,
+        pubkey: &EcdsaPub,
+        sig: &EcdsaSignature,
+    ) -> Result<u32, DpeErrorCode> {
+        Err(DpeErrorCode::InternalError)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::x509::X509CertWriter;
+    use asn1;
+
+    #[test]
+    fn encode_integers() {
+        let buffer_cases = [
+            [0; 8],
+            [0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00],
+            [0x01, 0x02, 0x03, 0x04, 0x00, 0x00, 0x00, 0x00],
+            [0x00, 0x00, 0xFF, 0x04, 0x00, 0x00, 0x00, 0x00],
+            [0x01, 0x02, 0x03, 0x04, 0x00, 0x00, 0x00, 0x00],
+        ];
+
+        for c in buffer_cases {
+            let mut cert = [0u8; 128];
+            let mut w = X509CertWriter::new(&mut cert);
+            let byte_count = w.encode_integer_bytes(&c).unwrap();
+            let n = asn1::parse_single::<u64>(&cert[..byte_count]).unwrap();
+            assert_eq!(n, u64::from_be_bytes(c));
+        }
+
+        let integer_cases = [0xFFFFFFFF00000000, 0x0102030405060708];
+
+        for c in integer_cases {
+            let mut cert = [0; 128];
+            let mut w = X509CertWriter::new(&mut cert);
+            let byte_count = w.encode_integer(c).unwrap();
+            let n = asn1::parse_single::<u64>(&cert[..byte_count]).unwrap();
+            assert_eq!(n, c);
+        }
+    }
+}

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -30,7 +30,7 @@ fn cleanup() {
             println!();
         }
         Err(_) => {
-            println!("Warning: Unable to unlink {}", SOCKET_PATH);
+            println!("Warning: Unable to unlink {SOCKET_PATH}");
         }
     }
 }
@@ -52,7 +52,7 @@ fn main() -> std::io::Result<()> {
 
     let mut dpe = DpeInstance::new();
 
-    println!("DPE listening to socket {}", SOCKET_PATH);
+    println!("DPE listening to socket {SOCKET_PATH}");
 
     for stream in listener.incoming() {
         match stream {
@@ -60,7 +60,7 @@ fn main() -> std::io::Result<()> {
                 handle_request(&mut dpe, &mut stream);
             }
             Err(err) => {
-                println!("Failed to open socket: {}", err);
+                println!("Failed to open socket: {err}");
                 cleanup();
                 break;
             }


### PR DESCRIPTION
DPE certificates are variable-size and therefore require real encoding (as opposed to templating). Add a library for encoding X.509 certificates.

Add encoding routines for ASN.1 INTEGERs. The remaining functions are stubbed.