### PR TITLE
Add concept of hardware localities.

### DIFF
--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -50,10 +50,11 @@ pub const DPE_PROFILE: DpeProfile = DpeProfile::P384Sha384;
 /// Returns the number of bytes written to `response`.
 pub fn execute_command<C: Crypto>(
     dpe: &mut dpe_instance::DpeInstance<C>,
+    locality: u32,
     cmd: &[u8],
     response: &mut [u8],
 ) -> Result<usize, DpeErrorCode> {
-    match dpe.execute_serialized_command(cmd) {
+    match dpe.execute_serialized_command(locality, cmd) {
         Ok(response_data) => {
             // Add the response header.
             let header_len = ResponseHdr::new(DpeErrorCode::NoError).serialize(response)?;

--- a/dpe/src/response.rs
+++ b/dpe/src/response.rs
@@ -136,7 +136,7 @@ pub enum DpeErrorCode {
     InvalidArgument = 3,
     ArgumentNotSupported = 4,
     InvalidHandle = 0x1000,
-    InvalidDomain = 0x1001,
+    InvalidLocality = 0x1001,
     BadTag = 0x1002,
     HandleDefined = 0x1003,
     MaxTcis = 0x1004,
@@ -193,7 +193,7 @@ mod tests {
         test_error_code_serialize(DpeErrorCode::InvalidArgument);
         test_error_code_serialize(DpeErrorCode::ArgumentNotSupported);
         test_error_code_serialize(DpeErrorCode::InvalidHandle);
-        test_error_code_serialize(DpeErrorCode::InvalidDomain);
+        test_error_code_serialize(DpeErrorCode::InvalidLocality);
         test_error_code_serialize(DpeErrorCode::BadTag);
         test_error_code_serialize(DpeErrorCode::HandleDefined);
         test_error_code_serialize(DpeErrorCode::MaxTcis);

--- a/verification/client.go
+++ b/verification/client.go
@@ -16,7 +16,7 @@ type DpeClient struct {
 	profile   uint32
 }
 
-func (c *DpeClient) Initialize(cmd *InitCtxCmd) (error, RespHdr, InitCtxResp) {
+func (c *DpeClient) Initialize(locality uint32, cmd *InitCtxCmd) (error, RespHdr, InitCtxResp) {
 	hdr := CommandHdr{
 		magic:   CmdMagic,
 		cmd:     InitCtxCode,
@@ -24,6 +24,7 @@ func (c *DpeClient) Initialize(cmd *InitCtxCmd) (error, RespHdr, InitCtxResp) {
 	}
 
 	buf := &bytes.Buffer{}
+	binary.Write(buf, binary.LittleEndian, locality)
 	binary.Write(buf, binary.LittleEndian, hdr)
 	binary.Write(buf, binary.LittleEndian, cmd)
 
@@ -47,13 +48,14 @@ func (c *DpeClient) Initialize(cmd *InitCtxCmd) (error, RespHdr, InitCtxResp) {
 	return nil, respHdr, respStruct
 }
 
-func (c *DpeClient) GetProfile() (error, RespHdr, GetProfileResp) {
+func (c *DpeClient) GetProfile(locality uint32) (error, RespHdr, GetProfileResp) {
 	hdr := CommandHdr{
 		magic: CmdMagic,
 		cmd:   GetProfileCode,
 	}
 
 	buf := &bytes.Buffer{}
+	binary.Write(buf, binary.LittleEndian, locality)
 	binary.Write(buf, binary.LittleEndian, hdr)
 
 	err, resp := c.transport.SendCmd(buf.Bytes())

--- a/verification/verification_test.go
+++ b/verification/verification_test.go
@@ -6,6 +6,11 @@ import (
 	"testing"
 )
 
+const (
+	AUTO_INIT_LOCALITY uint32 = 0
+	OTHER_LOCALITY     uint32 = 0x4f544852
+)
+
 var sim_exe = flag.String("sim", "../simulator/target/debug/simulator", "path to simulator executable")
 
 func TestGetProfile(t *testing.T) {
@@ -17,7 +22,7 @@ func TestGetProfile(t *testing.T) {
 	}
 
 	client := DpeClient{transport: &SimulatorTransport{}}
-	err, respHdr, _ := client.GetProfile()
+	err, respHdr, _ := client.GetProfile(AUTO_INIT_LOCALITY)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +40,7 @@ func TestInitializeContext(t *testing.T) {
 	}
 
 	client := DpeClient{transport: &SimulatorTransport{}}
-	err, respHdr, _ := client.GetProfile()
+	err, respHdr, _ := client.GetProfile(AUTO_INIT_LOCALITY)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +48,7 @@ func TestInitializeContext(t *testing.T) {
 		t.Fatal("Unable to get profile.")
 	}
 
-	err, respHdr, _ = client.Initialize(NewInitCtxIsDefault())
+	err, respHdr, _ = client.Initialize(AUTO_INIT_LOCALITY, NewInitCtxIsDefault())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
These are used to distinguish between requestors. One locality cannot access a handle from another locality. The spec describes what a locality is.

```
[A]n SoC may use hardware localities to distinguish between:

- Two co-processors each have a distinct Hardware Locality.
- An processor with multiple execution levels. Each has a distinct Hardware Locality.
```