### PR TITLE
Implement GetTaggedTCI and test it with TagTCI

### DIFF
--- a/dpe/src/commands/get_tagged_tci.rs
+++ b/dpe/src/commands/get_tagged_tci.rs
@@ -29,7 +29,7 @@ impl TryFrom<&[u8]> for GetTaggedTciCmd {
 }
 
 impl<C: Crypto> CommandExecution<C> for GetTaggedTciCmd {
-    fn execute(&self, dpe: &mut DpeInstance<C>, locality: u32) -> Result<Response, DpeErrorCode> {
+    fn execute(&self, dpe: &mut DpeInstance<C>, _: u32) -> Result<Response, DpeErrorCode> {
         // Make sure this command is supported.
         if !dpe.support.tagging {
             return Err(DpeErrorCode::InvalidCommand);
@@ -42,11 +42,6 @@ impl<C: Crypto> CommandExecution<C> for GetTaggedTciCmd {
             .iter()
             .find(|c| c.has_tag && c.tag == self.tag)
             .ok_or(DpeErrorCode::BadTag)?;
-
-        // Make sure the command is coming from the locality that owns the found context.
-        if ctx.locality != locality {
-            return Err(DpeErrorCode::InvalidHandle);
-        }
 
         Ok(Response::GetTaggedTci(GetTaggedTciResp {
             tci_cumulative: ctx.tci.tci_cumulative,

--- a/dpe/src/commands/get_tagged_tci.rs
+++ b/dpe/src/commands/get_tagged_tci.rs
@@ -1,0 +1,56 @@
+// Licensed under the Apache-2.0 license.
+use super::CommandExecution;
+use crate::{
+    dpe_instance::DpeInstance,
+    response::{DpeErrorCode, GetTaggedTciResp, Response},
+};
+use core::mem::size_of;
+use crypto::Crypto;
+
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(test, derive(zerocopy::AsBytes, zerocopy::FromBytes))]
+pub struct GetTaggedTciCmd {
+    tag: u32,
+}
+
+impl TryFrom<&[u8]> for GetTaggedTciCmd {
+    type Error = DpeErrorCode;
+
+    fn try_from(raw: &[u8]) -> Result<Self, Self::Error> {
+        if raw.len() < size_of::<GetTaggedTciCmd>() {
+            return Err(DpeErrorCode::InvalidArgument);
+        }
+
+        Ok(GetTaggedTciCmd {
+            tag: u32::from_le_bytes(raw[0..4].try_into().unwrap()),
+        })
+    }
+}
+
+impl<C: Crypto> CommandExecution<C> for GetTaggedTciCmd {
+    fn execute(&self, dpe: &mut DpeInstance<C>, locality: u32) -> Result<Response, DpeErrorCode> {
+        // Make sure this command is supported.
+        if !dpe.support.tagging {
+            return Err(DpeErrorCode::InvalidCommand);
+        }
+
+        // Tags are unique across all contexts, so we just need to return the first context
+        // we find with the requested tag.
+        let ctx = dpe
+            .contexts
+            .iter()
+            .find(|c| c.has_tag && c.tag == self.tag)
+            .ok_or(DpeErrorCode::BadTag)?;
+
+        // Make sure the command is coming from the locality that owns the found context.
+        if ctx.locality != locality {
+            return Err(DpeErrorCode::InvalidHandle);
+        }
+
+        Ok(Response::GetTaggedTci(GetTaggedTciResp {
+            tci_cumulative: ctx.tci.tci_cumulative,
+            tci_current: ctx.tci.tci_current,
+        }))
+    }
+}

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -197,16 +197,6 @@ pub mod tests {
                 .as_bytes()
             )
         );
-        assert_eq!(
-            invalid_command,
-            Command::deserialize(
-                CommandHdr {
-                    cmd_id: Command::GET_TAGGED_TCI,
-                    ..DEFAULT_COMMAND
-                }
-                .as_bytes()
-            )
-        );
     }
 
     #[test]

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub(crate) use self::initialize_context::InitCtxCmd;
 use self::certify_key::CertifyKeyCmd;
 use self::derive_child::DeriveChildCmd;
 use self::extend_tci::ExtendTciCmd;
+use self::get_tagged_tci::GetTaggedTciCmd;
 use self::rotate_context::RotateCtxCmd;
 use self::sign::SignCmd;
 use self::tag_tci::TagTciCmd;
@@ -26,6 +27,7 @@ mod certify_key;
 mod derive_child;
 mod destroy_context;
 mod extend_tci;
+mod get_tagged_tci;
 mod initialize_context;
 mod rotate_context;
 mod sign;
@@ -42,6 +44,7 @@ pub enum Command {
     DestroyCtx(DestroyCtxCmd),
     ExtendTci(ExtendTciCmd),
     TagTci(TagTciCmd),
+    GetTaggedTci(GetTaggedTciCmd),
 }
 
 impl Command {
@@ -79,7 +82,7 @@ impl Command {
             Command::GET_CERTIFICATE_CHAIN => Err(DpeErrorCode::InvalidCommand),
             Command::EXTEND_TCI => Ok(Command::ExtendTci(ExtendTciCmd::try_from(bytes)?)),
             Command::TAG_TCI => Ok(Command::TagTci(TagTciCmd::try_from(bytes)?)),
-            Command::GET_TAGGED_TCI => Err(DpeErrorCode::InvalidCommand),
+            Command::GET_TAGGED_TCI => Ok(Command::GetTaggedTci(GetTaggedTciCmd::try_from(bytes)?)),
             _ => Err(DpeErrorCode::InvalidCommand),
         }
     }
@@ -280,6 +283,7 @@ pub mod tests {
                 Command::DestroyCtx(_) => Command::DESTROY_CONTEXT,
                 Command::ExtendTci(_) => Command::EXTEND_TCI,
                 Command::TagTci(_) => Command::TAG_TCI,
+                Command::GetTaggedTci(_) => Command::GET_TAGGED_TCI,
             };
             CommandHdr {
                 magic: Self::DPE_COMMAND_MAGIC,

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -109,6 +109,7 @@ impl<C: Crypto> DpeInstance<'_, C> {
             Command::DestroyCtx(cmd) => cmd.execute(self, locality),
             Command::ExtendTci(cmd) => cmd.execute(self, locality),
             Command::TagTci(cmd) => cmd.execute(self, locality),
+            Command::GetTaggedTci(cmd) => cmd.execute(self, locality),
         }
     }
 

--- a/dpe/src/response.rs
+++ b/dpe/src/response.rs
@@ -5,7 +5,8 @@ Abstract:
     DPE reponses and serialization.
 --*/
 use crate::{
-    context::ContextHandle, CURRENT_PROFILE_VERSION, DPE_PROFILE, MAX_CERT_SIZE, MAX_HANDLES,
+    context::ContextHandle, tci::TciMeasurement, CURRENT_PROFILE_VERSION, DPE_PROFILE,
+    MAX_CERT_SIZE, MAX_HANDLES,
 };
 use core::mem::size_of;
 
@@ -219,8 +220,8 @@ impl SignResp {
 }
 
 #[repr(C)]
-#[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(test, derive(zerocopy::AsBytes, zerocopy::FromBytes))]
+#[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct GetTaggedTciResp {
     pub tci_cumulative: TciMeasurement,
     pub tci_current: TciMeasurement,

--- a/dpe/src/response.rs
+++ b/dpe/src/response.rs
@@ -9,7 +9,8 @@ use crate::{
 };
 use core::mem::size_of;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 #[allow(clippy::large_enum_variant)]
 pub enum Response {
     GetProfile(GetProfileResp),

--- a/dpe/src/tci.rs
+++ b/dpe/src/tci.rs
@@ -53,7 +53,8 @@ impl TciNodeData {
 }
 
 #[repr(transparent)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct TciMeasurement(pub [u8; DPE_PROFILE.get_tci_size()]);
 
 impl Default for TciMeasurement {

--- a/verification/abi.go
+++ b/verification/abi.go
@@ -14,6 +14,8 @@ const (
 	CommandInitializeContext CommandCode = 0x5
 	CommandCertifyKey        CommandCode = 0x7
 	CommandDestroyContext    CommandCode = 0xf
+	CommandTagTCI            CommandCode = 0x1002
+	CommandGetTaggedTCI      CommandCode = 0x1003
 )
 
 type CommandHdr struct {
@@ -40,12 +42,14 @@ func NewInitCtxIsSimulation() *InitCtxCmd {
 	return &InitCtxCmd{flags: 1 << 31}
 }
 
+type ContextHandle [16]byte
+
 type DestroyCtxCmd struct {
-	handle [16]byte
+	handle ContextHandle
 	flags  uint32
 }
 
-func NewDestroyCtx(handle [16]byte, destroy_descendants bool) *DestroyCtxCmd {
+func NewDestroyCtx(handle ContextHandle, destroy_descendants bool) *DestroyCtxCmd {
 	flags := uint32(0)
 	if destroy_descendants {
 		flags |= 1 << 31
@@ -54,7 +58,7 @@ func NewDestroyCtx(handle [16]byte, destroy_descendants bool) *DestroyCtxCmd {
 }
 
 type InitCtxResp struct {
-	Handle [16]byte
+	Handle ContextHandle
 }
 
 type GetProfileResp struct {
@@ -71,14 +75,34 @@ const (
 )
 
 type CertifyKeyReq[Digest DigestAlgorithm] struct {
-	ContextHandle [16]byte
+	ContextHandle ContextHandle
 	Flags         CertifyKeyFlags
 	Label         Digest
 }
 
 type CertifyKeyResp[CurveParameter Curve, Digest DigestAlgorithm] struct {
-	NewContextHandle  [16]byte
+	NewContextHandle  ContextHandle
 	DerivedPublicKeyX CurveParameter
 	DerivedPublicKeyY CurveParameter
 	Certificate       []byte
+}
+
+type TCITag uint32
+
+type TagTCIReq struct {
+	ContextHandle ContextHandle
+	Tag           TCITag
+}
+
+type TagTCIResp struct {
+	NewContextHandle ContextHandle
+}
+
+type GetTaggedTCIReq struct {
+	Tag TCITag
+}
+
+type GetTaggedTCIResp[Digest DigestAlgorithm] struct {
+	CumulativeTCI Digest
+	CurrentTCI    Digest
 }

--- a/verification/client.go
+++ b/verification/client.go
@@ -177,6 +177,30 @@ func (c *Client[CurveParameter, Digest]) CertifyKey(cmd *CertifyKeyReq[Digest]) 
 	}, nil
 }
 
+// TagTCI calls the DPE TagTCI command.
+func (c *Client[_, _]) TagTCI(cmd *TagTCIReq) (*TagTCIResp, error) {
+	var respStruct TagTCIResp
+
+	_, err := execCommand(c.transport, CommandTagTCI, c.Profile, cmd, &respStruct)
+	if err != nil {
+		return nil, err
+	}
+
+	return &respStruct, nil
+}
+
+// GetTaggedTCI calls the DPE GetTaggedTCI command.
+func (c *Client[_, Digest]) GetTaggedTCI(cmd *GetTaggedTCIReq) (*GetTaggedTCIResp[Digest], error) {
+	var respStruct GetTaggedTCIResp[Digest]
+
+	_, err := execCommand(c.transport, CommandGetTaggedTCI, c.Profile, cmd, &respStruct)
+	if err != nil {
+		return nil, err
+	}
+
+	return &respStruct, nil
+}
+
 func (s *Support) ToFlags() uint32 {
 	flags := uint32(0)
 	if s.Simulation {

--- a/verification/verification_test.go
+++ b/verification/verification_test.go
@@ -250,3 +250,69 @@ func testCertifyKey(d TestDPEInstance, t *testing.T) {
 
 	// TODO: When DeriveChild is implemented, call it here to add more TCIs and call CertifyKey again.
 }
+
+func TestTagTCI(t *testing.T) {
+	s := &DpeSimulator{exe_path: *sim_exe, supports: Support{AutoInit: true, Tagging: true}}
+	s.SetLocality(DPE_SIMULATOR_AUTO_INIT_LOCALITY)
+	if s.HasPowerControl() {
+		err := s.PowerOn()
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer s.PowerOff()
+	}
+
+	client, err := NewClient256(s)
+	if err != nil {
+		t.Fatalf("Could not initialize client: %v", err)
+	}
+
+	// Try to create the default context if isn't done automatically.
+	if !s.GetSupport().AutoInit {
+		initCtxResp, err := client.InitializeContext(NewInitCtxIsDefault())
+		if err != nil {
+			t.Fatalf("Failed to initialize default context: %v", err)
+		}
+		defer client.DestroyContext(NewDestroyCtx(initCtxResp.Handle, false))
+	}
+
+	tag := TCITag(12345)
+	// Check to see our tag is not yet found.
+	if _, err := client.GetTaggedTCI(&GetTaggedTCIReq{Tag: tag}); !errors.Is(err, StatusBadTag) {
+		t.Fatalf("GetTaggedTCI returned %v, want %v", err, StatusBadTag)
+	}
+
+	// Tag the default context
+	var ctx ContextHandle
+
+	tagResp, err := client.TagTCI(&TagTCIReq{ContextHandle: ctx, Tag: tag})
+	if err != nil {
+		t.Fatalf("Could not tag TCI: %v", err)
+	}
+
+	if tagResp.NewContextHandle != ctx {
+		t.Errorf("New context handle from TagTCI was %x, expected %x", tagResp.NewContextHandle, ctx)
+	}
+
+	getResp, err := client.GetTaggedTCI(&GetTaggedTCIReq{Tag: tag})
+	if err != nil {
+		t.Fatalf("Could not get tagged TCI: %v", err)
+	}
+
+	var wantCumulativeTCI SHA256Digest
+	if getResp.CumulativeTCI != wantCumulativeTCI {
+		t.Errorf("GetTaggedTCI returned cumulative TCI %x, expected %x", getResp.CumulativeTCI, wantCumulativeTCI)
+	}
+
+	var wantCurrentTCI SHA256Digest
+	if getResp.CurrentTCI != wantCurrentTCI {
+		t.Errorf("GetTaggedTCI returned current TCI %x, expected %x", getResp.CurrentTCI, wantCurrentTCI)
+	}
+
+	// Make sure some other tag is still not found.
+	if _, err := client.GetTaggedTCI(&GetTaggedTCIReq{Tag: TCITag(98765)}); !errors.Is(err, StatusBadTag) {
+		t.Fatalf("GetTaggedTCI returned %v, want %v", err, StatusBadTag)
+	}
+
+	// TODO: When DeriveChild is implemented, call it here to add more TCIs and call TagTCI again.
+}


### PR DESCRIPTION
This PR introduces an implementation of GetTaggedTci, and an integration test that tests it together with TagTci. Like CertifyKey, the test will be a lot more interesting after DeriveChild is complete.

As a small housekeeping item, this PR also introduces a type for context handle ([16]byte). Creating a type for this will keep the semantics a little clearer as the codebase grows.