### PR TITLE
Introduce a type for handles in Rust DPE library.

### DIFF
--- a/dpe/src/commands/derive_child.rs
+++ b/dpe/src/commands/derive_child.rs
@@ -1,9 +1,9 @@
 // Licensed under the Apache-2.0 license.
 use super::CommandExecution;
 use crate::{
-    dpe_instance::DpeInstance,
+    dpe_instance::{ContextHandle, DpeInstance},
     response::{DpeErrorCode, Response},
-    DPE_PROFILE, HANDLE_SIZE,
+    DPE_PROFILE,
 };
 use core::mem::size_of;
 use crypto::Crypto;
@@ -12,7 +12,7 @@ use crypto::Crypto;
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(test, derive(zerocopy::AsBytes, zerocopy::FromBytes))]
 pub struct DeriveChildCmd {
-    handle: [u8; HANDLE_SIZE],
+    handle: ContextHandle,
     data: [u8; DPE_PROFILE.get_hash_size()],
     flags: u32,
     tcb_type: u32,
@@ -58,9 +58,8 @@ impl TryFrom<&[u8]> for DeriveChildCmd {
 
         let mut offset: usize = 0;
 
-        let mut handle = [0; HANDLE_SIZE];
-        handle.copy_from_slice(&raw[offset..offset + HANDLE_SIZE]);
-        offset += HANDLE_SIZE;
+        let handle = ContextHandle::try_from(raw)?;
+        offset += ContextHandle::SIZE;
 
         let mut data = [0; DPE_PROFILE.get_hash_size()];
         data.copy_from_slice(&raw[offset..offset + DPE_PROFILE.get_hash_size()]);

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -1,9 +1,9 @@
 // Licensed under the Apache-2.0 license.
 use super::CommandExecution;
 use crate::{
-    dpe_instance::{flags_iter, DpeInstance},
+    dpe_instance::{flags_iter, ContextHandle, DpeInstance},
     response::{DpeErrorCode, Response},
-    HANDLE_SIZE, MAX_HANDLES,
+    MAX_HANDLES,
 };
 use core::mem::size_of;
 use crypto::Crypto;
@@ -12,7 +12,7 @@ use crypto::Crypto;
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(test, derive(zerocopy::AsBytes, zerocopy::FromBytes))]
 pub struct DestroyCtxCmd {
-    pub handle: [u8; HANDLE_SIZE],
+    pub handle: ContextHandle,
     pub flags: u32,
 }
 
@@ -32,10 +32,9 @@ impl TryFrom<&[u8]> for DestroyCtxCmd {
             return Err(DpeErrorCode::InvalidArgument);
         }
 
-        let mut handle = [0; HANDLE_SIZE];
-        handle.copy_from_slice(&raw[0..HANDLE_SIZE]);
+        let handle = ContextHandle::try_from(raw)?;
 
-        let raw = &raw[HANDLE_SIZE..];
+        let raw = &raw[ContextHandle::SIZE..];
         Ok(DestroyCtxCmd {
             handle,
             flags: u32::from_le_bytes(raw[0..4].try_into().unwrap()),

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license.
 use super::CommandExecution;
 use crate::{
-    dpe_instance::{ContextType, DpeInstance},
+    dpe_instance::{ContextHandle, ContextType, DpeInstance},
     response::{DpeErrorCode, NewHandleResp, Response},
 };
 use core::mem::size_of;
@@ -61,10 +61,7 @@ impl<C: Crypto> CommandExecution<C> for InitCtxCmd {
             .ok_or(DpeErrorCode::MaxTcis)?;
         let (context_type, handle) = if self.flag_is_default() {
             dpe.has_initialized = true;
-            (
-                ContextType::Normal,
-                DpeInstance::<C>::DEFAULT_CONTEXT_HANDLE,
-            )
+            (ContextType::Normal, ContextHandle::default())
         } else {
             // Simulation.
             (ContextType::Simulation, dpe.generate_new_handle()?)
@@ -150,7 +147,7 @@ mod tests {
             _ => panic!("Wrong response type."),
         };
         // Make sure default context is 0x0.
-        assert_eq!(DpeInstance::<OpensslCrypto>::DEFAULT_CONTEXT_HANDLE, handle);
+        assert_eq!(ContextHandle::default(), handle);
 
         // Try to double initialize the default context.
         assert_eq!(

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -15,7 +15,6 @@ mod x509;
 
 const MAX_CERT_SIZE: usize = 2048;
 const MAX_HANDLES: usize = 24;
-const HANDLE_SIZE: usize = 16;
 const CURRENT_PROFILE_VERSION: u32 = 0;
 
 pub enum DpeProfile {


### PR DESCRIPTION
This simplifies several aspects about handles: serializing, deserializing, and checks.