### PR TITLE
Move the rest of the commands into separate files.

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -1,0 +1,285 @@
+// Licensed under the Apache-2.0 license.
+use super::CommandExecution;
+use crate::{
+    dpe_instance::{DpeInstance, TciNodeData},
+    response::{CertifyKeyResp, DpeErrorCode, Response},
+    x509::{EcdsaPub, EcdsaSignature, MeasurementData, Name, X509CertWriter},
+    DPE_PROFILE, HANDLE_SIZE, MAX_CERT_SIZE, MAX_HANDLES,
+};
+use core::{
+    fmt::{Error, Write},
+    mem::size_of,
+};
+use crypto::Crypto;
+
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(test, derive(zerocopy::AsBytes, zerocopy::FromBytes))]
+pub struct CertifyKeyCmd {
+    handle: [u8; HANDLE_SIZE],
+    flags: u32,
+    label: [u8; DPE_PROFILE.get_hash_size()],
+}
+
+impl CertifyKeyCmd {
+    const fn new() -> CertifyKeyCmd {
+        CertifyKeyCmd {
+            handle: [0; HANDLE_SIZE],
+            flags: 0,
+            label: [0; DPE_PROFILE.get_hash_size()],
+        }
+    }
+}
+
+impl<C: Crypto> CommandExecution<C> for CertifyKeyCmd {
+    fn execute(&self, dpe: &mut DpeInstance<C>, locality: u32) -> Result<Response, DpeErrorCode> {
+        let idx = dpe
+            .get_active_context_pos(&self.handle, locality)
+            .ok_or(DpeErrorCode::InvalidHandle)?;
+
+        // Make sure the command is coming from the right locality.
+        if dpe.contexts[idx].locality != locality {
+            return Err(DpeErrorCode::InvalidHandle);
+        }
+
+        // Get TCI Nodes
+        const INITIALIZER: TciNodeData = TciNodeData::new();
+        let mut nodes = [INITIALIZER; MAX_HANDLES];
+        let tcb_count = dpe.get_tcb_nodes(&dpe.contexts[idx], &mut nodes)?;
+
+        // Hash TCI Nodes
+        let mut tci_bytes = [0u8; MAX_HANDLES * size_of::<TciNodeData>()];
+        let mut tci_offset = 0;
+        for n in &nodes[..tcb_count] {
+            tci_offset += n.serialize(&mut tci_bytes[tci_offset..])?;
+        }
+
+        let mut digest = [0; DPE_PROFILE.get_hash_size()];
+        C::hash(DPE_PROFILE.alg_len(), &tci_bytes[..tci_offset], &mut digest)
+            .map_err(|_| DpeErrorCode::InternalError)?;
+
+        // Derive CDI and public key
+        let cdi = C::derive_cdi(DPE_PROFILE.alg_len(), &digest, b"DPE")
+            .map_err(|_| DpeErrorCode::InternalError)?;
+        let mut pub_key = EcdsaPub::default();
+        C::derive_ecdsa_pub(
+            DPE_PROFILE.alg_len(),
+            &cdi,
+            &self.label,
+            b"ECC",
+            &mut pub_key.x,
+            &mut pub_key.y,
+        )
+        .map_err(|_| DpeErrorCode::InternalError)?;
+
+        // Hash the public key for the serialNumber name field
+        let mut pub_bytes = [0u8; size_of::<EcdsaPub>()];
+        let pub_offset = pub_key.serialize(&mut pub_bytes)?;
+        let mut pub_digest = [0u8; DPE_PROFILE.get_hash_size()];
+        C::hash(
+            DPE_PROFILE.alg_len(),
+            &pub_bytes[..pub_offset],
+            &mut pub_digest,
+        )
+        .map_err(|_| DpeErrorCode::InternalError)?;
+
+        // TODO: Let the platform specify issuer name
+        let issuer_name = Name {
+            cn: b"DPE Issuer",
+            serial: b"000000",
+        };
+
+        let mut subject_sn_str = [0u8; DPE_PROFILE.get_hash_size() * 2];
+        let mut w = BufWriter {
+            buf: &mut subject_sn_str,
+            offset: 0,
+        };
+        w.write_hex_str(&pub_digest)?;
+
+        let subject_name = Name {
+            cn: b"DPE Leaf",
+            serial: &subject_sn_str,
+        };
+
+        let measurements = MeasurementData {
+            _label: &self.label,
+            tci_nodes: &nodes[..tcb_count],
+        };
+
+        // Get certificate
+        let mut tbs_buffer = [0u8; MAX_CERT_SIZE];
+        let mut tbs_writer = X509CertWriter::new(&mut tbs_buffer);
+        let mut bytes_written = tbs_writer.encode_ecdsa_tbs(
+            /*serial=*/ &pub_digest,
+            &issuer_name,
+            &subject_name,
+            &pub_key,
+            &measurements,
+        )?;
+
+        let mut tbs_digest = [0u8; DPE_PROFILE.get_hash_size()];
+        C::hash(
+            DPE_PROFILE.alg_len(),
+            &tbs_buffer[..bytes_written],
+            &mut tbs_digest,
+        )
+        .map_err(|_| DpeErrorCode::InternalError)?;
+        let mut sig = EcdsaSignature::default();
+        C::ecdsa_sign_with_alias(DPE_PROFILE.alg_len(), &tbs_digest, &mut sig.r, &mut sig.s)
+            .map_err(|_| DpeErrorCode::InternalError)?;
+
+        let mut cert = [0u8; MAX_CERT_SIZE];
+        let mut cert_writer = X509CertWriter::new(&mut cert);
+        bytes_written = cert_writer.encode_ecdsa_certificate(&tbs_buffer[..bytes_written], &sig)?;
+        let cert_size = u32::try_from(bytes_written).map_err(|_| DpeErrorCode::InternalError)?;
+
+        // Rotate handle if it isn't the default
+        dpe.roll_onetime_use_handle(idx)?;
+
+        Ok(Response::CertifyKey(CertifyKeyResp {
+            new_context_handle: dpe.contexts[idx].handle,
+            derived_pubkey_x: pub_key.x,
+            derived_pubkey_y: pub_key.y,
+            cert_size,
+            cert,
+        }))
+    }
+}
+
+struct BufWriter<'a> {
+    buf: &'a mut [u8],
+    offset: usize,
+}
+
+impl Write for BufWriter<'_> {
+    fn write_str(&mut self, s: &str) -> Result<(), Error> {
+        if s.len() > self.buf.len().saturating_sub(self.offset) {
+            return Err(Error::default());
+        }
+
+        self.buf[self.offset..self.offset + s.len()].copy_from_slice(s.as_bytes());
+        self.offset += s.len();
+
+        Ok(())
+    }
+}
+
+impl BufWriter<'_> {
+    fn write_hex_str(&mut self, src: &[u8]) -> Result<(), DpeErrorCode> {
+        for &b in src {
+            write!(self, "{b:02x}").map_err(|_| DpeErrorCode::InternalError)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl TryFrom<&[u8]> for CertifyKeyCmd {
+    type Error = DpeErrorCode;
+
+    fn try_from(raw: &[u8]) -> Result<Self, Self::Error> {
+        if raw.len() < size_of::<CertifyKeyCmd>() {
+            return Err(DpeErrorCode::InvalidArgument);
+        }
+
+        let mut cmd = CertifyKeyCmd::new();
+        let mut offset: usize = 0;
+
+        cmd.handle
+            .copy_from_slice(&raw[offset..offset + HANDLE_SIZE]);
+        offset += HANDLE_SIZE;
+
+        cmd.flags = u32::from_le_bytes(raw[offset..offset + size_of::<u32>()].try_into().unwrap());
+        offset += size_of::<u32>();
+
+        cmd.label
+            .copy_from_slice(&raw[offset..offset + DPE_PROFILE.get_hash_size()]);
+
+        Ok(cmd)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        commands::{Command, CommandHdr, InitCtxCmd},
+        dpe_instance::{
+            tests::{SIMULATION_HANDLE, TEST_LOCALITIES},
+            Support,
+        },
+    };
+    use crypto::OpensslCrypto;
+    use x509_parser::nom::Parser;
+    use x509_parser::prelude::X509CertificateParser;
+    use x509_parser::prelude::*;
+    use zerocopy::AsBytes;
+
+    const TEST_CERTIFY_KEY_CMD: CertifyKeyCmd = CertifyKeyCmd {
+        handle: SIMULATION_HANDLE,
+        flags: 0x1234_5678,
+        label: [0xaa; DPE_PROFILE.get_hash_size()],
+    };
+
+    #[test]
+    fn test_deserialize_certify_key() {
+        let mut command = CommandHdr::new(Command::CertifyKey(TEST_CERTIFY_KEY_CMD))
+            .as_bytes()
+            .to_vec();
+        command.extend(TEST_CERTIFY_KEY_CMD.as_bytes());
+        assert_eq!(
+            Ok(Command::CertifyKey(TEST_CERTIFY_KEY_CMD)),
+            Command::deserialize(&command)
+        );
+    }
+
+    #[test]
+    fn test_slice_to_certify_key() {
+        let invalid_argument: Result<CertifyKeyCmd, DpeErrorCode> =
+            Err(DpeErrorCode::InvalidArgument);
+
+        // Test if too small.
+        assert_eq!(
+            invalid_argument,
+            CertifyKeyCmd::try_from([0u8; size_of::<CertifyKeyCmd>() - 1].as_slice())
+        );
+
+        assert_eq!(
+            TEST_CERTIFY_KEY_CMD,
+            CertifyKeyCmd::try_from(TEST_CERTIFY_KEY_CMD.as_bytes()).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_certify_key() {
+        let mut dpe =
+            DpeInstance::<OpensslCrypto>::new(Support::default(), &TEST_LOCALITIES).unwrap();
+
+        let init_resp = match InitCtxCmd::new_use_default()
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+            .unwrap()
+        {
+            Response::InitCtx(resp) => resp,
+            _ => panic!("Incorrect return type."),
+        };
+        let certify_cmd = CertifyKeyCmd {
+            handle: init_resp.handle,
+            flags: 0,
+            label: [0; DPE_PROFILE.get_hash_size()],
+        };
+
+        let certify_resp = match certify_cmd.execute(&mut dpe, TEST_LOCALITIES[0]).unwrap() {
+            Response::CertifyKey(resp) => resp,
+            _ => panic!("Wrong response type."),
+        };
+        assert_ne!(certify_resp.cert_size, 0);
+
+        let mut parser = X509CertificateParser::new().with_deep_parse_extensions(false);
+        match parser.parse(&certify_resp.cert[..certify_resp.cert_size.try_into().unwrap()]) {
+            Ok((_, cert)) => {
+                assert_eq!(cert.version(), X509Version::V3);
+            }
+            Err(e) => panic!("x509 parsing failed: {:?}", e),
+        };
+    }
+}

--- a/dpe/src/commands/derive_child.rs
+++ b/dpe/src/commands/derive_child.rs
@@ -1,0 +1,128 @@
+// Licensed under the Apache-2.0 license.
+use super::CommandExecution;
+use crate::{
+    dpe_instance::DpeInstance,
+    response::{DpeErrorCode, Response},
+    DPE_PROFILE, HANDLE_SIZE,
+};
+use core::mem::size_of;
+use crypto::Crypto;
+
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(test, derive(zerocopy::AsBytes, zerocopy::FromBytes))]
+pub struct DeriveChildCmd {
+    handle: [u8; HANDLE_SIZE],
+    data: [u8; DPE_PROFILE.get_hash_size()],
+    flags: u32,
+    tcb_type: u32,
+    target_locality: u32,
+}
+
+impl DeriveChildCmd {
+    const _INTERNAL_INPUT_INFO: u32 = 1 << 31;
+    const _INTERNAL_INPUT_DICE: u32 = 1 << 30;
+    const _RETAIN_PARENT: u32 = 1 << 29;
+    const _TARGET_IS_DEFAULT: u32 = 1 << 28;
+
+    const fn _is_internal_input_info(&self) -> bool {
+        self.flags & Self::_INTERNAL_INPUT_INFO != 0
+    }
+
+    const fn _is_internal_input_dice(&self) -> bool {
+        self.flags & Self::_INTERNAL_INPUT_DICE != 0
+    }
+
+    const fn _is_retain_parent(&self) -> bool {
+        self.flags & Self::_RETAIN_PARENT != 0
+    }
+
+    const fn _is_target_is_default(&self) -> bool {
+        self.flags & Self::_TARGET_IS_DEFAULT != 0
+    }
+}
+
+impl<C: Crypto> CommandExecution<C> for DeriveChildCmd {
+    fn execute(&self, _dpe: &mut DpeInstance<C>, _locality: u32) -> Result<Response, DpeErrorCode> {
+        Err(DpeErrorCode::InvalidCommand)
+    }
+}
+
+impl TryFrom<&[u8]> for DeriveChildCmd {
+    type Error = DpeErrorCode;
+
+    fn try_from(raw: &[u8]) -> Result<Self, Self::Error> {
+        if raw.len() < size_of::<DeriveChildCmd>() {
+            return Err(DpeErrorCode::InvalidArgument);
+        }
+
+        let mut offset: usize = 0;
+
+        let mut handle = [0; HANDLE_SIZE];
+        handle.copy_from_slice(&raw[offset..offset + HANDLE_SIZE]);
+        offset += HANDLE_SIZE;
+
+        let mut data = [0; DPE_PROFILE.get_hash_size()];
+        data.copy_from_slice(&raw[offset..offset + DPE_PROFILE.get_hash_size()]);
+        offset += DPE_PROFILE.get_hash_size();
+
+        let flags = u32::from_le_bytes(raw[offset..offset + size_of::<u32>()].try_into().unwrap());
+        offset += size_of::<u32>();
+
+        let tcb_type =
+            u32::from_le_bytes(raw[offset..offset + size_of::<u32>()].try_into().unwrap());
+        offset += size_of::<u32>();
+
+        let target_locality =
+            u32::from_le_bytes(raw[offset..offset + size_of::<u32>()].try_into().unwrap());
+
+        Ok(DeriveChildCmd {
+            handle,
+            data,
+            flags,
+            tcb_type,
+            target_locality,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{commands::tests::TEST_DIGEST, dpe_instance::tests::SIMULATION_HANDLE};
+    use zerocopy::{AsBytes, FromBytes};
+
+    const TEST_DERIVE_CHILD_CMD: DeriveChildCmd = DeriveChildCmd {
+        handle: SIMULATION_HANDLE,
+        data: TEST_DIGEST,
+        flags: 0x1234_5678,
+        tcb_type: 0x9876_5432,
+        target_locality: 0x10CA_1171,
+    };
+
+    #[test]
+    fn try_from_derive_child() {
+        let command_bytes = TEST_DERIVE_CHILD_CMD.as_bytes();
+        assert_eq!(
+            DeriveChildCmd::read_from_prefix(command_bytes).unwrap(),
+            DeriveChildCmd::try_from(command_bytes).unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_slice_to_derive_child() {
+        let invalid_argument: Result<DeriveChildCmd, DpeErrorCode> =
+            Err(DpeErrorCode::InvalidArgument);
+
+        // Test if too small.
+        assert_eq!(
+            invalid_argument,
+            DeriveChildCmd::try_from([0u8; size_of::<DeriveChildCmd>() - 1].as_slice())
+        );
+
+        assert_eq!(
+            TEST_DERIVE_CHILD_CMD,
+            DeriveChildCmd::try_from(TEST_DERIVE_CHILD_CMD.as_bytes()).unwrap()
+        );
+    }
+}

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -1,0 +1,121 @@
+// Licensed under the Apache-2.0 license.
+use super::CommandExecution;
+use crate::{
+    dpe_instance::{flags_iter, DpeInstance},
+    response::{DpeErrorCode, Response},
+    HANDLE_SIZE, MAX_HANDLES,
+};
+use core::mem::size_of;
+use crypto::Crypto;
+
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(test, derive(zerocopy::AsBytes, zerocopy::FromBytes))]
+pub struct DestroyCtxCmd {
+    pub handle: [u8; HANDLE_SIZE],
+    pub flags: u32,
+}
+
+impl DestroyCtxCmd {
+    const DESTROY_CHILDREN_FLAG_MASK: u32 = 1 << 31;
+
+    const fn flag_is_destroy_descendants(&self) -> bool {
+        self.flags & Self::DESTROY_CHILDREN_FLAG_MASK != 0
+    }
+}
+
+impl TryFrom<&[u8]> for DestroyCtxCmd {
+    type Error = DpeErrorCode;
+
+    fn try_from(raw: &[u8]) -> Result<Self, Self::Error> {
+        if raw.len() < size_of::<DestroyCtxCmd>() {
+            return Err(DpeErrorCode::InvalidArgument);
+        }
+
+        let mut handle = [0; HANDLE_SIZE];
+        handle.copy_from_slice(&raw[0..HANDLE_SIZE]);
+
+        let raw = &raw[HANDLE_SIZE..];
+        Ok(DestroyCtxCmd {
+            handle,
+            flags: u32::from_le_bytes(raw[0..4].try_into().unwrap()),
+        })
+    }
+}
+
+impl<C: Crypto> CommandExecution<C> for DestroyCtxCmd {
+    fn execute(&self, dpe: &mut DpeInstance<C>, locality: u32) -> Result<Response, DpeErrorCode> {
+        let idx = dpe
+            .get_active_context_pos(&self.handle, locality)
+            .ok_or(DpeErrorCode::InvalidHandle)?;
+        let context = &dpe.contexts[idx];
+        // Make sure the command is coming from the right locality.
+        if context.locality != locality {
+            return Err(DpeErrorCode::InvalidHandle);
+        }
+
+        let to_destroy = if self.flag_is_destroy_descendants() {
+            (1 << idx) | dpe.get_descendants(context)?
+        } else {
+            1 << idx
+        };
+
+        for idx in flags_iter(to_destroy, MAX_HANDLES) {
+            dpe.contexts[idx].destroy();
+        }
+        Ok(Response::DestroyCtx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        commands::{Command, CommandHdr},
+        dpe_instance::tests::SIMULATION_HANDLE,
+    };
+    use zerocopy::{AsBytes, FromBytes};
+
+    const TEST_DESTROY_CTX_CMD: DestroyCtxCmd = DestroyCtxCmd {
+        handle: SIMULATION_HANDLE,
+        flags: 0x1234_5678,
+    };
+
+    #[test]
+    fn try_from_destroy_ctx() {
+        let command_bytes = TEST_DESTROY_CTX_CMD.as_bytes();
+        assert_eq!(
+            DestroyCtxCmd::read_from_prefix(command_bytes).unwrap(),
+            DestroyCtxCmd::try_from(command_bytes).unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_deserialize_destroy_context() {
+        let mut command = CommandHdr::new(Command::DestroyCtx(TEST_DESTROY_CTX_CMD))
+            .as_bytes()
+            .to_vec();
+        command.extend(TEST_DESTROY_CTX_CMD.as_bytes());
+        assert_eq!(
+            Ok(Command::DestroyCtx(TEST_DESTROY_CTX_CMD)),
+            Command::deserialize(&command)
+        );
+    }
+
+    #[test]
+    fn test_slice_to_destroy_ctx() {
+        let invalid_argument: Result<DestroyCtxCmd, DpeErrorCode> =
+            Err(DpeErrorCode::InvalidArgument);
+
+        // Test if too small.
+        assert_eq!(
+            invalid_argument,
+            DestroyCtxCmd::try_from([0u8; size_of::<DestroyCtxCmd>() - 1].as_slice())
+        );
+
+        assert_eq!(
+            TEST_DESTROY_CTX_CMD,
+            DestroyCtxCmd::try_from(TEST_DESTROY_CTX_CMD.as_bytes()).unwrap()
+        );
+    }
+}

--- a/dpe/src/commands/extend_tci.rs
+++ b/dpe/src/commands/extend_tci.rs
@@ -1,0 +1,252 @@
+// Licensed under the Apache-2.0 license.
+use super::CommandExecution;
+use crate::{
+    dpe_instance::{DpeInstance, TciMeasurement},
+    response::{DpeErrorCode, NewHandleResp, Response},
+    DPE_PROFILE, HANDLE_SIZE,
+};
+use core::mem::size_of;
+use crypto::{Crypto, Hasher};
+
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(test, derive(zerocopy::AsBytes, zerocopy::FromBytes))]
+pub struct ExtendTciCmd {
+    handle: [u8; HANDLE_SIZE],
+    data: [u8; DPE_PROFILE.get_hash_size()],
+}
+
+impl TryFrom<&[u8]> for ExtendTciCmd {
+    type Error = DpeErrorCode;
+
+    fn try_from(raw: &[u8]) -> Result<Self, Self::Error> {
+        if raw.len() < size_of::<ExtendTciCmd>() {
+            return Err(DpeErrorCode::InvalidArgument);
+        }
+
+        Ok(ExtendTciCmd {
+            handle: raw[0..HANDLE_SIZE].try_into().unwrap(),
+            data: raw[HANDLE_SIZE..HANDLE_SIZE + DPE_PROFILE.get_hash_size()]
+                .try_into()
+                .unwrap(),
+        })
+    }
+}
+
+impl<C: Crypto> CommandExecution<C> for ExtendTciCmd {
+    fn execute(&self, dpe: &mut DpeInstance<C>, locality: u32) -> Result<Response, DpeErrorCode> {
+        // Make sure this command is supported.
+        if !dpe.support.extend_tci {
+            return Err(DpeErrorCode::InvalidCommand);
+        }
+        let idx = dpe
+            .get_active_context_pos(&self.handle, locality)
+            .ok_or(DpeErrorCode::InvalidHandle)?;
+        let context = &mut dpe.contexts[idx];
+
+        // Make sure the command is coming from the right locality.
+        if context.locality != locality {
+            return Err(DpeErrorCode::InvalidHandle);
+        }
+
+        // Derive the new TCI.
+        let mut hasher =
+            C::hash_initialize(DPE_PROFILE.alg_len()).map_err(|_| DpeErrorCode::InternalError)?;
+        hasher
+            .update(&context.tci.tci_cumulative.0)
+            .map_err(|_| DpeErrorCode::InternalError)?;
+        hasher
+            .update(&self.data)
+            .map_err(|_| DpeErrorCode::InternalError)?;
+        hasher
+            .finish(&mut context.tci.tci_cumulative.0)
+            .map_err(|_| DpeErrorCode::InternalError)?;
+
+        context.tci.tci_current = TciMeasurement(self.data);
+        // Rotate the handle if it isn't the default context.
+        dpe.roll_onetime_use_handle(idx)?;
+        Ok(Response::ExtendTci(NewHandleResp {
+            handle: dpe.contexts[idx].handle,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        commands::{tests::TEST_DIGEST, Command, CommandHdr, InitCtxCmd},
+        dpe_instance::{
+            tests::{SIMULATION_HANDLE, TEST_LOCALITIES},
+            Support,
+        },
+        DpeProfile,
+    };
+    use crypto::OpensslCrypto;
+    use zerocopy::{AsBytes, FromBytes};
+
+    const TEST_EXTEND_TCI_CMD: ExtendTciCmd = ExtendTciCmd {
+        handle: SIMULATION_HANDLE,
+        data: TEST_DIGEST,
+    };
+
+    #[test]
+    fn try_from_extend_tci() {
+        let command_bytes = TEST_EXTEND_TCI_CMD.as_bytes();
+        assert_eq!(
+            ExtendTciCmd::read_from_prefix(command_bytes).unwrap(),
+            ExtendTciCmd::try_from(command_bytes).unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_deserialize_extend_tci() {
+        let mut command = CommandHdr::new(Command::ExtendTci(TEST_EXTEND_TCI_CMD))
+            .as_bytes()
+            .to_vec();
+        command.extend(TEST_EXTEND_TCI_CMD.as_bytes());
+        assert_eq!(
+            Ok(Command::ExtendTci(TEST_EXTEND_TCI_CMD)),
+            Command::deserialize(&command)
+        );
+    }
+
+    #[test]
+    fn test_slice_to_extend_tci() {
+        // Test if too small.
+        assert_eq!(
+            Err(DpeErrorCode::InvalidArgument),
+            ExtendTciCmd::try_from([0u8; size_of::<ExtendTciCmd>() - 1].as_slice())
+        );
+
+        assert_eq!(
+            TEST_EXTEND_TCI_CMD,
+            ExtendTciCmd::try_from(TEST_EXTEND_TCI_CMD.as_bytes()).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_extend_tci() {
+        let mut dpe =
+            DpeInstance::<OpensslCrypto>::new(Support::default(), &TEST_LOCALITIES).unwrap();
+        // Make sure it returns an error if the command is marked unsupported.
+        assert_eq!(
+            Err(DpeErrorCode::InvalidCommand),
+            ExtendTciCmd {
+                handle: DpeInstance::<OpensslCrypto>::DEFAULT_CONTEXT_HANDLE,
+                data: [0; DPE_PROFILE.get_hash_size()],
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+        );
+
+        // Turn on support.
+        dpe.support.extend_tci = true;
+        InitCtxCmd::new_use_default()
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+            .unwrap();
+
+        // Wrong locality.
+        assert_eq!(
+            Err(DpeErrorCode::InvalidHandle),
+            ExtendTciCmd {
+                handle: DpeInstance::<OpensslCrypto>::DEFAULT_CONTEXT_HANDLE,
+                data: [0; DPE_PROFILE.get_hash_size()],
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[1])
+        );
+
+        let locality = DpeInstance::<OpensslCrypto>::AUTO_INIT_LOCALITY;
+        let default_handle = DpeInstance::<OpensslCrypto>::DEFAULT_CONTEXT_HANDLE;
+        let handle = dpe.contexts[dpe
+            .get_active_context_pos(&default_handle, locality)
+            .unwrap()]
+        .handle;
+        let data = [1; DPE_PROFILE.get_hash_size()];
+        ExtendTciCmd {
+            handle: DpeInstance::<OpensslCrypto>::DEFAULT_CONTEXT_HANDLE,
+            data,
+        }
+        .execute(&mut dpe, TEST_LOCALITIES[0])
+        .unwrap();
+
+        // Make sure extending the default TCI doesn't change the handle.
+        let default_context = &dpe.contexts[dpe
+            .get_active_context_pos(&default_handle, locality)
+            .unwrap()];
+        assert_eq!(handle, default_context.handle);
+        // Make sure the current TCI was updated correctly.
+        assert_eq!(data, default_context.tci.tci_current.0);
+
+        let md = match DPE_PROFILE {
+            DpeProfile::P256Sha256 => openssl::hash::MessageDigest::sha256(),
+            DpeProfile::P384Sha384 => openssl::hash::MessageDigest::sha384(),
+        };
+        let mut hasher = openssl::hash::Hasher::new(md).unwrap();
+
+        // Add the default TCI.
+        hasher.update(&[0; DPE_PROFILE.get_hash_size()]).unwrap();
+        hasher.update(&data).unwrap();
+        let first_cumulative = hasher.finish().unwrap();
+
+        // Make sure the cumulative was computed correctly.
+        assert_eq!(
+            first_cumulative.as_ref(),
+            default_context.tci.tci_cumulative.0
+        );
+
+        let data = [2; DPE_PROFILE.get_hash_size()];
+        ExtendTciCmd {
+            handle: DpeInstance::<OpensslCrypto>::DEFAULT_CONTEXT_HANDLE,
+            data,
+        }
+        .execute(&mut dpe, TEST_LOCALITIES[0])
+        .unwrap();
+        // Make sure the current TCI was updated correctly.
+        let default_context = &dpe.contexts[dpe
+            .get_active_context_pos(&default_handle, locality)
+            .unwrap()];
+        assert_eq!(data, default_context.tci.tci_current.0);
+
+        let mut hasher = openssl::hash::Hasher::new(md).unwrap();
+        hasher.update(&first_cumulative).unwrap();
+        hasher.update(&data).unwrap();
+        let second_cumulative = hasher.finish().unwrap();
+
+        // Make sure the cumulative was computed correctly.
+        assert_eq!(
+            second_cumulative.as_ref(),
+            default_context.tci.tci_cumulative.0
+        );
+
+        let sim_local = TEST_LOCALITIES[1];
+        dpe.support.simulation = true;
+        InitCtxCmd::new_simulation()
+            .execute(&mut dpe, sim_local)
+            .unwrap();
+
+        // Give the simulation context another handle so we can prove the handle rotates when it
+        // gets extended.
+        let simulation_ctx = &mut dpe.contexts[dpe
+            .get_active_context_pos(&SIMULATION_HANDLE, sim_local)
+            .unwrap()];
+        let sim_tmp_handle = [0xff; HANDLE_SIZE];
+        simulation_ctx.handle = sim_tmp_handle;
+        assert!(dpe
+            .get_active_context_pos(&SIMULATION_HANDLE, sim_local)
+            .is_none());
+
+        ExtendTciCmd {
+            handle: sim_tmp_handle,
+            data,
+        }
+        .execute(&mut dpe, TEST_LOCALITIES[1])
+        .unwrap();
+        // Make sure it rotated back to the deterministic simulation handle.
+        assert!(dpe
+            .get_active_context_pos(&sim_tmp_handle, sim_local)
+            .is_none());
+        assert!(dpe
+            .get_active_context_pos(&SIMULATION_HANDLE, sim_local)
+            .is_some());
+    }
+}

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -6,6 +6,7 @@ Abstract:
 --*/
 pub(crate) use self::initialize_context::InitCtxCmd;
 
+use self::derive_child::DeriveChildCmd;
 use crate::{
     dpe_instance::DpeInstance,
     response::{DpeErrorCode, Response},
@@ -14,6 +15,7 @@ use crate::{
 use core::mem::size_of;
 use crypto::Crypto;
 
+mod derive_child;
 mod initialize_context;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -110,78 +112,6 @@ impl TryFrom<&[u8]> for CommandHdr {
             return Err(DpeErrorCode::InvalidCommand);
         }
         Ok(header)
-    }
-}
-
-#[repr(C)]
-#[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(test, derive(zerocopy::AsBytes, zerocopy::FromBytes))]
-pub struct DeriveChildCmd {
-    pub handle: [u8; HANDLE_SIZE],
-    pub data: [u8; DPE_PROFILE.get_hash_size()],
-    pub flags: u32,
-    pub tcb_type: u32,
-    pub target_locality: u32,
-}
-
-impl DeriveChildCmd {
-    const INTERNAL_INPUT_INFO: u32 = 1 << 31;
-    const INTERNAL_INPUT_DICE: u32 = 1 << 30;
-    const RETAIN_PARENT: u32 = 1 << 29;
-    const TARGET_IS_DEFAULT: u32 = 1 << 28;
-
-    pub const fn is_internal_input_info(&self) -> bool {
-        self.flags & Self::INTERNAL_INPUT_INFO != 0
-    }
-
-    pub const fn is_internal_input_dice(&self) -> bool {
-        self.flags & Self::INTERNAL_INPUT_DICE != 0
-    }
-
-    pub const fn is_retain_parent(&self) -> bool {
-        self.flags & Self::RETAIN_PARENT != 0
-    }
-
-    pub const fn is_target_is_default(&self) -> bool {
-        self.flags & Self::TARGET_IS_DEFAULT != 0
-    }
-}
-
-impl TryFrom<&[u8]> for DeriveChildCmd {
-    type Error = DpeErrorCode;
-
-    fn try_from(raw: &[u8]) -> Result<Self, Self::Error> {
-        if raw.len() < size_of::<DeriveChildCmd>() {
-            return Err(DpeErrorCode::InvalidArgument);
-        }
-
-        let mut offset: usize = 0;
-
-        let mut handle = [0; HANDLE_SIZE];
-        handle.copy_from_slice(&raw[offset..offset + HANDLE_SIZE]);
-        offset += HANDLE_SIZE;
-
-        let mut data = [0; DPE_PROFILE.get_hash_size()];
-        data.copy_from_slice(&raw[offset..offset + DPE_PROFILE.get_hash_size()]);
-        offset += DPE_PROFILE.get_hash_size();
-
-        let flags = u32::from_le_bytes(raw[offset..offset + size_of::<u32>()].try_into().unwrap());
-        offset += size_of::<u32>();
-
-        let tcb_type =
-            u32::from_le_bytes(raw[offset..offset + size_of::<u32>()].try_into().unwrap());
-        offset += size_of::<u32>();
-
-        let target_locality =
-            u32::from_le_bytes(raw[offset..offset + size_of::<u32>()].try_into().unwrap());
-
-        Ok(DeriveChildCmd {
-            handle,
-            data,
-            flags,
-            tcb_type,
-            target_locality,
-        })
     }
 }
 
@@ -350,19 +280,19 @@ impl TryFrom<&[u8]> for TagTciCmd {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use crate::dpe_instance::tests::{SIMULATION_HANDLE, TEST_HANDLE};
     use crate::{DpeProfile, DPE_PROFILE};
     use zerocopy::{AsBytes, FromBytes};
 
     #[cfg(feature = "dpe_profile_p256_sha256")]
-    const TEST_DIGEST: [u8; DPE_PROFILE.get_hash_size()] = [
+    pub const TEST_DIGEST: [u8; DPE_PROFILE.get_hash_size()] = [
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
         26, 27, 28, 29, 30, 31, 32,
     ];
     #[cfg(feature = "dpe_profile_p384_sha384")]
-    const TEST_DIGEST: [u8; DPE_PROFILE.get_hash_size()] = [
+    pub const TEST_DIGEST: [u8; DPE_PROFILE.get_hash_size()] = [
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
         26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
     ];
@@ -371,13 +301,6 @@ mod tests {
         magic: CommandHdr::DPE_COMMAND_MAGIC,
         cmd_id: Command::GET_PROFILE,
         profile: DPE_PROFILE as u32,
-    };
-    const TEST_DERIVE_CHILD_CMD: DeriveChildCmd = DeriveChildCmd {
-        handle: SIMULATION_HANDLE,
-        data: TEST_DIGEST,
-        flags: 0x1234_5678,
-        tcb_type: 0x9876_5432,
-        target_locality: 0x10CA_1171,
     };
     const TEST_ROTATE_CTX_CMD: RotateCtxCmd = RotateCtxCmd {
         flags: 0x1234_5678,
@@ -408,15 +331,6 @@ mod tests {
         assert_eq!(
             CommandHdr::read_from_prefix(command_bytes).unwrap(),
             CommandHdr::try_from(command_bytes).unwrap(),
-        );
-    }
-
-    #[test]
-    fn try_from_derive_child() {
-        let command_bytes = TEST_DERIVE_CHILD_CMD.as_bytes();
-        assert_eq!(
-            DeriveChildCmd::read_from_prefix(command_bytes).unwrap(),
-            DeriveChildCmd::try_from(command_bytes).unwrap(),
         );
     }
 
@@ -630,23 +544,6 @@ mod tests {
         assert_eq!(
             GOOD_HEADER,
             CommandHdr::try_from(GOOD_HEADER.as_bytes()).unwrap()
-        );
-    }
-
-    #[test]
-    fn test_slice_to_derive_child() {
-        let invalid_argument: Result<DeriveChildCmd, DpeErrorCode> =
-            Err(DpeErrorCode::InvalidArgument);
-
-        // Test if too small.
-        assert_eq!(
-            invalid_argument,
-            DeriveChildCmd::try_from([0u8; size_of::<DeriveChildCmd>() - 1].as_slice())
-        );
-
-        assert_eq!(
-            TEST_DERIVE_CHILD_CMD,
-            DeriveChildCmd::try_from(TEST_DERIVE_CHILD_CMD.as_bytes()).unwrap()
         );
     }
 

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub(crate) use self::initialize_context::InitCtxCmd;
 
 use self::certify_key::CertifyKeyCmd;
 use self::derive_child::DeriveChildCmd;
+use self::extend_tci::ExtendTciCmd;
 use self::rotate_context::RotateCtxCmd;
 
 use crate::{
@@ -22,6 +23,7 @@ use crypto::Crypto;
 mod certify_key;
 mod derive_child;
 mod destroy_context;
+mod extend_tci;
 mod initialize_context;
 mod rotate_context;
 
@@ -125,31 +127,6 @@ impl TryFrom<&[u8]> for CommandHdr {
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(test, derive(zerocopy::AsBytes, zerocopy::FromBytes))]
-pub struct ExtendTciCmd {
-    pub handle: [u8; HANDLE_SIZE],
-    pub data: [u8; DPE_PROFILE.get_hash_size()],
-}
-
-impl TryFrom<&[u8]> for ExtendTciCmd {
-    type Error = DpeErrorCode;
-
-    fn try_from(raw: &[u8]) -> Result<Self, Self::Error> {
-        if raw.len() < size_of::<ExtendTciCmd>() {
-            return Err(DpeErrorCode::InvalidArgument);
-        }
-
-        Ok(ExtendTciCmd {
-            handle: raw[0..HANDLE_SIZE].try_into().unwrap(),
-            data: raw[HANDLE_SIZE..HANDLE_SIZE + DPE_PROFILE.get_hash_size()]
-                .try_into()
-                .unwrap(),
-        })
-    }
-}
-
-#[repr(C)]
-#[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(test, derive(zerocopy::AsBytes, zerocopy::FromBytes))]
 pub struct TagTciCmd {
     pub handle: [u8; HANDLE_SIZE],
     pub tag: u32,
@@ -193,10 +170,6 @@ pub mod tests {
         cmd_id: Command::GET_PROFILE,
         profile: DPE_PROFILE as u32,
     };
-    const TEST_EXTEND_TCI_CMD: ExtendTciCmd = ExtendTciCmd {
-        handle: SIMULATION_HANDLE,
-        data: TEST_DIGEST,
-    };
     const TEST_TAG_TCI_CMD: TagTciCmd = TagTciCmd {
         handle: SIMULATION_HANDLE,
         tag: 0x1234_5678,
@@ -208,15 +181,6 @@ pub mod tests {
         assert_eq!(
             CommandHdr::read_from_prefix(command_bytes).unwrap(),
             CommandHdr::try_from(command_bytes).unwrap(),
-        );
-    }
-
-    #[test]
-    fn try_from_extend_tci() {
-        let command_bytes = TEST_EXTEND_TCI_CMD.as_bytes();
-        assert_eq!(
-            ExtendTciCmd::read_from_prefix(command_bytes).unwrap(),
-            ExtendTciCmd::try_from(command_bytes).unwrap(),
         );
     }
 
@@ -235,18 +199,6 @@ pub mod tests {
         assert_eq!(
             Ok(Command::GetProfile),
             Command::deserialize(CommandHdr::new(Command::GetProfile).as_bytes())
-        );
-    }
-
-    #[test]
-    fn test_deserialize_extend_tci() {
-        let mut command = CommandHdr::new(Command::ExtendTci(TEST_EXTEND_TCI_CMD))
-            .as_bytes()
-            .to_vec();
-        command.extend(TEST_EXTEND_TCI_CMD.as_bytes());
-        assert_eq!(
-            Ok(Command::ExtendTci(TEST_EXTEND_TCI_CMD)),
-            Command::deserialize(&command)
         );
     }
 
@@ -367,20 +319,6 @@ pub mod tests {
         assert_eq!(
             GOOD_HEADER,
             CommandHdr::try_from(GOOD_HEADER.as_bytes()).unwrap()
-        );
-    }
-
-    #[test]
-    fn test_slice_to_extend_tci() {
-        // Test if too small.
-        assert_eq!(
-            Err(DpeErrorCode::InvalidArgument),
-            ExtendTciCmd::try_from([0u8; size_of::<ExtendTciCmd>() - 1].as_slice())
-        );
-
-        assert_eq!(
-            TEST_EXTEND_TCI_CMD,
-            ExtendTciCmd::try_from(TEST_EXTEND_TCI_CMD.as_bytes()).unwrap()
         );
     }
 

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -1,0 +1,180 @@
+// Licensed under the Apache-2.0 license.
+use super::CommandExecution;
+use crate::{
+    dpe_instance::DpeInstance,
+    response::{DpeErrorCode, NewHandleResp, Response},
+    HANDLE_SIZE,
+};
+use core::mem::size_of;
+use crypto::Crypto;
+
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(test, derive(zerocopy::AsBytes, zerocopy::FromBytes))]
+pub struct RotateCtxCmd {
+    handle: [u8; HANDLE_SIZE],
+    flags: u32,
+    target_locality: u32,
+}
+
+impl TryFrom<&[u8]> for RotateCtxCmd {
+    type Error = DpeErrorCode;
+
+    fn try_from(raw: &[u8]) -> Result<Self, Self::Error> {
+        if raw.len() < size_of::<RotateCtxCmd>() {
+            return Err(DpeErrorCode::InvalidArgument);
+        }
+
+        let mut handle = [0; HANDLE_SIZE];
+        handle.copy_from_slice(&raw[0..HANDLE_SIZE]);
+
+        let raw = &raw[HANDLE_SIZE..];
+        Ok(RotateCtxCmd {
+            handle,
+            flags: u32::from_le_bytes(raw[0..4].try_into().unwrap()),
+            target_locality: u32::from_le_bytes(raw[4..8].try_into().unwrap()),
+        })
+    }
+}
+
+impl<C: Crypto> CommandExecution<C> for RotateCtxCmd {
+    fn execute(&self, dpe: &mut DpeInstance<C>, locality: u32) -> Result<Response, DpeErrorCode> {
+        if !dpe.support.rotate_context {
+            return Err(DpeErrorCode::InvalidCommand);
+        }
+        let idx = dpe
+            .get_active_context_pos(&self.handle, locality)
+            .ok_or(DpeErrorCode::InvalidHandle)?;
+
+        // Make sure the command is coming from the right locality.
+        if dpe.contexts[idx].locality != locality {
+            return Err(DpeErrorCode::InvalidHandle);
+        }
+
+        let new_handle = dpe.generate_new_handle()?;
+        dpe.contexts[idx].handle = new_handle;
+        Ok(Response::RotateCtx(NewHandleResp { handle: new_handle }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        commands::{Command, CommandHdr, InitCtxCmd},
+        dpe_instance::{
+            tests::{SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES},
+            Support,
+        },
+    };
+    use crypto::OpensslCrypto;
+    use zerocopy::{AsBytes, FromBytes};
+
+    const TEST_ROTATE_CTX_CMD: RotateCtxCmd = RotateCtxCmd {
+        flags: 0x1234_5678,
+        handle: TEST_HANDLE,
+        target_locality: 0x9876_5432,
+    };
+
+    #[test]
+    fn try_from_rotate_ctx() {
+        let command_bytes = TEST_ROTATE_CTX_CMD.as_bytes();
+        assert_eq!(
+            RotateCtxCmd::read_from_prefix(command_bytes).unwrap(),
+            RotateCtxCmd::try_from(command_bytes).unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_deserialize_rotate_context() {
+        let mut command = CommandHdr::new(Command::RotateCtx(TEST_ROTATE_CTX_CMD))
+            .as_bytes()
+            .to_vec();
+        command.extend(TEST_ROTATE_CTX_CMD.as_bytes());
+        assert_eq!(
+            Ok(Command::RotateCtx(TEST_ROTATE_CTX_CMD)),
+            Command::deserialize(&command)
+        );
+    }
+
+    #[test]
+    fn test_slice_to_rotate_ctx() {
+        let invalid_argument: Result<RotateCtxCmd, DpeErrorCode> =
+            Err(DpeErrorCode::InvalidArgument);
+
+        // Test if too small.
+        assert_eq!(
+            invalid_argument,
+            RotateCtxCmd::try_from([0u8; size_of::<RotateCtxCmd>() - 1].as_slice())
+        );
+
+        assert_eq!(
+            TEST_ROTATE_CTX_CMD,
+            RotateCtxCmd::try_from(TEST_ROTATE_CTX_CMD.as_bytes()).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_rotate_context() {
+        let mut dpe =
+            DpeInstance::<OpensslCrypto>::new(Support::default(), &TEST_LOCALITIES).unwrap();
+        // Make sure it returns an error if the command is marked unsupported.
+        assert_eq!(
+            Err(DpeErrorCode::InvalidCommand),
+            RotateCtxCmd {
+                handle: DpeInstance::<OpensslCrypto>::DEFAULT_CONTEXT_HANDLE,
+                flags: 0,
+                target_locality: 0
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+        );
+
+        // Make a new instance that supports RotateContext.
+        let mut dpe = DpeInstance::<OpensslCrypto>::new(
+            Support {
+                rotate_context: true,
+                ..Support::default()
+            },
+            &TEST_LOCALITIES,
+        )
+        .unwrap();
+        InitCtxCmd::new_use_default()
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+            .unwrap();
+
+        // Invalid handle.
+        assert_eq!(
+            Err(DpeErrorCode::InvalidHandle),
+            RotateCtxCmd {
+                handle: TEST_HANDLE,
+                flags: 0,
+                target_locality: 0
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+        );
+
+        // Wrong locality.
+        assert_eq!(
+            Err(DpeErrorCode::InvalidHandle),
+            RotateCtxCmd {
+                handle: DpeInstance::<OpensslCrypto>::DEFAULT_CONTEXT_HANDLE,
+                flags: 0,
+                target_locality: 0
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[1])
+        );
+
+        // Rotate default handle.
+        assert_eq!(
+            Ok(Response::RotateCtx(NewHandleResp {
+                handle: SIMULATION_HANDLE
+            })),
+            RotateCtxCmd {
+                handle: DpeInstance::<OpensslCrypto>::DEFAULT_CONTEXT_HANDLE,
+                flags: 0,
+                target_locality: 0
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+        );
+    }
+}

--- a/dpe/src/commands/tag_tci.rs
+++ b/dpe/src/commands/tag_tci.rs
@@ -1,0 +1,237 @@
+// Licensed under the Apache-2.0 license.
+use super::CommandExecution;
+use crate::{
+    dpe_instance::DpeInstance,
+    response::{DpeErrorCode, NewHandleResp, Response},
+    HANDLE_SIZE,
+};
+use core::mem::size_of;
+use crypto::Crypto;
+
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(test, derive(zerocopy::AsBytes, zerocopy::FromBytes))]
+pub struct TagTciCmd {
+    handle: [u8; HANDLE_SIZE],
+    tag: u32,
+}
+
+impl TryFrom<&[u8]> for TagTciCmd {
+    type Error = DpeErrorCode;
+
+    fn try_from(raw: &[u8]) -> Result<Self, Self::Error> {
+        if raw.len() < size_of::<TagTciCmd>() {
+            return Err(DpeErrorCode::InvalidArgument);
+        }
+
+        Ok(TagTciCmd {
+            handle: raw[0..HANDLE_SIZE].try_into().unwrap(),
+            tag: u32::from_le_bytes(raw[HANDLE_SIZE..HANDLE_SIZE + 4].try_into().unwrap()),
+        })
+    }
+}
+
+impl<C: Crypto> CommandExecution<C> for TagTciCmd {
+    fn execute(&self, dpe: &mut DpeInstance<C>, locality: u32) -> Result<Response, DpeErrorCode> {
+        // Make sure this command is supported.
+        if !dpe.support.tagging {
+            return Err(DpeErrorCode::InvalidCommand);
+        }
+        // Make sure the tag isn't used by any other contexts.
+        if dpe.contexts.iter().any(|c| c.has_tag && c.tag == self.tag) {
+            return Err(DpeErrorCode::BadTag);
+        }
+
+        let idx = dpe
+            .get_active_context_pos(&self.handle, locality)
+            .ok_or(DpeErrorCode::InvalidHandle)?;
+
+        // Make sure the command is coming from the right locality.
+        if dpe.contexts[idx].locality != locality {
+            return Err(DpeErrorCode::InvalidHandle);
+        }
+        if dpe.contexts[idx].has_tag {
+            return Err(DpeErrorCode::BadTag);
+        }
+
+        // Because handles are one-time use, let's rotate the handle, if it isn't the default.
+        dpe.roll_onetime_use_handle(idx)?;
+        let context = &mut dpe.contexts[idx];
+        context.has_tag = true;
+        context.tag = self.tag;
+
+        Ok(Response::TagTci(NewHandleResp {
+            handle: context.handle,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        commands::{Command, CommandHdr, InitCtxCmd},
+        dpe_instance::{
+            tests::{SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES},
+            Support,
+        },
+    };
+    use crypto::OpensslCrypto;
+    use zerocopy::{AsBytes, FromBytes};
+
+    const TEST_TAG_TCI_CMD: TagTciCmd = TagTciCmd {
+        handle: SIMULATION_HANDLE,
+        tag: 0x1234_5678,
+    };
+
+    #[test]
+    fn try_from_tag_tci() {
+        let command_bytes = TEST_TAG_TCI_CMD.as_bytes();
+        assert_eq!(
+            TagTciCmd::read_from_prefix(command_bytes).unwrap(),
+            TagTciCmd::try_from(command_bytes).unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_deserialize_tag_tci() {
+        let mut command = CommandHdr::new(Command::TagTci(TEST_TAG_TCI_CMD))
+            .as_bytes()
+            .to_vec();
+        command.extend(TEST_TAG_TCI_CMD.as_bytes());
+        assert_eq!(
+            Ok(Command::TagTci(TEST_TAG_TCI_CMD)),
+            Command::deserialize(&command)
+        );
+    }
+
+    #[test]
+    fn test_slice_to_tag_tci() {
+        // Test if too small.
+        assert_eq!(
+            Err(DpeErrorCode::InvalidArgument),
+            TagTciCmd::try_from([0u8; size_of::<TagTciCmd>() - 1].as_slice())
+        );
+
+        assert_eq!(
+            TEST_TAG_TCI_CMD,
+            TagTciCmd::try_from(TEST_TAG_TCI_CMD.as_bytes()).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_tag_tci() {
+        let mut dpe =
+            DpeInstance::<OpensslCrypto>::new(Support::default(), &TEST_LOCALITIES).unwrap();
+        // Make sure it returns an error if the command is marked unsupported.
+        assert_eq!(
+            Err(DpeErrorCode::InvalidCommand),
+            TagTciCmd {
+                handle: DpeInstance::<OpensslCrypto>::DEFAULT_CONTEXT_HANDLE,
+                tag: 0,
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+        );
+
+        // Make a new instance that supports tagging.
+        let mut dpe = DpeInstance::<OpensslCrypto>::new(
+            Support {
+                tagging: true,
+                simulation: true,
+                ..Support::default()
+            },
+            &TEST_LOCALITIES,
+        )
+        .unwrap();
+        InitCtxCmd::new_use_default()
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+            .unwrap();
+        let sim_local = TEST_LOCALITIES[1];
+        // Make a simulation context to test against.
+        InitCtxCmd::new_simulation()
+            .execute(&mut dpe, sim_local)
+            .unwrap();
+
+        // Invalid handle.
+        assert_eq!(
+            Err(DpeErrorCode::InvalidHandle),
+            TagTciCmd {
+                handle: TEST_HANDLE,
+                tag: 0,
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+        );
+
+        // Wrong locality.
+        assert_eq!(
+            Err(DpeErrorCode::InvalidHandle),
+            TagTciCmd {
+                handle: DpeInstance::<OpensslCrypto>::DEFAULT_CONTEXT_HANDLE,
+                tag: 0,
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[1])
+        );
+
+        // Tag default handle.
+        assert_eq!(
+            Ok(Response::TagTci(NewHandleResp {
+                handle: DpeInstance::<OpensslCrypto>::DEFAULT_CONTEXT_HANDLE,
+            })),
+            TagTciCmd {
+                handle: DpeInstance::<OpensslCrypto>::DEFAULT_CONTEXT_HANDLE,
+                tag: 0,
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+        );
+
+        // Try to re-tag the default context.
+        assert_eq!(
+            Err(DpeErrorCode::BadTag),
+            TagTciCmd {
+                handle: DpeInstance::<OpensslCrypto>::DEFAULT_CONTEXT_HANDLE,
+                tag: 1,
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+        );
+
+        // Try same tag on simulation.
+        assert_eq!(
+            Err(DpeErrorCode::BadTag),
+            TagTciCmd {
+                handle: SIMULATION_HANDLE,
+                tag: 0,
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[1])
+        );
+
+        // Give the simulation context another handle so we can prove the handle rotates when it
+        // gets tagged.
+        let simulation_ctx = &mut dpe.contexts[dpe
+            .get_active_context_pos(&SIMULATION_HANDLE, sim_local)
+            .unwrap()];
+        let sim_tmp_handle = [0xff; HANDLE_SIZE];
+        simulation_ctx.handle = sim_tmp_handle;
+        assert!(dpe
+            .get_active_context_pos(&SIMULATION_HANDLE, sim_local)
+            .is_none());
+
+        // Tag simulation.
+        assert_eq!(
+            Ok(Response::TagTci(NewHandleResp {
+                handle: SIMULATION_HANDLE,
+            })),
+            TagTciCmd {
+                handle: sim_tmp_handle,
+                tag: 1,
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[1])
+        );
+        // Make sure it rotated back to the deterministic simulation handle.
+        assert!(dpe
+            .get_active_context_pos(&sim_tmp_handle, sim_local)
+            .is_none());
+        assert!(dpe
+            .get_active_context_pos(&SIMULATION_HANDLE, sim_local)
+            .is_some());
+    }
+}

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -7,8 +7,8 @@ Abstract:
 use crate::{
     _set_flag,
     commands::{
-        CertifyKeyCmd, Command, CommandExecution, DeriveChildCmd, DestroyCtxCmd, ExtendTciCmd,
-        InitCtxCmd, RotateCtxCmd, TagTciCmd,
+        CertifyKeyCmd, Command, CommandExecution, DestroyCtxCmd, ExtendTciCmd, InitCtxCmd,
+        RotateCtxCmd, TagTciCmd,
     },
     response::{CertifyKeyResp, DpeErrorCode, GetProfileResp, NewHandleResp, Response},
     x509::{EcdsaPub, EcdsaSignature, MeasurementData, Name, X509CertWriter},
@@ -71,14 +71,6 @@ impl<C: Crypto> DpeInstance<'_, C> {
 
     pub fn get_profile(&self) -> Result<GetProfileResp, DpeErrorCode> {
         Ok(GetProfileResp::new(self.support.get_flags()))
-    }
-
-    pub fn derive_child(
-        &mut self,
-        _locality: u32,
-        _cmd: &DeriveChildCmd,
-    ) -> Result<Response, DpeErrorCode> {
-        Err(DpeErrorCode::InvalidCommand)
     }
 
     /// Rotate the handle for given context to another random value. This also allows changing the
@@ -341,7 +333,7 @@ impl<C: Crypto> DpeInstance<'_, C> {
         match command {
             Command::GetProfile => Ok(Response::GetProfile(self.get_profile()?)),
             Command::InitCtx(cmd) => cmd.execute(self, locality),
-            Command::DeriveChild(cmd) => self.derive_child(locality, &cmd),
+            Command::DeriveChild(cmd) => cmd.execute(self, locality),
             Command::CertifyKey(context) => {
                 Ok(Response::CertifyKey(self.certify_key(locality, &context)?))
             }


### PR DESCRIPTION
This moves the rest of the commands in this order:

1. Add separate file for `DeriveChild` command.
2. Add separate file for `CertifyKey` command.
3. Add separate file for `RotateContext` command.
4. Add separate file for `DestroyContext` command.
5. Add separate file for `ExtendTci` command.
6. Add separate file for `TagTci` command.
