### PR TITLE
Implement `DeriveChild` command.

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -29,6 +29,7 @@ impl AlgLen {
     }
 }
 
+#[derive(Debug)]
 pub enum CryptoError {
     AbstractionLayer,
     CryptoLibError,

--- a/dpe/src/commands/derive_child.rs
+++ b/dpe/src/commands/derive_child.rs
@@ -1,8 +1,10 @@
 // Licensed under the Apache-2.0 license.
 use super::CommandExecution;
 use crate::{
-    dpe_instance::{ContextHandle, DpeInstance},
-    response::{DpeErrorCode, Response},
+    dpe_instance::{
+        ActiveContextArgs, ContextHandle, ContextState, ContextType, DpeInstance, TciMeasurement,
+    },
+    response::{DeriveChildResp, DpeErrorCode, Response},
     DPE_PROFILE,
 };
 use core::mem::size_of;
@@ -15,36 +17,123 @@ pub struct DeriveChildCmd {
     handle: ContextHandle,
     data: [u8; DPE_PROFILE.get_hash_size()],
     flags: u32,
-    tcb_type: u32,
+    tci_type: u32,
     target_locality: u32,
 }
 
 impl DeriveChildCmd {
-    const _INTERNAL_INPUT_INFO: u32 = 1 << 31;
-    const _INTERNAL_INPUT_DICE: u32 = 1 << 30;
-    const _RETAIN_PARENT: u32 = 1 << 29;
-    const _TARGET_IS_DEFAULT: u32 = 1 << 28;
+    const INTERNAL_INPUT_INFO: u32 = 1 << 31;
+    const INTERNAL_INPUT_DICE: u32 = 1 << 30;
+    const RETAIN_PARENT: u32 = 1 << 29;
+    const MAKE_DEFAULT: u32 = 1 << 28;
+    const CHANGE_LOCALITY: u32 = 1 << 27;
 
-    const fn _is_internal_input_info(&self) -> bool {
-        self.flags & Self::_INTERNAL_INPUT_INFO != 0
+    const fn uses_internal_info_input(&self) -> bool {
+        self.flags & Self::INTERNAL_INPUT_INFO != 0
     }
 
-    const fn _is_internal_input_dice(&self) -> bool {
-        self.flags & Self::_INTERNAL_INPUT_DICE != 0
+    const fn uses_internal_dice_input(&self) -> bool {
+        self.flags & Self::INTERNAL_INPUT_DICE != 0
     }
 
-    const fn _is_retain_parent(&self) -> bool {
-        self.flags & Self::_RETAIN_PARENT != 0
+    const fn retains_parent(&self) -> bool {
+        self.flags & Self::RETAIN_PARENT != 0
     }
 
-    const fn _is_target_is_default(&self) -> bool {
-        self.flags & Self::_TARGET_IS_DEFAULT != 0
+    const fn makes_default(&self) -> bool {
+        self.flags & Self::MAKE_DEFAULT != 0
+    }
+
+    const fn changes_locality(&self) -> bool {
+        self.flags & Self::CHANGE_LOCALITY != 0
+    }
+
+    /// Check if this will result in two default contexts in the same locality.
+    ///
+    /// There can only be one default context in each locality at any given time. A default context
+    /// has a specific handle. If there are multiple, the DPE instance will not be able to
+    /// differentiate between them.
+    ///
+    /// # Arguments
+    ///
+    /// * `parent_idx` - Index of the soon-to-be parent.
+    /// * `default_context_idx` - Index of the current default context, if there is one.
+    fn safe_to_make_default(&self, parent_idx: usize, default_context_idx: Option<usize>) -> bool {
+        if let Some(default_idx) = default_context_idx {
+            if default_idx != parent_idx || self.retains_parent() {
+                return false;
+            }
+        }
+        true
     }
 }
 
 impl<C: Crypto> CommandExecution<C> for DeriveChildCmd {
-    fn execute(&self, _dpe: &mut DpeInstance<C>, _locality: u32) -> Result<Response, DpeErrorCode> {
-        Err(DpeErrorCode::InvalidCommand)
+    fn execute(&self, dpe: &mut DpeInstance<C>, locality: u32) -> Result<Response, DpeErrorCode> {
+        // Make sure the operation is supported.
+        if !dpe.support.internal_info && self.uses_internal_info_input()
+            || !dpe.support.internal_dice && self.uses_internal_dice_input()
+        {
+            return Err(DpeErrorCode::InvalidArgument);
+        }
+
+        let parent_idx = dpe
+            .get_active_context_pos(&self.handle, locality)
+            .ok_or(DpeErrorCode::InvalidHandle)?;
+        let child_idx = dpe
+            .get_next_inactive_context_pos()
+            .ok_or(DpeErrorCode::MaxTcis)?;
+
+        let target_locality = if !self.changes_locality() {
+            locality
+        } else {
+            // Make sure the target locality is valid.
+            if !dpe.localities.iter().any(|&l| l == self.target_locality) {
+                return Err(DpeErrorCode::InvalidLocality);
+            }
+            self.target_locality
+        };
+
+        // Make sure it can be the default if it is supposed to be.
+        if self.makes_default() {
+            let default_context_idx =
+                dpe.get_active_context_pos(&ContextHandle::default(), target_locality);
+
+            if !self.safe_to_make_default(parent_idx, default_context_idx) {
+                return Err(DpeErrorCode::InvalidArgument);
+            }
+        }
+
+        let child_handle = if self.makes_default() {
+            ContextHandle::default()
+        } else {
+            dpe.generate_new_handle()?
+        };
+
+        if !self.retains_parent() {
+            dpe.contexts[parent_idx].state = ContextState::Retired;
+            dpe.contexts[parent_idx].handle = ContextHandle([0xff; ContextHandle::SIZE]);
+        } else if !dpe.contexts[parent_idx].handle.is_default() {
+            dpe.contexts[parent_idx].handle = dpe.generate_new_handle()?;
+        }
+
+        dpe.contexts[child_idx].activate(&ActiveContextArgs {
+            context_type: ContextType::Normal,
+            locality: target_locality,
+            handle: &child_handle,
+            tci_type: self.tci_type,
+            parent_idx: parent_idx as u8,
+        });
+
+        dpe.add_tci_measurement(child_idx, &TciMeasurement(self.data), target_locality)?;
+
+        // Add child to the parent's list of children.
+        dpe.contexts[parent_idx].add_child(child_idx)?;
+
+        Ok(Response::DeriveChild(DeriveChildResp {
+            handle: child_handle,
+            parent_handle: dpe.contexts[parent_idx].handle,
+        }))
     }
 }
 
@@ -68,7 +157,7 @@ impl TryFrom<&[u8]> for DeriveChildCmd {
         let flags = u32::from_le_bytes(raw[offset..offset + size_of::<u32>()].try_into().unwrap());
         offset += size_of::<u32>();
 
-        let tcb_type =
+        let tci_type =
             u32::from_le_bytes(raw[offset..offset + size_of::<u32>()].try_into().unwrap());
         offset += size_of::<u32>();
 
@@ -79,7 +168,7 @@ impl TryFrom<&[u8]> for DeriveChildCmd {
             handle,
             data,
             flags,
-            tcb_type,
+            tci_type,
             target_locality,
         })
     }
@@ -88,14 +177,22 @@ impl TryFrom<&[u8]> for DeriveChildCmd {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{commands::tests::TEST_DIGEST, dpe_instance::tests::SIMULATION_HANDLE};
+    use crate::{
+        commands::{tests::TEST_DIGEST, InitCtxCmd},
+        dpe_instance::{
+            tests::{SIMULATION_HANDLE, TEST_LOCALITIES},
+            Support,
+        },
+        MAX_HANDLES,
+    };
+    use crypto::OpensslCrypto;
     use zerocopy::{AsBytes, FromBytes};
 
     const TEST_DERIVE_CHILD_CMD: DeriveChildCmd = DeriveChildCmd {
         handle: SIMULATION_HANDLE,
         data: TEST_DIGEST,
         flags: 0x1234_5678,
-        tcb_type: 0x9876_5432,
+        tci_type: 0x9876_5432,
         target_locality: 0x10CA_1171,
     };
 
@@ -123,5 +220,319 @@ mod tests {
             TEST_DERIVE_CHILD_CMD,
             DeriveChildCmd::try_from(TEST_DERIVE_CHILD_CMD.as_bytes()).unwrap()
         );
+    }
+
+    #[test]
+    fn test_initial_conditions() {
+        let mut dpe =
+            DpeInstance::<OpensslCrypto>::new_for_test(Support::default(), &TEST_LOCALITIES)
+                .unwrap();
+
+        // Right now this command doesn't support INTERNAL_INPUT_INFO, make sure it errors.
+        assert_eq!(
+            Err(DpeErrorCode::InvalidArgument),
+            DeriveChildCmd {
+                handle: ContextHandle::default(),
+                data: [0; DPE_PROFILE.get_tci_size()],
+                flags: DeriveChildCmd::INTERNAL_INPUT_INFO,
+                tci_type: 0,
+                target_locality: 0
+            }
+            .execute(&mut dpe, 0)
+        );
+
+        // Right now this command doesn't support INTERNAL_INPUT_DICE, make sure it errors.
+        assert_eq!(
+            Err(DpeErrorCode::InvalidArgument),
+            DeriveChildCmd {
+                handle: ContextHandle::default(),
+                data: [0; DPE_PROFILE.get_tci_size()],
+                flags: DeriveChildCmd::INTERNAL_INPUT_DICE,
+                tci_type: 0,
+                target_locality: 0
+            }
+            .execute(&mut dpe, 0)
+        );
+
+        InitCtxCmd::new_use_default().execute(&mut dpe, 0).unwrap();
+
+        // Make sure it can detect wrong locality.
+        assert_eq!(
+            Err(DpeErrorCode::InvalidHandle),
+            DeriveChildCmd {
+                handle: ContextHandle::default(),
+                data: [0; DPE_PROFILE.get_tci_size()],
+                flags: 0,
+                tci_type: 0,
+                target_locality: 0
+            }
+            .execute(&mut dpe, 1)
+        );
+
+        // Make sure it can detect an invalid locality.
+        assert_eq!(
+            Err(DpeErrorCode::InvalidLocality),
+            DeriveChildCmd {
+                handle: ContextHandle::default(),
+                data: [0; DPE_PROFILE.get_tci_size()],
+                flags: DeriveChildCmd::CHANGE_LOCALITY,
+                tci_type: 0,
+                target_locality: 2
+            }
+            .execute(&mut dpe, 0)
+        );
+    }
+
+    #[test]
+    fn test_max_tcis() {
+        let mut dpe = DpeInstance::<OpensslCrypto>::new_for_test(
+            Support {
+                auto_init: true,
+                ..Support::default()
+            },
+            &TEST_LOCALITIES,
+        )
+        .unwrap();
+
+        // Fill all contexts with children (minus the auto-init context).
+        for _ in 0..MAX_HANDLES - 1 {
+            DeriveChildCmd {
+                handle: ContextHandle::default(),
+                data: [0; DPE_PROFILE.get_tci_size()],
+                flags: DeriveChildCmd::MAKE_DEFAULT,
+                tci_type: 0,
+                target_locality: 0,
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+            .unwrap();
+        }
+
+        // Try to create one too many.
+        assert_eq!(
+            Err(DpeErrorCode::MaxTcis),
+            DeriveChildCmd {
+                handle: ContextHandle::default(),
+                data: [0; DPE_PROFILE.get_tci_size()],
+                flags: 0,
+                tci_type: 0,
+                target_locality: 0
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+        );
+    }
+
+    #[test]
+    fn test_set_child_parent_relationship() {
+        let mut dpe = DpeInstance::<OpensslCrypto>::new_for_test(
+            Support {
+                auto_init: true,
+                ..Support::default()
+            },
+            &TEST_LOCALITIES,
+        )
+        .unwrap();
+
+        let parent_idx = dpe
+            .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[0])
+            .unwrap();
+        DeriveChildCmd {
+            handle: ContextHandle::default(),
+            data: [0; DPE_PROFILE.get_tci_size()],
+            flags: DeriveChildCmd::MAKE_DEFAULT | DeriveChildCmd::CHANGE_LOCALITY,
+            tci_type: 7,
+            target_locality: TEST_LOCALITIES[1],
+        }
+        .execute(&mut dpe, TEST_LOCALITIES[0])
+        .unwrap();
+        let child_idx = dpe
+            .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[1])
+            .unwrap();
+        let child = &dpe.contexts[child_idx];
+
+        assert_eq!(parent_idx, child.parent_idx as usize);
+        assert_eq!(
+            child_idx,
+            dpe.contexts[parent_idx].children.trailing_zeros() as usize
+        );
+        assert_eq!(7, child.tci.tci_type);
+        assert_eq!(TEST_LOCALITIES[1], child.locality);
+    }
+
+    #[test]
+    fn test_set_other_values() {
+        let mut dpe = DpeInstance::<OpensslCrypto>::new_for_test(
+            Support {
+                auto_init: true,
+                ..Support::default()
+            },
+            &TEST_LOCALITIES,
+        )
+        .unwrap();
+
+        DeriveChildCmd {
+            handle: ContextHandle::default(),
+            data: [0; DPE_PROFILE.get_tci_size()],
+            flags: DeriveChildCmd::MAKE_DEFAULT | DeriveChildCmd::CHANGE_LOCALITY,
+            tci_type: 7,
+            target_locality: TEST_LOCALITIES[1],
+        }
+        .execute(&mut dpe, TEST_LOCALITIES[0])
+        .unwrap();
+
+        let child = &dpe.contexts[dpe
+            .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[1])
+            .unwrap()];
+
+        assert_eq!(7, child.tci.tci_type);
+        assert_eq!(TEST_LOCALITIES[1], child.locality);
+        assert_eq!(ContextType::Normal, child.context_type);
+    }
+
+    #[test]
+    fn test_correct_child_handle() {
+        let mut dpe = DpeInstance::<OpensslCrypto>::new_for_test(
+            Support {
+                auto_init: true,
+                ..Support::default()
+            },
+            &TEST_LOCALITIES,
+        )
+        .unwrap();
+
+        // Make sure child handle is default when creating default child.
+        assert_eq!(
+            Ok(Response::DeriveChild(DeriveChildResp {
+                handle: ContextHandle::default(),
+                parent_handle: ContextHandle([0xff; ContextHandle::SIZE])
+            })),
+            DeriveChildCmd {
+                handle: ContextHandle::default(),
+                data: [0; DPE_PROFILE.get_tci_size()],
+                flags: DeriveChildCmd::MAKE_DEFAULT,
+                tci_type: 0,
+                target_locality: 0,
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+        );
+
+        // Make sure child has a random handle when not creating default.
+        assert_eq!(
+            Ok(Response::DeriveChild(DeriveChildResp {
+                handle: SIMULATION_HANDLE,
+                parent_handle: ContextHandle([0xff; ContextHandle::SIZE])
+            })),
+            DeriveChildCmd {
+                handle: ContextHandle::default(),
+                data: [0; DPE_PROFILE.get_tci_size()],
+                flags: 0,
+                tci_type: 0,
+                target_locality: 0,
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+        );
+    }
+
+    #[test]
+    fn test_correct_parent_handle() {
+        let mut dpe = DpeInstance::<OpensslCrypto>::new_for_test(
+            Support {
+                auto_init: true,
+                ..Support::default()
+            },
+            &TEST_LOCALITIES,
+        )
+        .unwrap();
+
+        // Make sure the parent handle is non-sense when not retaining.
+        assert_eq!(
+            Ok(Response::DeriveChild(DeriveChildResp {
+                handle: ContextHandle::default(),
+                parent_handle: ContextHandle([0xff; ContextHandle::SIZE])
+            })),
+            DeriveChildCmd {
+                handle: ContextHandle::default(),
+                data: [0; DPE_PROFILE.get_tci_size()],
+                flags: DeriveChildCmd::MAKE_DEFAULT,
+                tci_type: 0,
+                target_locality: 0,
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+        );
+
+        // Make sure the default parent handle stays the default handle when retained.
+        assert_eq!(
+            Ok(Response::DeriveChild(DeriveChildResp {
+                handle: ContextHandle::default(),
+                parent_handle: ContextHandle::default(),
+            })),
+            DeriveChildCmd {
+                handle: ContextHandle::default(),
+                data: [0; DPE_PROFILE.get_tci_size()],
+                flags: DeriveChildCmd::RETAIN_PARENT
+                    | DeriveChildCmd::MAKE_DEFAULT
+                    | DeriveChildCmd::CHANGE_LOCALITY,
+                tci_type: 0,
+                target_locality: TEST_LOCALITIES[1],
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+        );
+
+        // The next test case is to make sure the parent handle rotates when not the default and
+        // parent is retained. For this to work, we need the child to be created as the default (see
+        // note below). Right now both localities have a default. We need to mutate one of them so
+        // we can create a new child as the default in the locality.
+        let old_default_idx = dpe
+            .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[0])
+            .unwrap();
+        dpe.contexts[old_default_idx].handle = ContextHandle([0x1; ContextHandle::SIZE]);
+
+        // Make sure the parent handle is regenerated when being retained.
+        assert_eq!(
+            Ok(Response::DeriveChild(DeriveChildResp {
+                handle: ContextHandle::default(),
+                parent_handle: SIMULATION_HANDLE,
+            })),
+            DeriveChildCmd {
+                handle: dpe.contexts[old_default_idx].handle,
+                data: [0; DPE_PROFILE.get_tci_size()],
+                flags: DeriveChildCmd::RETAIN_PARENT | DeriveChildCmd::MAKE_DEFAULT,
+                tci_type: 0,
+                target_locality: 0,
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+        );
+
+        // NOTE: The deterministic RNG we use in tests will create the same value every time. This
+        // makes it so we can't test the case where neither parent or child are default and the
+        // parent will be retained. It would try to generate two new handles, but they would be the
+        // same value and throw an error. We either need to change the RNG or test this test case
+        // outside of unit tests.
+    }
+
+    #[test]
+    fn test_safe_to_make_default() {
+        let mut make_default_in_0 = DeriveChildCmd {
+            handle: ContextHandle::default(),
+            data: TciMeasurement::default().0,
+            flags: DeriveChildCmd::MAKE_DEFAULT,
+            tci_type: 0,
+            target_locality: 0,
+        };
+        let parent_idx = 0;
+        // No default context.
+        assert!(make_default_in_0.safe_to_make_default(parent_idx, None));
+        // Default context at parent, but not going to retain parent.
+        assert!(make_default_in_0.safe_to_make_default(parent_idx, Some(parent_idx)));
+        // Make default in a different locality that already has a default.
+        assert!(!make_default_in_0.safe_to_make_default(parent_idx, Some(1)));
+
+        make_default_in_0.flags |= DeriveChildCmd::RETAIN_PARENT;
+
+        // Retain parent and make default in another locality that doesn't have a default.
+        assert!(make_default_in_0.safe_to_make_default(parent_idx, None));
+        // Retain default parent and make default in another locality that has a default.
+        assert!(!make_default_in_0.safe_to_make_default(parent_idx, Some(1)));
+        // Retain default parent.
+        assert!(!make_default_in_0.safe_to_make_default(parent_idx, Some(parent_idx)));
     }
 }

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license.
 use super::CommandExecution;
 use crate::{
-    dpe_instance::{ContextHandle, ContextType, DpeInstance},
+    dpe_instance::{ActiveContextArgs, Context, ContextHandle, ContextType, DpeInstance},
     response::{DpeErrorCode, NewHandleResp, Response},
 };
 use core::mem::size_of;
@@ -67,7 +67,13 @@ impl<C: Crypto> CommandExecution<C> for InitCtxCmd {
             (ContextType::Simulation, dpe.generate_new_handle()?)
         };
 
-        dpe.contexts[idx].activate(context_type, locality, &handle);
+        dpe.contexts[idx].activate(&ActiveContextArgs {
+            context_type,
+            locality,
+            handle: &handle,
+            tci_type: 0,
+            parent_idx: Context::ROOT_INDEX,
+        });
         Ok(Response::InitCtx(NewHandleResp { handle }))
     }
 }

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use core::marker::PhantomData;
 use core::mem::size_of;
-use crypto::Crypto;
+use crypto::{Crypto, Hasher};
 
 pub struct DpeInstance<'a, C: Crypto> {
     pub(crate) contexts: [Context; MAX_HANDLES],
@@ -202,6 +202,42 @@ impl<C: Crypto> DpeInstance<'_, C> {
 
         Ok(out_idx)
     }
+
+    pub(crate) fn add_tci_measurement(
+        &mut self,
+        idx: usize,
+        measurement: &TciMeasurement,
+        locality: u32,
+    ) -> Result<(), DpeErrorCode> {
+        if idx >= MAX_HANDLES {
+            return Err(DpeErrorCode::InternalError);
+        }
+
+        let context = &mut self.contexts[idx];
+
+        if context.state != ContextState::Active {
+            return Err(DpeErrorCode::InvalidHandle);
+        }
+        if context.locality != locality {
+            return Err(DpeErrorCode::InvalidLocality);
+        }
+
+        // Derive the new TCI as HASH(TCI_CUMULATIVE || INPUT_DATA).
+        let mut hasher =
+            C::hash_initialize(DPE_PROFILE.alg_len()).map_err(|_| DpeErrorCode::InternalError)?;
+        hasher
+            .update(&context.tci.tci_cumulative.0)
+            .map_err(|_| DpeErrorCode::InternalError)?;
+        hasher
+            .update(&measurement.0)
+            .map_err(|_| DpeErrorCode::InternalError)?;
+        hasher
+            .finish(&mut context.tci.tci_cumulative.0)
+            .map_err(|_| DpeErrorCode::InternalError)?;
+
+        context.tci.tci_current = *measurement;
+        Ok(())
+    }
 }
 
 #[repr(transparent)]
@@ -326,9 +362,14 @@ pub(crate) enum ContextState {
     Inactive,
     /// Context is initialized and ready to be used.
     Active,
+    /// A child was derived from this context, but it was not retained. This will need to be
+    /// destroyed automatically if all of it's children have been destroyed. It is preserved for its
+    /// TCI data, but the handle is no longer valid. Because the handle is no longer valid, a client
+    /// cannot command it to be destroyed.
+    Retired,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub(crate) enum ContextType {
     /// Typical context.
     Normal,
@@ -379,14 +420,15 @@ impl Context {
     /// * `locality` - Which hardware locality owns the context.
     /// * `handle` - Value that will be used to refer to the context. Random value for simulation
     ///   contexts and 0x0 for the default context.
-    pub fn activate(&mut self, context_type: ContextType, locality: u32, handle: &ContextHandle) {
-        self.handle = *handle;
+    pub fn activate(&mut self, args: &ActiveContextArgs) {
+        self.handle = *args.handle;
         self.tci = TciNodeData::new();
+        self.tci.tci_type = args.tci_type;
         self.children = 0;
-        self.parent_idx = Self::ROOT_INDEX;
-        self.context_type = context_type;
+        self.parent_idx = args.parent_idx;
+        self.context_type = args.context_type;
         self.state = ContextState::Active;
-        self.locality = locality;
+        self.locality = args.locality;
     }
 
     /// Destroy this context so it can no longer be used until it is re-initialized. The default
@@ -397,6 +439,23 @@ impl Context {
         self.tag = 0;
         self.state = ContextState::Inactive;
     }
+
+    /// Add a child to list of children in the context.
+    pub fn add_child(&mut self, idx: usize) -> Result<(), DpeErrorCode> {
+        if idx >= MAX_HANDLES {
+            return Err(DpeErrorCode::InternalError);
+        }
+        self.children |= 1 << idx;
+        Ok(())
+    }
+}
+
+pub(crate) struct ActiveContextArgs<'a> {
+    pub context_type: ContextType,
+    pub locality: u32,
+    pub handle: &'a ContextHandle,
+    pub tci_type: u32,
+    pub parent_idx: u8,
 }
 
 /// Iterate over all of the bits set to 1 in a u32. Each iteration returns the bit index 0 being the
@@ -738,6 +797,12 @@ pub mod tests {
             .get_active_context_pos(&SIMULATION_HANDLE, locality)
             .is_none());
 
+        // Shouldn't be able to find it if it is retired either.
+        dpe.contexts[expected_index].state = ContextState::Retired;
+        assert!(dpe
+            .get_active_context_pos(&SIMULATION_HANDLE, locality)
+            .is_none());
+
         // Mark it active, but check the wrong locality.
         let locality = 2;
         dpe.contexts[expected_index].state = ContextState::Active;
@@ -751,6 +816,56 @@ pub mod tests {
             .get_active_context_pos(&SIMULATION_HANDLE, locality)
             .unwrap();
         assert_eq!(expected_index, idx);
+    }
+
+    #[test]
+    fn test_add_tci_measurement() {
+        let mut dpe = DpeInstance::<OpensslCrypto>::new_for_test(
+            Support {
+                auto_init: true,
+                ..Default::default()
+            },
+            &TEST_LOCALITIES,
+        )
+        .unwrap();
+
+        // Verify bounds checking.
+        assert_eq!(
+            Err(DpeErrorCode::InternalError),
+            dpe.add_tci_measurement(MAX_HANDLES, &TciMeasurement::default(), TEST_LOCALITIES[0])
+        );
+
+        let data = [1; DPE_PROFILE.get_hash_size()];
+        dpe.add_tci_measurement(0, &TciMeasurement(data), TEST_LOCALITIES[0])
+            .unwrap();
+        let context = &dpe.contexts[0];
+        assert_eq!(data, context.tci.tci_current.0);
+
+        // Compute cumulative.
+        let mut hasher = OpensslCrypto::hash_initialize(DPE_PROFILE.alg_len()).unwrap();
+        hasher.update(&[0; DPE_PROFILE.get_hash_size()]).unwrap();
+        hasher.update(&data).unwrap();
+        let mut first_cumulative = [0; DPE_PROFILE.get_hash_size()];
+        hasher.finish(&mut first_cumulative).unwrap();
+
+        // Make sure the cumulative was computed correctly.
+        assert_eq!(first_cumulative.as_ref(), context.tci.tci_cumulative.0);
+
+        let data = [2; DPE_PROFILE.get_hash_size()];
+        dpe.add_tci_measurement(0, &TciMeasurement(data), TEST_LOCALITIES[0])
+            .unwrap();
+        // Make sure the current TCI was updated correctly.
+        let context = &dpe.contexts[0];
+        assert_eq!(data, context.tci.tci_current.0);
+
+        let mut hasher = OpensslCrypto::hash_initialize(DPE_PROFILE.alg_len()).unwrap();
+        hasher.update(&first_cumulative).unwrap();
+        hasher.update(&data).unwrap();
+        let mut second_cumulative = [0; DPE_PROFILE.get_hash_size()];
+        hasher.finish(&mut second_cumulative).unwrap();
+
+        // Make sure the cumulative was computed correctly.
+        assert_eq!(second_cumulative.as_ref(), context.tci.tci_cumulative.0);
     }
 
     #[test]


### PR DESCRIPTION
Because this has a lot of the same functionality as `ExtendTci`, this also moves adding a TCI measurement into its own function.