### PR TITLE
Make Name in DPE certificates a printable string

### DIFF
--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -15,6 +15,7 @@ use crate::{
     DPE_PROFILE, HANDLE_SIZE, MAX_CERT_SIZE, MAX_HANDLES,
 };
 use core::convert::TryFrom;
+use core::fmt::{Error, Write};
 use core::marker::PhantomData;
 use core::mem::size_of;
 use crypto::{Crypto, Hasher};
@@ -296,12 +297,19 @@ impl<C: Crypto> DpeInstance<'_, C> {
         // TODO: Let the platform specify issuer name
         let issuer_name = Name {
             cn: b"DPE Issuer",
-            serial: &[0; DPE_PROFILE.get_hash_size()],
+            serial: b"000000",
         };
+
+        let mut subject_sn_str = [0u8; DPE_PROFILE.get_hash_size() * 2];
+        let mut w = BufWriter {
+            buf: &mut subject_sn_str,
+            offset: 0,
+        };
+        w.write_hex_str(&pub_digest)?;
 
         let subject_name = Name {
             cn: b"DPE Leaf",
-            serial: &pub_digest,
+            serial: &subject_sn_str,
         };
 
         let measurements = MeasurementData {
@@ -469,6 +477,34 @@ impl<C: Crypto> DpeInstance<'_, C> {
         }
 
         Ok(out_idx)
+    }
+}
+
+struct BufWriter<'a> {
+    buf: &'a mut [u8],
+    offset: usize,
+}
+
+impl Write for BufWriter<'_> {
+    fn write_str(&mut self, s: &str) -> Result<(), Error> {
+        if s.len() > self.buf.len().saturating_sub(self.offset) {
+            return Err(Error::default());
+        }
+
+        self.buf[self.offset..self.offset + s.len()].copy_from_slice(s.as_bytes());
+        self.offset += s.len();
+
+        Ok(())
+    }
+}
+
+impl BufWriter<'_> {
+    fn write_hex_str(&mut self, src: &[u8]) -> Result<(), DpeErrorCode> {
+        for &b in src {
+            write!(self, "{b:02x}").map_err(|_| DpeErrorCode::InternalError)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/verification/verification_test.go
+++ b/verification/verification_test.go
@@ -1,6 +1,7 @@
 package verification
 
 import (
+	"crypto/x509"
 	"errors"
 	"flag"
 	"log"
@@ -235,18 +236,17 @@ func testCertifyKey(d TestDPEInstance, t *testing.T) {
 		Flags:         0,
 		Label:         [32]byte{0},
 	}
-	if _, err = client.CertifyKey(&certifyKeyReq); err != nil {
+
+	certifyKeyResp, err := client.CertifyKey(&certifyKeyReq)
+	if err != nil {
 		t.Fatalf("Could not certify key: %v", err)
 	}
-	// TODO(https://github.com/chipsalliance/caliptra-dpe/issues/44): Parse the certificate when the certificate being produced by the DPE is valid.
-	/*
-		cert, err := x509.ParseCertificate(certifyKeyResp.Certificate)
-		if err != nil {
-			t.Logf("Cert data: %x", certifyKeyResp.Certificate)
-			t.Fatalf("Could not parse certificate: %v", err)
-		}
-		t.Logf("Certificate: %#v", cert)
-	*/
+	cert, err := x509.ParseCertificate(certifyKeyResp.Certificate)
+	if err != nil {
+		t.Logf("Cert data: %x", certifyKeyResp.Certificate)
+		t.Fatalf("Could not parse certificate: %v", err)
+	}
+	t.Logf("Certificate: %#v", cert)
 
 	// TODO: When DeriveChild is implemented, call it here to add more TCIs and call CertifyKey again.
 }


### PR DESCRIPTION
The serialNumber field in the subject name was previously raw bytes. Update this be a printable hex string instead.

Fixes #44 