### PR TITLE
Add missing TCI node member to `serialize` function.

### DIFF
--- a/dpe/src/tci.rs
+++ b/dpe/src/tci.rs
@@ -4,6 +4,7 @@ use core::mem::size_of;
 
 #[repr(C, align(4))]
 #[derive(Default, Copy, Clone)]
+#[cfg_attr(test, derive(zerocopy::AsBytes, zerocopy::FromBytes))]
 pub(crate) struct TciNodeData {
     pub tci_type: u32,
 
@@ -41,10 +42,16 @@ impl TciNodeData {
         }
 
         let mut offset: usize = 0;
+
         dst[offset..offset + size_of::<u32>()].copy_from_slice(&self.tci_type.to_le_bytes());
         offset += size_of::<u32>();
+
+        dst[offset..offset + size_of::<u32>()].copy_from_slice(&self.flags.to_le_bytes());
+        offset += size_of::<u32>();
+
         dst[offset..offset + self.tci_cumulative.0.len()].copy_from_slice(&self.tci_cumulative.0);
         offset += self.tci_cumulative.0.len();
+
         dst[offset..offset + self.tci_current.0.len()].copy_from_slice(&self.tci_current.0);
         offset += self.tci_current.0.len();
 
@@ -54,11 +61,40 @@ impl TciNodeData {
 
 #[repr(transparent)]
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
+#[cfg_attr(test, derive(PartialEq, Eq, zerocopy::AsBytes, zerocopy::FromBytes))]
 pub struct TciMeasurement(pub [u8; DPE_PROFILE.get_tci_size()]);
 
 impl Default for TciMeasurement {
     fn default() -> Self {
         Self([0; DPE_PROFILE.get_tci_size()])
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use zerocopy::AsBytes;
+
+    #[test]
+    fn test_serialize_tci_node_data() {
+        let tci_node_data = TciNodeData {
+            tci_type: 0x1234_5678,
+            flags: 0x9876_5432,
+            tci_cumulative: TciMeasurement(core::array::from_fn(|i| (i + 1) as u8)),
+            tci_current: TciMeasurement(core::array::from_fn(|i| (0xff - i) as u8)),
+        };
+        // Test too small slice.
+        let mut response_buffer = [0; size_of::<TciNodeData>() - 1];
+        assert_eq!(
+            Err(DpeErrorCode::InternalError),
+            tci_node_data.serialize(response_buffer.as_mut_slice())
+        );
+        let mut response_buffer = [0; size_of::<TciNodeData>()];
+
+        assert_eq!(
+            2 * DPE_PROFILE.get_tci_size() + 2 * 4,
+            tci_node_data.serialize(&mut response_buffer).unwrap()
+        );
+        assert_eq!(tci_node_data.as_bytes(), response_buffer);
     }
 }


### PR DESCRIPTION
Also adds a unit tests.