### PR TITLE
Make new handle the default handle if TARGET_IS_DEFAULT is set in Rot…

### DIFF
--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -213,7 +213,7 @@ mod tests {
                 handle: ContextHandle::default()
             })),
             RotateCtxCmd {
-                handle: ContextHandle::default(),
+                handle: SIMULATION_HANDLE,
                 flags: RotateCtxCmd::TARGET_IS_DEFAULT,
                 target_locality: 0
             }

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -206,7 +206,7 @@ mod tests {
             }
             .execute(&mut dpe, TEST_LOCALITIES[0])
         );
-        
+
         // New handle is all 0s if caller requests default handle
         assert_eq!(
             Ok(Response::RotateCtx(NewHandleResp {


### PR DESCRIPTION
…ateContext

Currently, we always generate a random new handle in rotate context, but new handle should be a buffer of 0s if the TARGET_IS_DEFAULT flag is set.