### PR TITLE
Serialize and Deserialize DeriveChild command.

### DIFF
--- a/dpe/src/commands.rs
+++ b/dpe/src/commands.rs
@@ -11,6 +11,7 @@ use core::mem::size_of;
 pub enum Command {
     GetProfile,
     InitCtx(InitCtxCmd),
+    DeriveChild(DeriveChildCmd),
     CertifyKey(CertifyKeyCmd),
     RotateCtx(RotateCtxCmd),
     DestroyCtx(DestroyCtxCmd),
@@ -141,6 +142,78 @@ impl TryFrom<&[u8]> for InitCtxCmd {
         }
         Ok(InitCtxCmd {
             flags: u32::from_le_bytes(raw[0..4].try_into().unwrap()),
+        })
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(test, derive(zerocopy::AsBytes, zerocopy::FromBytes))]
+pub struct DeriveChildCmd {
+    pub handle: [u8; HANDLE_SIZE],
+    pub data: [u8; DPE_PROFILE.get_hash_size()],
+    pub flags: u32,
+    pub tcb_type: u32,
+    pub target_locality: u32,
+}
+
+impl DeriveChildCmd {
+    const INTERNAL_INPUT_INFO: u32 = 1 << 31;
+    const INTERNAL_INPUT_DICE: u32 = 1 << 30;
+    const RETAIN_PARENT: u32 = 1 << 29;
+    const TARGET_IS_DEFAULT: u32 = 1 << 28;
+
+    pub const fn is_internal_input_info(&self) -> bool {
+        self.flags & Self::INTERNAL_INPUT_INFO != 0
+    }
+
+    pub const fn is_internal_input_dice(&self) -> bool {
+        self.flags & Self::INTERNAL_INPUT_DICE != 0
+    }
+
+    pub const fn is_retain_parent(&self) -> bool {
+        self.flags & Self::RETAIN_PARENT != 0
+    }
+
+    pub const fn is_target_is_default(&self) -> bool {
+        self.flags & Self::TARGET_IS_DEFAULT != 0
+    }
+}
+
+impl TryFrom<&[u8]> for DeriveChildCmd {
+    type Error = DpeErrorCode;
+
+    fn try_from(raw: &[u8]) -> Result<Self, Self::Error> {
+        if raw.len() < size_of::<DeriveChildCmd>() {
+            return Err(DpeErrorCode::InvalidArgument);
+        }
+
+        let mut offset: usize = 0;
+
+        let mut handle = [0; HANDLE_SIZE];
+        handle.copy_from_slice(&raw[offset..offset + HANDLE_SIZE]);
+        offset += HANDLE_SIZE;
+
+        let mut data = [0; DPE_PROFILE.get_hash_size()];
+        data.copy_from_slice(&raw[offset..offset + DPE_PROFILE.get_hash_size()]);
+        offset += DPE_PROFILE.get_hash_size();
+
+        let flags = u32::from_le_bytes(raw[offset..offset + size_of::<u32>()].try_into().unwrap());
+        offset += size_of::<u32>();
+
+        let tcb_type =
+            u32::from_le_bytes(raw[offset..offset + size_of::<u32>()].try_into().unwrap());
+        offset += size_of::<u32>();
+
+        let target_locality =
+            u32::from_le_bytes(raw[offset..offset + size_of::<u32>()].try_into().unwrap());
+
+        Ok(DeriveChildCmd {
+            handle,
+            data,
+            flags,
+            tcb_type,
+            target_locality,
         })
     }
 }
@@ -316,12 +389,30 @@ mod tests {
     use crate::{DpeProfile, DPE_PROFILE};
     use zerocopy::{AsBytes, FromBytes};
 
+    #[cfg(feature = "dpe_profile_p256_sha256")]
+    const TEST_DIGEST: [u8; DPE_PROFILE.get_hash_size()] = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+        26, 27, 28, 29, 30, 31, 32,
+    ];
+    #[cfg(feature = "dpe_profile_p384_sha384")]
+    const TEST_DIGEST: [u8; DPE_PROFILE.get_hash_size()] = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+        26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
+    ];
+
     const DEFAULT_COMMAND: CommandHdr = CommandHdr {
         magic: CommandHdr::DPE_COMMAND_MAGIC,
         cmd_id: Command::GET_PROFILE,
         profile: DPE_PROFILE as u32,
     };
     const TEST_INIT_CTX_CMD: InitCtxCmd = InitCtxCmd { flags: 0x1234_5678 };
+    const TEST_DERIVE_CHILD_CMD: DeriveChildCmd = DeriveChildCmd {
+        handle: SIMULATION_HANDLE,
+        data: TEST_DIGEST,
+        flags: 0x1234_5678,
+        tcb_type: 0x9876_5432,
+        target_locality: 0x10CA_1171,
+    };
     const TEST_ROTATE_CTX_CMD: RotateCtxCmd = RotateCtxCmd {
         flags: 0x1234_5678,
         handle: TEST_HANDLE,
@@ -338,17 +429,7 @@ mod tests {
     };
     const TEST_EXTEND_TCI_CMD: ExtendTciCmd = ExtendTciCmd {
         handle: SIMULATION_HANDLE,
-        #[cfg(feature = "dpe_profile_p256_sha256")]
-        data: [
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-            25, 26, 27, 28, 29, 30, 31, 32,
-        ],
-        #[cfg(feature = "dpe_profile_p384_sha384")]
-        data: [
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
-            25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
-            47, 48,
-        ],
+        data: TEST_DIGEST,
     };
     const TEST_TAG_TCI_CMD: TagTciCmd = TagTciCmd {
         handle: SIMULATION_HANDLE,
@@ -370,6 +451,15 @@ mod tests {
         assert_eq!(
             InitCtxCmd::read_from_prefix(command_bytes).unwrap(),
             InitCtxCmd::try_from(command_bytes).unwrap(),
+        );
+    }
+
+    #[test]
+    fn try_from_derive_child() {
+        let command_bytes = TEST_DERIVE_CHILD_CMD.as_bytes();
+        assert_eq!(
+            DeriveChildCmd::read_from_prefix(command_bytes).unwrap(),
+            DeriveChildCmd::try_from(command_bytes).unwrap(),
         );
     }
 
@@ -615,6 +705,23 @@ mod tests {
     }
 
     #[test]
+    fn test_slice_to_derive_child() {
+        let invalid_argument: Result<DeriveChildCmd, DpeErrorCode> =
+            Err(DpeErrorCode::InvalidArgument);
+
+        // Test if too small.
+        assert_eq!(
+            invalid_argument,
+            DeriveChildCmd::try_from([0u8; size_of::<DeriveChildCmd>() - 1].as_slice())
+        );
+
+        assert_eq!(
+            TEST_DERIVE_CHILD_CMD,
+            DeriveChildCmd::try_from(TEST_DERIVE_CHILD_CMD.as_bytes()).unwrap()
+        );
+    }
+
+    #[test]
     fn test_slice_to_rotate_ctx() {
         let invalid_argument: Result<RotateCtxCmd, DpeErrorCode> =
             Err(DpeErrorCode::InvalidArgument);
@@ -698,6 +805,7 @@ mod tests {
             let cmd_id = match command {
                 Command::GetProfile => Command::GET_PROFILE,
                 Command::InitCtx(_) => Command::INITIALIZE_CONTEXT,
+                Command::DeriveChild(_) => Command::DERIVE_CHILD,
                 Command::CertifyKey(_) => Command::CERTIFY_KEY,
                 Command::RotateCtx(_) => Command::ROTATE_CONTEXT_HANDLE,
                 Command::DestroyCtx(_) => Command::DESTROY_CONTEXT,

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -7,7 +7,8 @@ Abstract:
 use crate::{
     _set_flag,
     commands::{
-        CertifyKeyCmd, Command, DestroyCtxCmd, ExtendTciCmd, InitCtxCmd, RotateCtxCmd, TagTciCmd,
+        CertifyKeyCmd, Command, DeriveChildCmd, DestroyCtxCmd, ExtendTciCmd, InitCtxCmd,
+        RotateCtxCmd, TagTciCmd,
     },
     response::{CertifyKeyResp, DpeErrorCode, GetProfileResp, NewHandleResp, Response},
     x509::{EcdsaPub, EcdsaSignature, MeasurementData, Name, X509CertWriter},
@@ -96,6 +97,14 @@ impl<C: Crypto> DpeInstance<'_, C> {
 
         self.contexts[idx].activate(context_type, locality, &handle);
         Ok(NewHandleResp { handle })
+    }
+
+    pub fn derive_child(
+        &mut self,
+        _locality: u32,
+        _cmd: &DeriveChildCmd,
+    ) -> Result<Response, DpeErrorCode> {
+        Err(DpeErrorCode::InvalidCommand)
     }
 
     /// Rotate the handle for given context to another random value. This also allows changing the
@@ -353,6 +362,7 @@ impl<C: Crypto> DpeInstance<'_, C> {
             Command::InitCtx(context) => Ok(Response::InitCtx(
                 self.initialize_context(locality, &context)?,
             )),
+            Command::DeriveChild(cmd) => self.derive_child(locality, &cmd),
             Command::CertifyKey(context) => {
                 Ok(Response::CertifyKey(self.certify_key(locality, &context)?))
             }


### PR DESCRIPTION
This change only implements the deserialization of the command and serialization of the response for the DeriveChild command. This does not implement the actually functionality of the command. This will need to come later.