### PR TITLE
Use `zerocopy` crate for de-serializing. 

### DIFF
--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -10,10 +10,10 @@ dpe_profile_p384_sha384 = []
 
 [dependencies]
 crypto = {path = "../crypto"}
+zerocopy = "0.6.1"
 
 [dev-dependencies]
 asn1 = "0.13.0"
-zerocopy = "0.6.1"
 openssl = "0.10"
 x509-parser = "0.14.0"
 crypto = {path = "../crypto", features = ["deterministic_rand"]}

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -6,12 +6,11 @@ use crate::{
     response::{DpeErrorCode, Response},
     MAX_HANDLES,
 };
-use core::mem::size_of;
 use crypto::Crypto;
 
 #[repr(C)]
-#[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(test, derive(zerocopy::AsBytes, zerocopy::FromBytes))]
+#[derive(Debug, PartialEq, Eq, zerocopy::FromBytes)]
+#[cfg_attr(test, derive(zerocopy::AsBytes))]
 pub struct DestroyCtxCmd {
     pub handle: ContextHandle,
     pub flags: u32,
@@ -22,24 +21,6 @@ impl DestroyCtxCmd {
 
     const fn flag_is_destroy_descendants(&self) -> bool {
         self.flags & Self::DESTROY_CHILDREN_FLAG_MASK != 0
-    }
-}
-
-impl TryFrom<&[u8]> for DestroyCtxCmd {
-    type Error = DpeErrorCode;
-
-    fn try_from(raw: &[u8]) -> Result<Self, Self::Error> {
-        if raw.len() < size_of::<DestroyCtxCmd>() {
-            return Err(DpeErrorCode::InvalidArgument);
-        }
-
-        let handle = ContextHandle::try_from(raw)?;
-
-        let raw = &raw[ContextHandle::SIZE..];
-        Ok(DestroyCtxCmd {
-            handle,
-            flags: u32::from_le_bytes(raw[0..4].try_into().unwrap()),
-        })
     }
 }
 
@@ -74,21 +55,12 @@ mod tests {
         commands::{Command, CommandHdr},
         dpe_instance::tests::SIMULATION_HANDLE,
     };
-    use zerocopy::{AsBytes, FromBytes};
+    use zerocopy::AsBytes;
 
     const TEST_DESTROY_CTX_CMD: DestroyCtxCmd = DestroyCtxCmd {
         handle: SIMULATION_HANDLE,
         flags: 0x1234_5678,
     };
-
-    #[test]
-    fn try_from_destroy_ctx() {
-        let command_bytes = TEST_DESTROY_CTX_CMD.as_bytes();
-        assert_eq!(
-            DestroyCtxCmd::read_from_prefix(command_bytes).unwrap(),
-            DestroyCtxCmd::try_from(command_bytes).unwrap(),
-        );
-    }
 
     #[test]
     fn test_deserialize_destroy_context() {
@@ -99,23 +71,6 @@ mod tests {
         assert_eq!(
             Ok(Command::DestroyCtx(TEST_DESTROY_CTX_CMD)),
             Command::deserialize(&command)
-        );
-    }
-
-    #[test]
-    fn test_slice_to_destroy_ctx() {
-        let invalid_argument: Result<DestroyCtxCmd, DpeErrorCode> =
-            Err(DpeErrorCode::InvalidArgument);
-
-        // Test if too small.
-        assert_eq!(
-            invalid_argument,
-            DestroyCtxCmd::try_from([0u8; size_of::<DestroyCtxCmd>() - 1].as_slice())
-        );
-
-        assert_eq!(
-            TEST_DESTROY_CTX_CMD,
-            DestroyCtxCmd::try_from(TEST_DESTROY_CTX_CMD.as_bytes()).unwrap()
         );
     }
 }

--- a/dpe/src/commands/get_tagged_tci.rs
+++ b/dpe/src/commands/get_tagged_tci.rs
@@ -4,28 +4,13 @@ use crate::{
     dpe_instance::DpeInstance,
     response::{DpeErrorCode, GetTaggedTciResp, Response},
 };
-use core::mem::size_of;
 use crypto::Crypto;
 
 #[repr(C)]
-#[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(test, derive(zerocopy::AsBytes, zerocopy::FromBytes))]
+#[derive(Debug, PartialEq, Eq, zerocopy::FromBytes)]
+#[cfg_attr(test, derive(zerocopy::AsBytes))]
 pub struct GetTaggedTciCmd {
     tag: u32,
-}
-
-impl TryFrom<&[u8]> for GetTaggedTciCmd {
-    type Error = DpeErrorCode;
-
-    fn try_from(raw: &[u8]) -> Result<Self, Self::Error> {
-        if raw.len() < size_of::<GetTaggedTciCmd>() {
-            return Err(DpeErrorCode::InvalidArgument);
-        }
-
-        Ok(GetTaggedTciCmd {
-            tag: u32::from_le_bytes(raw[0..4].try_into().unwrap()),
-        })
-    }
 }
 
 impl<C: Crypto> CommandExecution<C> for GetTaggedTciCmd {

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -5,12 +5,11 @@ use crate::{
     dpe_instance::DpeInstance,
     response::{DpeErrorCode, NewHandleResp, Response},
 };
-use core::mem::size_of;
 use crypto::Crypto;
 
 #[repr(C)]
-#[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(test, derive(zerocopy::AsBytes, zerocopy::FromBytes))]
+#[derive(Debug, PartialEq, Eq, zerocopy::FromBytes)]
+#[cfg_attr(test, derive(zerocopy::AsBytes))]
 pub struct RotateCtxCmd {
     handle: ContextHandle,
     flags: u32,
@@ -22,25 +21,6 @@ impl RotateCtxCmd {
 
     const fn uses_target_is_default(&self) -> bool {
         self.flags & Self::TARGET_IS_DEFAULT != 0
-    }
-}
-
-impl TryFrom<&[u8]> for RotateCtxCmd {
-    type Error = DpeErrorCode;
-
-    fn try_from(raw: &[u8]) -> Result<Self, Self::Error> {
-        if raw.len() < size_of::<RotateCtxCmd>() {
-            return Err(DpeErrorCode::InvalidArgument);
-        }
-
-        let handle = ContextHandle::try_from(raw)?;
-
-        let raw = &raw[ContextHandle::SIZE..];
-        Ok(RotateCtxCmd {
-            handle,
-            flags: u32::from_le_bytes(raw[0..4].try_into().unwrap()),
-            target_locality: u32::from_le_bytes(raw[4..8].try_into().unwrap()),
-        })
     }
 }
 
@@ -86,22 +66,13 @@ mod tests {
         support::Support,
     };
     use crypto::OpensslCrypto;
-    use zerocopy::{AsBytes, FromBytes};
+    use zerocopy::AsBytes;
 
     const TEST_ROTATE_CTX_CMD: RotateCtxCmd = RotateCtxCmd {
         flags: 0x1234_5678,
         handle: TEST_HANDLE,
         target_locality: 0x9876_5432,
     };
-
-    #[test]
-    fn try_from_rotate_ctx() {
-        let command_bytes = TEST_ROTATE_CTX_CMD.as_bytes();
-        assert_eq!(
-            RotateCtxCmd::read_from_prefix(command_bytes).unwrap(),
-            RotateCtxCmd::try_from(command_bytes).unwrap(),
-        );
-    }
 
     #[test]
     fn test_deserialize_rotate_context() {
@@ -112,23 +83,6 @@ mod tests {
         assert_eq!(
             Ok(Command::RotateCtx(TEST_ROTATE_CTX_CMD)),
             Command::deserialize(&command)
-        );
-    }
-
-    #[test]
-    fn test_slice_to_rotate_ctx() {
-        let invalid_argument: Result<RotateCtxCmd, DpeErrorCode> =
-            Err(DpeErrorCode::InvalidArgument);
-
-        // Test if too small.
-        assert_eq!(
-            invalid_argument,
-            RotateCtxCmd::try_from([0u8; size_of::<RotateCtxCmd>() - 1].as_slice())
-        );
-
-        assert_eq!(
-            TEST_ROTATE_CTX_CMD,
-            RotateCtxCmd::try_from(TEST_ROTATE_CTX_CMD.as_bytes()).unwrap()
         );
     }
 

--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -76,8 +76,7 @@ impl Context {
 }
 
 #[repr(C)]
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(test, derive(zerocopy::AsBytes, zerocopy::FromBytes))]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, zerocopy::AsBytes, zerocopy::FromBytes)]
 pub struct ContextHandle(pub [u8; ContextHandle::SIZE]);
 
 impl ContextHandle {

--- a/simulator/Cargo.lock
+++ b/simulator/Cargo.lock
@@ -24,6 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +101,7 @@ name = "dpe"
 version = "0.1.0"
 dependencies = [
  "crypto",
+ "zerocopy",
 ]
 
 [[package]]
@@ -548,3 +555,24 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "zerocopy"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332f188cc1bcf1fe1064b8c58d150f497e697f49774aa846f2dc949d9a25f236"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6505e6815af7de1746a08f69c69606bb45695a17149517680f3b2149713b19a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]


### PR DESCRIPTION
Changes to use crate instead of manually de-serializing structs.