### PR TITLE
Add base struct to simplify Crypto library.

### DIFF
--- a/crypto/Cargo.lock
+++ b/crypto/Cargo.lock
@@ -32,6 +32,8 @@ version = "0.1.0"
 dependencies = [
  "openssl",
  "openssl-kdf",
+ "strum",
+ "strum_macros",
 ]
 
 [[package]]
@@ -48,6 +50,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "libc"
@@ -136,6 +144,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -10,3 +10,7 @@ deterministic_rand = ["openssl"]
 [dependencies]
 openssl = {version = "0.10", optional = true}
 openssl-kdf = {version = "0.4.1", optional = true}
+
+[dev-dependencies]
+strum = "0.24"
+strum_macros = "0.24"

--- a/crypto/src/signer.rs
+++ b/crypto/src/signer.rs
@@ -1,0 +1,87 @@
+// Licensed under the Apache-2.0 license
+
+use crate::{AlgLen, CryptoError};
+
+/// An ECDSA signature
+pub struct EcdsaSig {
+    pub r: CryptoBuf,
+    pub s: CryptoBuf,
+}
+
+impl EcdsaSig {
+    pub fn default(alg: AlgLen) -> EcdsaSig {
+        EcdsaSig {
+            r: CryptoBuf::default(alg),
+            s: CryptoBuf::default(alg),
+        }
+    }
+}
+
+/// An ECDSA public key
+pub struct EcdsaPub {
+    pub x: CryptoBuf,
+    pub y: CryptoBuf,
+}
+
+impl EcdsaPub {
+    pub fn default(alg: AlgLen) -> EcdsaPub {
+        EcdsaPub {
+            x: CryptoBuf::default(alg),
+            y: CryptoBuf::default(alg),
+        }
+    }
+}
+
+/// An HMAC Signature
+pub type HmacSig = CryptoBuf;
+
+/// An HMAC Key
+pub type HmacKey = CryptoBuf;
+
+/// A common base struct that can be used for all digests, signatures, and keys.
+pub struct CryptoBuf {
+    pub(crate) bytes: [u8; Self::MAX_SIZE],
+    pub(crate) len: usize,
+}
+
+impl CryptoBuf {
+    pub const MAX_SIZE: usize = AlgLen::MAX_ALG_LEN_BYTES;
+
+    pub fn new(bytes: &[u8], alg: AlgLen) -> Result<CryptoBuf, CryptoError> {
+        if bytes.len() < alg.size() {
+            return Err(CryptoError::Size);
+        }
+
+        let mut copied_bytes = [0; Self::MAX_SIZE];
+        copied_bytes[..alg.size()].copy_from_slice(&bytes[..alg.size()]);
+        Ok(CryptoBuf {
+            bytes: copied_bytes,
+            len: alg.size(),
+        })
+    }
+
+    pub fn default(alg: AlgLen) -> CryptoBuf {
+        CryptoBuf {
+            bytes: [0; Self::MAX_SIZE],
+            len: alg.size(),
+        }
+    }
+
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes[..self.len]
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+}
+
+impl AsRef<[u8]> for CryptoBuf {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes()
+    }
+}


### PR DESCRIPTION
This adds a base struct for handling all crypto objects (digests, keys, signatures). This simplifies the `Crypto` API and removes some of the arguments that could be easy to mix up. This new struct will help streamline changes needed for symmetric signing.