### PR TITLE
Fail RotateContext if caller's locality already has default context

### DIFF
--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -67,6 +67,7 @@ impl<C: Crypto> CommandExecution<C> for RotateCtxCmd {
             }
         }
 
+        let new_handle = dpe.generate_new_handle()?;
         dpe.contexts[idx].handle = new_handle;
         Ok(Response::RotateCtx(NewHandleResp { handle: new_handle }))
     }

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -55,7 +55,7 @@ impl<C: Crypto> CommandExecution<C> for RotateCtxCmd {
 
         // Make sure the command is coming from the right locality.
         if dpe.contexts[idx].locality != locality {
-            return Err(DpeErrorCode::InvalidLocality);
+            return Err(DpeErrorCode::InvalidHandle);
         }
         
         // Make sure caller's locality does not already have a default context.
@@ -67,7 +67,6 @@ impl<C: Crypto> CommandExecution<C> for RotateCtxCmd {
             }
         }
 
-        let new_handle = dpe.generate_new_handle()?;
         dpe.contexts[idx].handle = new_handle;
         Ok(Response::RotateCtx(NewHandleResp { handle: new_handle }))
     }
@@ -170,7 +169,7 @@ mod tests {
 
         // Wrong locality.
         assert_eq!(
-            Err(DpeErrorCode::InvalidLocality),
+            Err(DpeErrorCode::InvalidHandle),
             RotateCtxCmd {
                 handle: ContextHandle::default(),
                 flags: 0,

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -17,6 +17,14 @@ pub struct RotateCtxCmd {
     target_locality: u32,
 }
 
+impl RotateCtxCmd {
+    pub const TARGET_IS_DEFAULT: u32 = 1 << 31;
+    
+    const fn uses_target_is_default(&self) -> bool {
+        self.flags & Self::TARGET_IS_DEFAULT != 0
+    }
+}
+
 impl TryFrom<&[u8]> for RotateCtxCmd {
     type Error = DpeErrorCode;
 
@@ -37,12 +45,6 @@ impl TryFrom<&[u8]> for RotateCtxCmd {
 }
 
 impl<C: Crypto> CommandExecution<C> for RotateCtxCmd {
-    pub const TARGET_IS_DEFAULT: u32 = 1 << 31;
-    
-    const fn uses_target_is_default(&self) -> bool {
-        self.flags & Self::TARGET_IS_DEFAULT != 0
-    }
-    
     fn execute(&self, dpe: &mut DpeInstance<C>, locality: u32) -> Result<Response, DpeErrorCode> {
         if !dpe.support.rotate_context {
             return Err(DpeErrorCode::InvalidCommand);
@@ -182,7 +184,7 @@ mod tests {
             Err(DpeErrorCode::InvalidArgument),
             RotateCtxCmd {
                 handle: ContextHandle::default(),
-                flags: 0,
+                flags: RotateCtxCmd::TARGET_IS_DEFAULT,
                 target_locality: 0
             }
             .execute(&mut dpe, TEST_LOCALITIES[0])

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -19,7 +19,7 @@ pub struct RotateCtxCmd {
 
 impl RotateCtxCmd {
     pub const TARGET_IS_DEFAULT: u32 = 1 << 31;
-    
+
     const fn uses_target_is_default(&self) -> bool {
         self.flags & Self::TARGET_IS_DEFAULT != 0
     }
@@ -57,13 +57,13 @@ impl<C: Crypto> CommandExecution<C> for RotateCtxCmd {
         if dpe.contexts[idx].locality != locality {
             return Err(DpeErrorCode::InvalidHandle);
         }
-        
+
         // Make sure caller's locality does not already have a default context.
         if self.uses_target_is_default() {
             let default_context_idx =
                 dpe.get_active_context_pos(&ContextHandle::default(), locality);
             if default_context_idx.is_some() {
-                return Err(DpeErrorCode::InvalidArgument);   
+                return Err(DpeErrorCode::InvalidArgument);
             }
         }
 
@@ -178,7 +178,7 @@ mod tests {
             }
             .execute(&mut dpe, TEST_LOCALITIES[1])
         );
-        
+
         // Caller's locality already has default context.
         assert_eq!(
             Err(DpeErrorCode::InvalidArgument),


### PR DESCRIPTION
See issue https://github.com/chipsalliance/caliptra-dpe/issues/38 for more details.