### PR TITLE
Make the Crypto trait defined on DpeInstance

### DIFF
--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -49,11 +49,11 @@ pub const DPE_PROFILE: DpeProfile = DpeProfile::P384Sha384;
 /// Execute a DPE command.
 /// Returns the number of bytes written to `response`.
 pub fn execute_command<C: Crypto>(
-    dpe: &mut dpe_instance::DpeInstance,
+    dpe: &mut dpe_instance::DpeInstance<C>,
     cmd: &[u8],
     response: &mut [u8],
 ) -> Result<usize, DpeErrorCode> {
-    match dpe.execute_serialized_command::<C>(cmd) {
+    match dpe.execute_serialized_command(cmd) {
         Ok(response_data) => {
             // Add the response header.
             let header_len = ResponseHdr::new(DpeErrorCode::NoError).serialize(response)?;

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -12,7 +12,7 @@ use std::process;
 
 const SOCKET_PATH: &str = "/tmp/dpe-sim.socket";
 
-fn handle_request(dpe: &mut DpeInstance, stream: &mut UnixStream) {
+fn handle_request(dpe: &mut DpeInstance<OpensslCrypto>, stream: &mut UnixStream) {
     let mut buf = [0u8; 128];
     let len = stream.read(&mut buf).unwrap();
 
@@ -25,7 +25,7 @@ fn handle_request(dpe: &mut DpeInstance, stream: &mut UnixStream) {
     println!("|");
 
     let mut response = [0u8; 128];
-    let len = execute_command::<OpensslCrypto>(dpe, &buf[..len], &mut response).unwrap();
+    let len = execute_command(dpe, &buf[..len], &mut response).unwrap();
 
     let response_code = u32::from_le_bytes(response[4..8].try_into().unwrap());
     // There are a few vendor error codes starting at 0x1000, so this can be a 2 bytes.
@@ -95,7 +95,7 @@ fn main() -> std::io::Result<()> {
         tagging: args.supports_tagging,
         rotate_context: args.supports_rotate_context,
     };
-    let mut dpe = DpeInstance::new::<OpensslCrypto>(support);
+    let mut dpe = DpeInstance::<OpensslCrypto>::new(support);
 
     println!("DPE listening to socket {SOCKET_PATH}");
 


### PR DESCRIPTION
Instead of defining the Crypto trait on individual functions, define it on the DpeInstance struct. Since all Crypto function and data are static, DpeInstance does not need to hold an instance of Crypto.