### PR TITLE
Add a test for `DpeInstance::derive_cdi()`.

### DIFF
--- a/dpe/src/commands/derive_child.rs
+++ b/dpe/src/commands/derive_child.rs
@@ -14,19 +14,19 @@ use crypto::Crypto;
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(test, derive(zerocopy::AsBytes, zerocopy::FromBytes))]
 pub struct DeriveChildCmd {
-    handle: ContextHandle,
-    data: [u8; DPE_PROFILE.get_hash_size()],
-    flags: u32,
-    tci_type: u32,
-    target_locality: u32,
+    pub handle: ContextHandle,
+    pub data: [u8; DPE_PROFILE.get_hash_size()],
+    pub flags: u32,
+    pub tci_type: u32,
+    pub target_locality: u32,
 }
 
 impl DeriveChildCmd {
-    const INTERNAL_INPUT_INFO: u32 = 1 << 31;
-    const INTERNAL_INPUT_DICE: u32 = 1 << 30;
-    const RETAIN_PARENT: u32 = 1 << 29;
-    const MAKE_DEFAULT: u32 = 1 << 28;
-    const CHANGE_LOCALITY: u32 = 1 << 27;
+    pub const INTERNAL_INPUT_INFO: u32 = 1 << 31;
+    pub const INTERNAL_INPUT_DICE: u32 = 1 << 30;
+    pub const RETAIN_PARENT: u32 = 1 << 29;
+    pub const MAKE_DEFAULT: u32 = 1 << 28;
+    pub const CHANGE_LOCALITY: u32 = 1 << 27;
 
     const fn uses_internal_info_input(&self) -> bool {
         self.flags & Self::INTERNAL_INPUT_INFO != 0

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -4,11 +4,11 @@ Licensed under the Apache-2.0 license.
 Abstract:
     DPE Commands and deserialization.
 --*/
+pub(crate) use self::derive_child::DeriveChildCmd;
 pub(crate) use self::destroy_context::DestroyCtxCmd;
 pub(crate) use self::initialize_context::InitCtxCmd;
 
 use self::certify_key::CertifyKeyCmd;
-use self::derive_child::DeriveChildCmd;
 use self::extend_tci::ExtendTciCmd;
 use self::get_tagged_tci::GetTaggedTciCmd;
 use self::rotate_context::RotateCtxCmd;


### PR DESCRIPTION
`derive_cdi` will be used in several places so we need to make sure, it works as expected. The `Sign` command will rely on this function being valid for its verification. This change is in preparation to begin merging the implementation of the `Sign` command.