### PR TITLE
Remove unused code bypass in clippy.

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -1,11 +1,6 @@
 #!/bin/sh
 set -ex
 
-# TODO: Remove once we don't generate those warnings. They currently polute the
-# script output and prevents easily identifying more important warnings and
-# errors.
-export RUSTFLAGS='-A dead_code -A unused_variables'
-
 ( cd dpe
   cargo build
   cargo build --no-default-features --features=dpe_profile_p384_sha384

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -5,10 +5,11 @@ Abstract:
     Defines an instance of DPE and all of its contexts.
 --*/
 use crate::{
+    _set_flag,
     commands::{Command, DestroyCtxCmd, InitCtxCmd},
     crypto::Crypto,
     response::{DpeErrorCode, GetProfileResp, InitCtxResp, Response},
-    set_flag, DPE_PROFILE, HANDLE_SIZE, MAX_HANDLES,
+    DPE_PROFILE, HANDLE_SIZE, MAX_HANDLES,
 };
 
 pub struct DpeInstance {
@@ -207,8 +208,8 @@ impl TciNodeData {
         self.flags & Self::INTERNAL_FLAG_MASK != 0
     }
 
-    fn set_flag_is_internal(&mut self, value: bool) {
-        set_flag(&mut self.flags, Self::INTERNAL_FLAG_MASK, value);
+    fn _set_flag_is_internal(&mut self, value: bool) {
+        _set_flag(&mut self.flags, Self::INTERNAL_FLAG_MASK, value);
     }
 
     pub const fn new() -> TciNodeData {

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -66,6 +66,6 @@ pub fn execute_command<C: Crypto>(
     }
 }
 
-fn set_flag(field: &mut u32, mask: u32, value: bool) {
+fn _set_flag(field: &mut u32, mask: u32, value: bool) {
     *field = if value { *field | mask } else { *field & !mask };
 }

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -3,6 +3,11 @@
 //! DPE requires encoding variable-length certificates. This module provides
 //! this functionality for a no_std environment.
 
+// TODO: Remove once we don't generate those warnings. They currently polute the
+// script output and prevents easily identifying more important warnings and
+// errors.
+#![allow(dead_code)]
+
 use crate::{
     dpe_instance::{TciMeasurement, TciNodeData},
     response::DpeErrorCode,


### PR DESCRIPTION
Isolates the warnings bypasses to `dpe/src/x509.rs`.