### PR TITLE
Let the platform specify certificate issuer

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -6,10 +6,7 @@ use crate::{
     x509::{EcdsaPub, EcdsaSignature, MeasurementData, Name, X509CertWriter},
     DPE_PROFILE, HANDLE_SIZE, MAX_CERT_SIZE, MAX_HANDLES,
 };
-use core::{
-    fmt::{Error, Write},
-    mem::size_of,
-};
+use core::mem::size_of;
 use crypto::Crypto;
 
 #[repr(C)]
@@ -72,34 +69,24 @@ impl<C: Crypto> CommandExecution<C> for CertifyKeyCmd {
         )
         .map_err(|_| DpeErrorCode::InternalError)?;
 
-        // Hash the public key for the serialNumber name field
-        let mut pub_bytes = [0u8; size_of::<EcdsaPub>()];
-        let pub_offset = pub_key.serialize(&mut pub_bytes)?;
-        let mut pub_digest = [0u8; DPE_PROFILE.get_hash_size()];
-        C::hash(
+        let mut issuer_name = Name {
+            cn: dpe.issuer_cn,
+            serial: [0u8; DPE_PROFILE.get_hash_size() * 2],
+        };
+        C::get_ecdsa_alias_serial(DPE_PROFILE.alg_len(), &mut issuer_name.serial)
+            .map_err(|_| DpeErrorCode::InternalError)?;
+
+        let mut subject_name = Name {
+            cn: b"DPE Leaf",
+            serial: [0u8; DPE_PROFILE.get_hash_size() * 2],
+        };
+        C::get_pubkey_serial(
             DPE_PROFILE.alg_len(),
-            &pub_bytes[..pub_offset],
-            &mut pub_digest,
+            &pub_key.x,
+            &pub_key.y,
+            &mut subject_name.serial,
         )
         .map_err(|_| DpeErrorCode::InternalError)?;
-
-        // TODO: Let the platform specify issuer name
-        let issuer_name = Name {
-            cn: b"DPE Issuer",
-            serial: b"000000",
-        };
-
-        let mut subject_sn_str = [0u8; DPE_PROFILE.get_hash_size() * 2];
-        let mut w = BufWriter {
-            buf: &mut subject_sn_str,
-            offset: 0,
-        };
-        w.write_hex_str(&pub_digest)?;
-
-        let subject_name = Name {
-            cn: b"DPE Leaf",
-            serial: &subject_sn_str,
-        };
 
         let measurements = MeasurementData {
             _label: &self.label,
@@ -110,7 +97,8 @@ impl<C: Crypto> CommandExecution<C> for CertifyKeyCmd {
         let mut tbs_buffer = [0u8; MAX_CERT_SIZE];
         let mut tbs_writer = X509CertWriter::new(&mut tbs_buffer);
         let mut bytes_written = tbs_writer.encode_ecdsa_tbs(
-            /*serial=*/ &pub_digest,
+            /*serial=*/
+            &subject_name.serial[..20], // Serial number must be truncated to 20 bytes
             &issuer_name,
             &subject_name,
             &pub_key,
@@ -143,34 +131,6 @@ impl<C: Crypto> CommandExecution<C> for CertifyKeyCmd {
             cert_size,
             cert,
         }))
-    }
-}
-
-struct BufWriter<'a> {
-    buf: &'a mut [u8],
-    offset: usize,
-}
-
-impl Write for BufWriter<'_> {
-    fn write_str(&mut self, s: &str) -> Result<(), Error> {
-        if s.len() > self.buf.len().saturating_sub(self.offset) {
-            return Err(Error::default());
-        }
-
-        self.buf[self.offset..self.offset + s.len()].copy_from_slice(s.as_bytes());
-        self.offset += s.len();
-
-        Ok(())
-    }
-}
-
-impl BufWriter<'_> {
-    fn write_hex_str(&mut self, src: &[u8]) -> Result<(), DpeErrorCode> {
-        for &b in src {
-            write!(self, "{b:02x}").map_err(|_| DpeErrorCode::InternalError)?;
-        }
-
-        Ok(())
     }
 }
 
@@ -253,7 +213,8 @@ mod tests {
     #[test]
     fn test_certify_key() {
         let mut dpe =
-            DpeInstance::<OpensslCrypto>::new(Support::default(), &TEST_LOCALITIES).unwrap();
+            DpeInstance::<OpensslCrypto>::new_for_test(Support::default(), &TEST_LOCALITIES)
+                .unwrap();
 
         let init_resp = match InitCtxCmd::new_use_default()
             .execute(&mut dpe, TEST_LOCALITIES[0])

--- a/dpe/src/commands/extend_tci.rs
+++ b/dpe/src/commands/extend_tci.rs
@@ -128,7 +128,8 @@ mod tests {
     #[test]
     fn test_extend_tci() {
         let mut dpe =
-            DpeInstance::<OpensslCrypto>::new(Support::default(), &TEST_LOCALITIES).unwrap();
+            DpeInstance::<OpensslCrypto>::new_for_test(Support::default(), &TEST_LOCALITIES)
+                .unwrap();
         // Make sure it returns an error if the command is marked unsupported.
         assert_eq!(
             Err(DpeErrorCode::InvalidCommand),

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -140,7 +140,8 @@ mod tests {
     #[test]
     fn test_initialize_context() {
         let mut dpe =
-            DpeInstance::<OpensslCrypto>::new(Support::default(), &TEST_LOCALITIES).unwrap();
+            DpeInstance::<OpensslCrypto>::new_for_test(Support::default(), &TEST_LOCALITIES)
+                .unwrap();
 
         let handle = match InitCtxCmd::new_use_default()
             .execute(&mut dpe, TEST_LOCALITIES[0])
@@ -171,7 +172,7 @@ mod tests {
         );
 
         // Change to support simulation.
-        let mut dpe = DpeInstance::<OpensslCrypto>::new(
+        let mut dpe = DpeInstance::<OpensslCrypto>::new_for_test(
             Support {
                 simulation: true,
                 ..Support::default()

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -117,7 +117,8 @@ mod tests {
     #[test]
     fn test_rotate_context() {
         let mut dpe =
-            DpeInstance::<OpensslCrypto>::new(Support::default(), &TEST_LOCALITIES).unwrap();
+            DpeInstance::<OpensslCrypto>::new_for_test(Support::default(), &TEST_LOCALITIES)
+                .unwrap();
         // Make sure it returns an error if the command is marked unsupported.
         assert_eq!(
             Err(DpeErrorCode::InvalidCommand),
@@ -130,7 +131,7 @@ mod tests {
         );
 
         // Make a new instance that supports RotateContext.
-        let mut dpe = DpeInstance::<OpensslCrypto>::new(
+        let mut dpe = DpeInstance::<OpensslCrypto>::new_for_test(
             Support {
                 rotate_context: true,
                 ..Support::default()

--- a/dpe/src/commands/tag_tci.rs
+++ b/dpe/src/commands/tag_tci.rs
@@ -122,7 +122,8 @@ mod tests {
     #[test]
     fn test_tag_tci() {
         let mut dpe =
-            DpeInstance::<OpensslCrypto>::new(Support::default(), &TEST_LOCALITIES).unwrap();
+            DpeInstance::<OpensslCrypto>::new_for_test(Support::default(), &TEST_LOCALITIES)
+                .unwrap();
         // Make sure it returns an error if the command is marked unsupported.
         assert_eq!(
             Err(DpeErrorCode::InvalidCommand),
@@ -134,7 +135,7 @@ mod tests {
         );
 
         // Make a new instance that supports tagging.
-        let mut dpe = DpeInstance::<OpensslCrypto>::new(
+        let mut dpe = DpeInstance::<OpensslCrypto>::new_for_test(
             Support {
                 tagging: true,
                 simulation: true,

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -23,6 +23,9 @@ pub struct DpeInstance<'a, C: Crypto> {
     /// `InitializeContext(simulation=false)`) once per reset cycle.
     pub(crate) has_initialized: bool,
 
+    // Issuer Common Name to use in DPE leaf certs
+    pub(crate) issuer_cn: &'a [u8],
+
     // All functions/data in C are static and global. For this reason
     // DpeInstance doesn't actually need to hold an instance. The PhantomData
     // is just to make the Crypto trait work.
@@ -40,7 +43,11 @@ impl<C: Crypto> DpeInstance<'_, C> {
     ///
     /// * `support` - optional functionality the instance supports
     /// * `localities` - all possible valid localities for the system
-    pub fn new(support: Support, localities: &[u32]) -> Result<DpeInstance<C>, DpeErrorCode> {
+    pub fn new<'a>(
+        support: Support,
+        localities: &'a [u32],
+        issuer_cn: &'a [u8],
+    ) -> Result<DpeInstance<'a, C>, DpeErrorCode> {
         if localities.is_empty() {
             return Err(DpeErrorCode::InvalidLocality);
         }
@@ -50,6 +57,7 @@ impl<C: Crypto> DpeInstance<'_, C> {
             support,
             localities,
             has_initialized: false,
+            issuer_cn,
             phantom: PhantomData,
         };
 
@@ -61,6 +69,14 @@ impl<C: Crypto> DpeInstance<'_, C> {
             InitCtxCmd::new_use_default().execute(&mut dpe, Self::AUTO_INIT_LOCALITY)?;
         }
         Ok(dpe)
+    }
+
+    pub fn new_for_test(
+        support: Support,
+        localities: &[u32],
+    ) -> Result<DpeInstance<C>, DpeErrorCode> {
+        const TEST_ISSUER: &[u8] = b"Test Issuer";
+        Self::new(support, localities, TEST_ISSUER)
     }
 
     pub fn get_profile(&self) -> Result<GetProfileResp, DpeErrorCode> {
@@ -457,7 +473,7 @@ pub mod tests {
         // Empty list of localities.
         assert_eq!(
             DpeErrorCode::InvalidLocality,
-            DpeInstance::<OpensslCrypto>::new(SUPPORT, &[])
+            DpeInstance::<OpensslCrypto>::new_for_test(SUPPORT, &[])
                 .err()
                 .unwrap()
         );
@@ -465,12 +481,13 @@ pub mod tests {
         // Auto-init without the auto-init locality.
         assert_eq!(
             DpeErrorCode::InvalidLocality,
-            DpeInstance::<OpensslCrypto>::new(SUPPORT, &TEST_LOCALITIES[1..])
+            DpeInstance::<OpensslCrypto>::new_for_test(SUPPORT, &TEST_LOCALITIES[1..])
                 .err()
                 .unwrap()
         );
 
-        let mut dpe = DpeInstance::<OpensslCrypto>::new(SUPPORT, &TEST_LOCALITIES).unwrap();
+        let mut dpe =
+            DpeInstance::<OpensslCrypto>::new_for_test(SUPPORT, &TEST_LOCALITIES).unwrap();
         assert_eq!(
             Err(DpeErrorCode::InvalidLocality),
             dpe.execute_serialized_command(
@@ -523,7 +540,8 @@ pub mod tests {
 
     #[test]
     fn test_execute_serialized_command() {
-        let mut dpe = DpeInstance::<OpensslCrypto>::new(SUPPORT, &TEST_LOCALITIES).unwrap();
+        let mut dpe =
+            DpeInstance::<OpensslCrypto>::new_for_test(SUPPORT, &TEST_LOCALITIES).unwrap();
 
         assert_eq!(
             Response::GetProfile(GetProfileResp::new(SUPPORT.get_flags())),
@@ -551,7 +569,7 @@ pub mod tests {
 
     #[test]
     fn test_get_profile() {
-        let dpe = DpeInstance::<OpensslCrypto>::new(SUPPORT, &TEST_LOCALITIES).unwrap();
+        let dpe = DpeInstance::<OpensslCrypto>::new_for_test(SUPPORT, &TEST_LOCALITIES).unwrap();
         let profile = dpe.get_profile().unwrap();
         assert_eq!(profile.version, CURRENT_PROFILE_VERSION);
         assert_eq!(profile.flags, SUPPORT.get_flags());
@@ -675,7 +693,8 @@ pub mod tests {
     #[test]
     fn test_get_active_context_index() {
         let mut dpe =
-            DpeInstance::<OpensslCrypto>::new(Support::default(), &TEST_LOCALITIES).unwrap();
+            DpeInstance::<OpensslCrypto>::new_for_test(Support::default(), &TEST_LOCALITIES)
+                .unwrap();
         let expected_index = 7;
         dpe.contexts[expected_index]
             .handle
@@ -705,7 +724,8 @@ pub mod tests {
     #[test]
     fn test_get_descendants() {
         let mut dpe =
-            DpeInstance::<OpensslCrypto>::new(Support::default(), &TEST_LOCALITIES).unwrap();
+            DpeInstance::<OpensslCrypto>::new_for_test(Support::default(), &TEST_LOCALITIES)
+                .unwrap();
         let root = 7;
         let child_1 = 3;
         let child_1_1 = 0;

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -125,12 +125,13 @@ fn main() -> std::io::Result<()> {
         internal_info: args.supports_internal_info,
         internal_dice: args.supports_internal_dice,
     };
-    let mut dpe = DpeInstance::<OpensslCrypto>::new(support, &LOCALITIES).map_err(|err| {
-        Error::new(
-            ErrorKind::Other,
-            format!("{err:?} while creating new DPE instance"),
-        )
-    })?;
+    let mut dpe =
+        DpeInstance::<OpensslCrypto>::new_for_test(support, &LOCALITIES).map_err(|err| {
+            Error::new(
+                ErrorKind::Other,
+                format!("{err:?} while creating new DPE instance"),
+            )
+        })?;
 
     info!("DPE listening to socket {SOCKET_PATH}");
 


### PR DESCRIPTION
1. Pass issuer common name when creating a DPE instance
2. Compute issuer serial number from public key

I considered adding a callback for the common name as well, but it's not particularly ergonomic since in `certify_key` we don't know the size of the string.