### PR TITLE
Add missing fields for updated `GetProfile` command.

### DIFF
--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -304,7 +304,7 @@ pub mod tests {
     use crate::commands::DestroyCtxCmd;
     use crate::response::NewHandleResp;
     use crate::support::test::SUPPORT;
-    use crate::{commands::CommandHdr, CURRENT_PROFILE_VERSION};
+    use crate::{commands::CommandHdr, CURRENT_PROFILE_MAJOR_VERSION};
     use crypto::OpensslCrypto;
     use zerocopy::AsBytes;
 
@@ -421,7 +421,7 @@ pub mod tests {
     fn test_get_profile() {
         let dpe = DpeInstance::<OpensslCrypto>::new_for_test(SUPPORT, &TEST_LOCALITIES).unwrap();
         let profile = dpe.get_profile().unwrap();
-        assert_eq!(profile.version, CURRENT_PROFILE_VERSION);
+        assert_eq!(profile.major_version, CURRENT_PROFILE_MAJOR_VERSION);
         assert_eq!(profile.flags, SUPPORT.get_flags());
     }
 

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -22,7 +22,10 @@ mod x509;
 
 const MAX_CERT_SIZE: usize = 2048;
 const MAX_HANDLES: usize = 24;
-const CURRENT_PROFILE_VERSION: u32 = 0;
+const CURRENT_PROFILE_MAJOR_VERSION: u16 = 0;
+const CURRENT_PROFILE_MINOR_VERSION: u16 = 8;
+const VENDOR_ID: u32 = 0;
+const VENDOR_SKU: u32 = 0;
 
 pub enum DpeProfile {
     P256Sha256 = 1,

--- a/verification/abi.go
+++ b/verification/abi.go
@@ -4,7 +4,8 @@ const (
 	CmdMagic  uint32 = 0x44504543
 	RespMagic uint32 = 0x44504552
 
-	CURRENT_PROFILE_VERSION uint32 = 0
+	CURRENT_PROFILE_MAJOR_VERSION uint16 = 0
+	CURRENT_PROFILE_MINOR_VERSION uint16 = 8
 )
 
 type CommandCode uint32
@@ -62,10 +63,13 @@ type InitCtxResp struct {
 }
 
 type GetProfileResp struct {
-	Profile     Profile
-	Version     uint32
-	MaxTciNodes uint32
-	Flags       uint32
+	Profile      Profile
+	MajorVersion uint16
+	MinorVersion uint16
+	VendorId     uint32
+	VendorSku    uint32
+	MaxTciNodes  uint32
+	Flags        uint32
 }
 
 type CertifyKeyFlags uint32

--- a/verification/client.go
+++ b/verification/client.go
@@ -24,11 +24,14 @@ type Transport interface {
 
 // Client is a connection to a DPE instance, parameterized by hash algorithm and ECC curve.
 type Client[CurveParameter Curve, Digest DigestAlgorithm] struct {
-	transport   Transport
-	Profile     Profile
-	Version     uint32
-	MaxTciNodes uint32
-	Flags       uint32
+	transport    Transport
+	Profile      Profile
+	MajorVersion uint16
+	MinorVersion uint16
+	VendorId     uint32
+	VendorSku    uint32
+	MaxTciNodes  uint32
+	Flags        uint32
 }
 
 // Client256 is a client that implements DPE_PROFILE_IROT_P256_SHA256
@@ -77,11 +80,13 @@ func NewClient[C Curve, D DigestAlgorithm](t Transport) (*Client[C, D], error) {
 	}
 
 	return &Client[C, D]{
-		transport:   t,
-		Profile:     rsp.Profile,
-		Version:     rsp.Version,
-		MaxTciNodes: rsp.MaxTciNodes,
-		Flags:       rsp.Flags,
+		transport:    t,
+		Profile:      rsp.Profile,
+		MajorVersion: rsp.MajorVersion,
+		MinorVersion: rsp.MinorVersion,
+		VendorId:     rsp.VendorId,
+		VendorSku:    rsp.VendorSku,
+		Flags:        rsp.Flags,
 	}, nil
 }
 
@@ -113,9 +118,12 @@ func getProfile(t Transport) (*GetProfileResp, error) {
 	// Define an anonymous struct for the actual wire-format members of GetProfile,
 	// since GetProfileResp includes the actual profile copied from the response header.
 	respStruct := struct {
-		Version     uint32
-		MaxTciNodes uint32
-		Flags       uint32
+		MajorVersion uint16
+		MinorVersion uint16
+		VendorId     uint32
+		VendorSku    uint32
+		MaxTciNodes  uint32
+		Flags        uint32
 	}{}
 
 	respHdr, err := execCommand(t, CommandGetProfile, 0, cmd, &respStruct)
@@ -125,10 +133,13 @@ func getProfile(t Transport) (*GetProfileResp, error) {
 
 	return &GetProfileResp{
 		// Special case for GetProfile: copy the profile from the inner packet header into the response structure.
-		Profile:     respHdr.Profile,
-		Version:     respStruct.Version,
-		MaxTciNodes: respStruct.MaxTciNodes,
-		Flags:       respStruct.Flags,
+		Profile:      respHdr.Profile,
+		MajorVersion: respStruct.MajorVersion,
+		MinorVersion: respStruct.MinorVersion,
+		VendorId:     respStruct.VendorId,
+		VendorSku:    respStruct.VendorSku,
+		MaxTciNodes:  respStruct.MaxTciNodes,
+		Flags:        respStruct.Flags,
 	}, nil
 }
 

--- a/verification/simulator.go
+++ b/verification/simulator.go
@@ -15,11 +15,14 @@ import (
 const (
 	socketPath = "/tmp/dpe-sim.socket"
 
-	DPE_SIMULATOR_AUTO_INIT_LOCALITY uint32  = 0
-	DPE_SIMULATOR_OTHER_LOCALITY     uint32  = 0x4f544852
-	DPE_SIMULATOR_PROFILE            Profile = ProfileP256SHA256
-	DPE_SIMULATOR_MAX_TCI_NODES      uint32  = 24
-	DPE_SIMULATOR_PROFILE_VERSION    uint32  = CURRENT_PROFILE_VERSION
+	DPE_SIMULATOR_AUTO_INIT_LOCALITY    uint32  = 0
+	DPE_SIMULATOR_OTHER_LOCALITY        uint32  = 0x4f544852
+	DPE_SIMULATOR_PROFILE               Profile = ProfileP256SHA256
+	DPE_SIMULATOR_MAX_TCI_NODES         uint32  = 24
+	DPE_SIMULATOR_MAJOR_PROFILE_VERSION uint16  = CURRENT_PROFILE_MAJOR_VERSION
+	DPE_SIMULATOR_MINOR_PROFILE_VERSION uint16  = CURRENT_PROFILE_MINOR_VERSION
+	DPE_SIMULATOR_VENDOR_ID             uint32  = 0
+	DPE_SIMULATOR_VENDOR_SKU            uint32  = 0
 )
 
 type DpeSimulator struct {
@@ -168,6 +171,18 @@ func (s *DpeSimulator) GetMaxTciNodes() uint32 {
 	return DPE_SIMULATOR_MAX_TCI_NODES
 }
 
-func (s *DpeSimulator) GetProfileVersion() uint32 {
-	return DPE_SIMULATOR_PROFILE_VERSION
+func (s *DpeSimulator) GetProfileMajorVersion() uint16 {
+	return DPE_SIMULATOR_MAJOR_PROFILE_VERSION
+}
+
+func (s *DpeSimulator) GetProfileMinorVersion() uint16 {
+	return DPE_SIMULATOR_MINOR_PROFILE_VERSION
+}
+
+func (s *DpeSimulator) GetProfileVendorId() uint32 {
+	return DPE_SIMULATOR_VENDOR_ID
+}
+
+func (s *DpeSimulator) GetProfileVendorSku() uint32 {
+	return DPE_SIMULATOR_VENDOR_SKU
 }

--- a/verification/verification_test.go
+++ b/verification/verification_test.go
@@ -36,8 +36,14 @@ type TestDPEInstance interface {
 	GetLocality() uint32
 	// Returns the Maximum number of the TCIs instance can have.
 	GetMaxTciNodes() uint32
-	// Returns the version of the profile the instance implements.
-	GetProfileVersion() uint32
+	// Returns the major version of the profile the instance implements.
+	GetProfileMajorVersion() uint16
+	// Returns the minor version of the profile the instance implements.
+	GetProfileMinorVersion() uint16
+	// Returns the Vendor ID of the profile.
+	GetProfileVendorId() uint32
+	// Returns the vendor's product SKU.
+	GetProfileVendorSku() uint32
 }
 
 func TestGetProfile(t *testing.T) {
@@ -93,8 +99,17 @@ func testGetProfile(d TestDPEInstance, t *testing.T) {
 		if rsp.Profile != d.GetProfile() {
 			t.Fatalf("Incorrect profile. 0x%08x != 0x%08x", d.GetProfile(), rsp.Profile)
 		}
-		if rsp.Version != d.GetProfileVersion() {
-			t.Fatalf("Incorrect version. 0x%08x != 0x%08x", d.GetProfileVersion(), rsp.Version)
+		if rsp.MajorVersion != d.GetProfileMajorVersion() {
+			t.Fatalf("Incorrect version. 0x%08x != 0x%08x", d.GetProfileMajorVersion(), rsp.MajorVersion)
+		}
+		if rsp.MinorVersion != d.GetProfileMinorVersion() {
+			t.Fatalf("Incorrect version. 0x%08x != 0x%08x", d.GetProfileMinorVersion(), rsp.MinorVersion)
+		}
+		if rsp.VendorId != d.GetProfileVendorId() {
+			t.Fatalf("Incorrect version. 0x%08x != 0x%08x", d.GetProfileVendorId(), rsp.VendorId)
+		}
+		if rsp.VendorSku != d.GetProfileVendorSku() {
+			t.Fatalf("Incorrect version. 0x%08x != 0x%08x", d.GetProfileVendorSku(), rsp.VendorSku)
 		}
 		if rsp.MaxTciNodes != d.GetMaxTciNodes() {
 			t.Fatalf("Incorrect max TCI nodes. 0x%08x != 0x%08x", d.GetMaxTciNodes(), rsp.MaxTciNodes)


### PR DESCRIPTION
A few new fields have been added to the `GetProfile` command. This adds those fields and updates all of the tests to match. This does not add the new support flags.