### PR TITLE
Add generic crypto impl with trait of traits.

### DIFF
--- a/dpe/Cargo.lock
+++ b/dpe/Cargo.lock
@@ -30,6 +30,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "chrono"
 version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,7 +62,29 @@ name = "dpe"
 version = "0.1.0"
 dependencies = [
  "asn1",
+ "openssl",
 ]
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "libc"
+version = "0.2.139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "num-integer"
@@ -64,6 +104,57 @@ checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "openssl"
+version = "0.10.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "proc-macro2"
@@ -99,3 +190,9 @@ name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"

--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -12,3 +12,4 @@ dpe_profile_p384_sha384 = []
 
 [dev-dependencies]
 asn1 = "0.13.0"
+openssl = "0.10"

--- a/dpe/src/crypto.rs
+++ b/dpe/src/crypto.rs
@@ -1,0 +1,27 @@
+/*++
+Licensed under the Apache-2.0 license.
+
+Abstract:
+    Generic trait definition of Cryptographic functions.
+--*/
+
+use crate::{response::DpeErrorCode, profile};
+
+pub trait Crypto {
+    type Rng: Rng;
+    type Hash: Hash;
+    fn rng(&mut self) -> &mut Self::Rng;
+    fn hash(&mut self) -> &mut Self::Hash;
+}
+
+pub trait Rng {
+    fn rand_bytes(&self, dst: &mut [u8]) -> Result<(), DpeErrorCode>;
+}
+
+pub trait Hash {
+    fn hash(
+        &self,
+        bytes: &[u8],
+        digest: &mut [u8; profile::DIGEST_SIZE],
+    ) -> Result<(), DpeErrorCode>;
+}

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -6,9 +6,11 @@ Abstract:
 --*/
 #![cfg_attr(not(test), no_std)]
 
+use crypto::Crypto;
 use response::{DpeErrorCode, ResponseHdr};
 pub mod commands;
 pub mod dpe_instance;
+pub mod crypto;
 mod response;
 mod x509;
 
@@ -26,6 +28,7 @@ mod profile {
     pub const TCI_SIZE: usize = 32;
     pub const CDI_SIZE: usize = 32;
     pub const ECC_INT_SIZE: usize = 32;
+    pub const DIGEST_SIZE: usize = 32;
 }
 
 #[cfg(feature = "dpe_profile_p384_sha384")]
@@ -34,16 +37,18 @@ mod profile {
     pub const TCI_SIZE: usize = 48;
     pub const CDI_SIZE: usize = 48;
     pub const ECC_INT_SIZE: usize = 48;
+    pub const DIGEST_SIZE: usize = 48;
 }
 
 /// Execute a DPE command.
 /// Returns the number of bytes written to `response`.
 pub fn execute_command(
     dpe: &mut dpe_instance::DpeInstance,
+    crypto: &mut impl Crypto,
     cmd: &[u8],
     response: &mut [u8],
 ) -> Result<usize, DpeErrorCode> {
-    match dpe.execute_serialized_command(cmd) {
+    match dpe.execute_serialized_command(crypto, cmd) {
         Ok(response_data) => {
             // Add the response header.
             let header_len = ResponseHdr::new(DpeErrorCode::NoError).serialize(response)?;


### PR DESCRIPTION
I have a couple options for how to have a generic Crypto interface mocked up. I'll send two PRs and we can decide which direction we want to go. Then I'll clean it up.

@ia0 is there a clean way to add a trait with child traits as an object to a struct. I was hoping to be able to add it to the DpeInstance struct, but can't find a good way of doing it.