### PR TITLE
Add power on and power off to transport template.

### DIFF
--- a/verification/client.go
+++ b/verification/client.go
@@ -7,8 +7,31 @@ import (
 	"fmt"
 )
 
+type Support struct {
+	Simulation    bool
+	ExtendTci     bool
+	AutoInit      bool
+	Tagging       bool
+	RotateContext bool
+}
+
+// An interface to define how to test and send messages to a DPE instance.
 type Transport interface {
+	// If power control is unavailable for the given device, return false from
+	// HasPowerControl and return an error from PowerOn and PowerOff. For devices
+	// that don't support power control but do have reset capability, return true
+	// from HasPowerControl leave PowerOn empty and execute the reset in PowerOff.
+	HasPowerControl() bool
+	// If supported, turns on the device or starts the emulator/simulator.
+	PowerOn() error
+	// If supported, turns of the device, stops the emulator/simulator, or resets.
+	PowerOff() error
+	// Send a command to the DPE instance.
 	SendCmd(buf []byte) (error, []byte)
+	// The Transport implementations are not expected to be able to set the values
+	// it supports, but this function is used by tests to know how to test the DPE
+	// instance.
+	GetSupport() Support
 }
 
 type DpeClient struct {

--- a/verification/verification_test.go
+++ b/verification/verification_test.go
@@ -14,14 +14,14 @@ const (
 var sim_exe = flag.String("sim", "../simulator/target/debug/simulator", "path to simulator executable")
 
 func TestGetProfile(t *testing.T) {
-	simulator := DpeSimulator{}
-	defer simulator.Terminate()
-	err := simulator.Start(*sim_exe)
+	simulator := DpeSimulator{exe_path: *sim_exe}
+	defer simulator.PowerOff()
+	err := simulator.PowerOn()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	client := DpeClient{transport: &SimulatorTransport{}}
+	client := DpeClient{transport: &simulator}
 	err, respHdr, _ := client.GetProfile(AUTO_INIT_LOCALITY)
 	if err != nil {
 		t.Fatal(err)
@@ -32,14 +32,14 @@ func TestGetProfile(t *testing.T) {
 }
 
 func TestInitializeContext(t *testing.T) {
-	simulator := DpeSimulator{}
-	defer simulator.Terminate()
-	err := simulator.Start(*sim_exe)
+	simulator := DpeSimulator{exe_path: *sim_exe}
+	defer simulator.PowerOff()
+	err := simulator.PowerOn()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	client := DpeClient{transport: &SimulatorTransport{}}
+	client := DpeClient{transport: &simulator}
 	err, respHdr, _ := client.GetProfile(AUTO_INIT_LOCALITY)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Adds a more generic way of powering on and off the device. This will be helpful when we need to reset a scenario during testing. For example, checking if auto-init works as well as the request to initialize the default context.