### PR TITLE
Refactor Go DPE client to support future work

### DIFF
--- a/verification/abi.go
+++ b/verification/abi.go
@@ -12,17 +12,6 @@ const (
 	DPE_PROFILE_P384_SHA384 uint32 = 2
 
 	CURRENT_PROFILE_VERSION uint32 = 0
-
-	DPE_STATUS_SUCCESS                uint32 = 0
-	DPE_STATUS_INTERNAL_ERROR         uint32 = 1
-	DPE_STATUS_INVALID_COMMAND        uint32 = 2
-	DPE_STATUS_INVALID_ARGUMENT       uint32 = 3
-	DPE_STATUS_ARGUMENT_NOT_SUPPORTED uint32 = 4
-	DPE_STATUS_INVALID_HANDLE         uint32 = 0x1000
-	DPE_STATUS_INVALID_DOMAIN         uint32 = 0x1001
-	DPE_STATUS_BAD_TAG                uint32 = 0x1002
-	DPE_STATUS_HANDLE_DEFINED         uint32 = 0x1003
-	DPE_STATUS_MAX_TCIS               uint32 = 0x1004
 )
 
 type CommandHdr struct {
@@ -67,6 +56,7 @@ type InitCtxResp struct {
 }
 
 type GetProfileResp struct {
+	Profile     uint32
 	Version     uint32
 	MaxTciNodes uint32
 	Flags       uint32

--- a/verification/abi.go
+++ b/verification/abi.go
@@ -4,25 +4,29 @@ const (
 	CmdMagic  uint32 = 0x44504543
 	RespMagic uint32 = 0x44504552
 
-	GetProfileCode uint32 = 0x1
-	InitCtxCode    uint32 = 0x5
-	DestroyCtxCode uint32 = 0xf
-
 	DPE_PROFILE_P256_SHA256 uint32 = 1
 	DPE_PROFILE_P384_SHA384 uint32 = 2
 
 	CURRENT_PROFILE_VERSION uint32 = 0
 )
 
+type CommandCode uint32
+
+const (
+	CommandGetProfile        CommandCode = 0x1
+	CommandInitializeContext CommandCode = 0x5
+	CommandDestroyContext    CommandCode = 0xf
+)
+
 type CommandHdr struct {
 	magic   uint32
-	cmd     uint32
+	cmd     CommandCode
 	profile uint32
 }
 
 type RespHdr struct {
 	Magic   uint32
-	Status  uint32
+	Status  Status
 	Profile uint32
 }
 

--- a/verification/client.go
+++ b/verification/client.go
@@ -15,7 +15,7 @@ type Support struct {
 // An interface to define how to test and send messages to a DPE instance.
 type Transport interface {
 	// Send a command to the DPE instance.
-	SendCmd(buf []byte) (error, []byte)
+	SendCmd(buf []byte) ([]byte, error)
 }
 
 type Client struct {

--- a/verification/errors.go
+++ b/verification/errors.go
@@ -1,0 +1,42 @@
+package verification
+
+import "fmt"
+
+type Status uint32
+
+const (
+	StatusInternalError        Status = 1
+	StatusInvalidCommand       Status = 2
+	StatusInvalidArgument      Status = 3
+	StatusArgumentNotSupported Status = 4
+	StatusInvalidHandle        Status = 0x1000
+	StatusInvalidLocality      Status = 0x1001
+	StatusBadTag               Status = 0x1002
+	StatusHandleDefined        Status = 0x1003
+	StatusMaxTCIs              Status = 0x1004
+)
+
+func (s Status) Error() string {
+	switch s {
+	case StatusInternalError:
+		return "error internal to DPE"
+	case StatusInvalidCommand:
+		return "command ID is invalid"
+	case StatusInvalidArgument:
+		return "argument is invalid"
+	case StatusArgumentNotSupported:
+		return "argument is not supported by this profile, implementation, or integration"
+	case StatusInvalidHandle:
+		return "contextHandle does not exist"
+	case StatusInvalidLocality:
+		return "Hardware Locality does not exist"
+	case StatusBadTag:
+		return "TCI Tag is either in use (TagTci) or not found (GetTaggedTci)"
+	case StatusHandleDefined:
+		return "passed handle is already defined"
+	case StatusMaxTCIs:
+		return "maximum number of TCIs have been created"
+	default:
+		return fmt.Sprintf("unrecognized status code 0x%0x", uint32(s))
+	}
+}

--- a/verification/helpers.go
+++ b/verification/helpers.go
@@ -32,7 +32,7 @@ func execCommand(t Transport, code CommandCode, profile uint32, cmd any, rsp any
 	binary.Write(buf, binary.LittleEndian, hdr)
 	binary.Write(buf, binary.LittleEndian, cmd)
 
-	err, resp := t.SendCmd(buf.Bytes())
+	resp, err := t.SendCmd(buf.Bytes())
 	if err != nil {
 		return nil, err
 	}

--- a/verification/helpers.go
+++ b/verification/helpers.go
@@ -1,0 +1,55 @@
+package verification
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+// checkRespHdr checks that the response header has all expected values and did not indicate an error.
+func checkRespHdr(hdr RespHdr) error {
+	if hdr.Magic != RespMagic {
+		fmt.Println(hdr)
+		return errors.New("invalid response magic value")
+	}
+	if hdr.Status != 0 {
+		return Status(hdr.Status)
+	}
+	return nil
+}
+
+// execCommand executes the command. It returns the response header in the case of success, for internal use (i.e., GetProfile).
+// cmd must be a struct of fixed-size values (or pointer to such), and rsp must be a pointer to such a struct.
+func execCommand(t Transport, code CommandCode, profile uint32, cmd any, rsp any) (*RespHdr, error) {
+	hdr := CommandHdr{
+		magic:   CmdMagic,
+		cmd:     code,
+		profile: profile,
+	}
+
+	buf := &bytes.Buffer{}
+	binary.Write(buf, binary.LittleEndian, hdr)
+	binary.Write(buf, binary.LittleEndian, cmd)
+
+	err, resp := t.SendCmd(buf.Bytes())
+	if err != nil {
+		return nil, err
+	}
+
+	respHdr := RespHdr{}
+
+	r := bytes.NewReader(resp)
+	if err = binary.Read(r, binary.LittleEndian, &respHdr); err != nil {
+		return nil, err
+	}
+	if err = checkRespHdr(respHdr); err != nil {
+		return nil, err
+	}
+
+	if err = binary.Read(r, binary.LittleEndian, rsp); err != nil {
+		return nil, err
+	}
+
+	return &respHdr, nil
+}


### PR DESCRIPTION
The Go client only supports InitializeContext, DestroyContext, and GetProfile. There's a few cleanups that are a lot easier to do now than later, and that will help make the Go library easier to use and maintain down the road. This change is organized into 5 commits that each make one type of fix:

1. Move the simulator-specific client out of Transport. Not every DPE client supports all the simulator hooks; a simulator needs to expose these things to tests out-of-band to the "DPE client library."
2. Make a semantic error type for DPE errors. In Go, errors are values, and this allows us to simplify the calling pattern for the client API (by giving them an error and not any extra header-parsing homework)
3. Introduce a constructor for `Client` (was called `DPEClient`) to enforce that somebody has to check what profile the implementation supports before they can safely use it. This will become very important as we introduce DPE commands whose ABI depends on the profile.
4. Extract some shared helper code. Because we're relying on `binary.Write` to read and write to the bus, we can pass each command's command and response structures by `any` interface to a shared function. This makes each client command's implementation very small.
5. Fix some miscellaneous Go style warnings, see https://go.dev/doc/effective_go