### PR TITLE
Add Non-deterministic key derivation mode

### DIFF
--- a/crypto/src/signer.rs
+++ b/crypto/src/signer.rs
@@ -32,6 +32,8 @@ impl EcdsaPub {
     }
 }
 
+pub type EcdsaPriv = CryptoBuf;
+
 /// An HMAC Signature
 pub type HmacSig = CryptoBuf;
 
@@ -39,6 +41,7 @@ pub type HmacSig = CryptoBuf;
 pub type HmacKey = CryptoBuf;
 
 /// A common base struct that can be used for all digests, signatures, and keys.
+#[derive(Debug, PartialEq)]
 pub struct CryptoBuf {
     pub(crate) bytes: [u8; Self::MAX_SIZE],
     pub(crate) len: usize,

--- a/dpe/src/commands/extend_tci.rs
+++ b/dpe/src/commands/extend_tci.rs
@@ -28,6 +28,9 @@ impl<C: Crypto> CommandExecution<C> for ExtendTciCmd {
             .ok_or(DpeErrorCode::InvalidHandle)?;
         let context = &mut dpe.contexts[idx];
 
+        // invalidate cached private key
+        context.cached_priv_key = None;
+
         // Make sure the command is coming from the right locality.
         if context.locality != locality {
             return Err(DpeErrorCode::InvalidHandle);
@@ -123,6 +126,8 @@ mod tests {
         assert_eq!(handle, default_context.handle);
         // Make sure the current TCI was updated correctly.
         assert_eq!(data, default_context.tci.tci_current.0);
+        // Make sure cached private key is invalidated
+        assert_eq!(None, default_context.cached_priv_key);
 
         let sim_local = TEST_LOCALITIES[1];
         dpe.support.simulation = true;

--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -1,6 +1,7 @@
 // Licensed under the Apache-2.0 license.
 use crate::{response::DpeErrorCode, tci::TciNodeData, MAX_HANDLES};
 use core::mem::size_of;
+use crypto::EcdsaPriv;
 
 #[repr(C, align(4))]
 pub(crate) struct Context {
@@ -18,6 +19,8 @@ pub(crate) struct Context {
     pub has_tag: bool,
     /// Optional tag assigned to the context.
     pub tag: u32,
+    /// Private key which is cached only in non-deterministic key derivation mode
+    pub cached_priv_key: Option<EcdsaPriv>,
 }
 
 impl Context {
@@ -34,6 +37,7 @@ impl Context {
             locality: 0,
             has_tag: false,
             tag: 0,
+            cached_priv_key: None,
         }
     }
 
@@ -63,6 +67,7 @@ impl Context {
         self.has_tag = false;
         self.tag = 0;
         self.state = ContextState::Inactive;
+        self.cached_priv_key = None;
     }
 
     /// Add a child to list of children in the context.

--- a/dpe/src/support.rs
+++ b/dpe/src/support.rs
@@ -9,6 +9,8 @@ pub struct Support {
     pub rotate_context: bool,
     pub certify_key: bool,
     pub certify_csr: bool,
+    pub is_symmetric: bool,
+    pub nd_derivation: bool,
     pub internal_info: bool,
     pub internal_dice: bool,
 }
@@ -24,6 +26,8 @@ impl Support {
             | self.get_rotate_context_flag()
             | self.get_certify_key_flag()
             | self.get_certify_csr_flag()
+            | self.get_is_symmetric_flag()
+            | self.get_nd_derivation_flag()
             | self.get_internal_info_flag()
             | self.get_internal_dice_flag()
     }
@@ -48,11 +52,17 @@ impl Support {
     fn get_certify_csr_flag(&self) -> u32 {
         u32::from(self.certify_csr) << 25
     }
+    fn get_is_symmetric_flag(&self) -> u32 {
+        u32::from(self.is_symmetric) << 24
+    }
+    fn get_nd_derivation_flag(&self) -> u32 {
+        u32::from(self.nd_derivation) << 23
+    }
     fn get_internal_info_flag(&self) -> u32 {
-        u32::from(self.internal_info) << 24
+        u32::from(self.internal_info) << 22
     }
     fn get_internal_dice_flag(&self) -> u32 {
-        u32::from(self.internal_dice) << 23
+        u32::from(self.internal_dice) << 21
     }
 }
 
@@ -68,6 +78,8 @@ pub mod test {
         rotate_context: true,
         certify_key: true,
         certify_csr: false,
+        is_symmetric: false,
+        nd_derivation: false,
         internal_info: false,
         internal_dice: false,
     };
@@ -123,43 +135,62 @@ pub mod test {
         }
         .get_flags();
         assert_eq!(flags, 1 << 25);
+        // Supports is symmetric.
+        let flags = Support {
+            is_symmetric: true,
+            ..Support::default()
+        }
+        .get_flags();
+        assert_eq!(flags, 1 << 24);
+        // Supports nd derivation.
+        let flags = Support {
+            nd_derivation: true,
+            ..Support::default()
+        }
+        .get_flags();
+        assert_eq!(flags, 1 << 23);
         // Supports internal info.
         let flags = Support {
             internal_info: true,
             ..Support::default()
         }
         .get_flags();
-        assert_eq!(flags, 1 << 24);
+        assert_eq!(flags, 1 << 22);
         // Supports internal DICE.
         let flags = Support {
             internal_dice: true,
             ..Support::default()
         }
         .get_flags();
-        assert_eq!(flags, 1 << 23);
+        assert_eq!(flags, 1 << 21);
         // Supports a couple combos.
         let flags = Support {
             simulation: true,
             auto_init: true,
             rotate_context: true,
             certify_csr: true,
+            nd_derivation: true,
             internal_dice: true,
             ..Support::default()
         }
         .get_flags();
         assert_eq!(
             flags,
-            (1 << 31) | (1 << 29) | (1 << 27) | (1 << 25) | (1 << 23)
+            (1 << 31) | (1 << 29) | (1 << 27) | (1 << 25) | (1 << 23) | (1 << 21)
         );
         let flags = Support {
             extend_tci: true,
             tagging: true,
             certify_key: true,
+            is_symmetric: true,
             internal_info: true,
             ..Support::default()
         }
         .get_flags();
-        assert_eq!(flags, (1 << 30) | (1 << 28) | (1 << 26) | (1 << 24));
+        assert_eq!(
+            flags,
+            (1 << 30) | (1 << 28) | (1 << 26) | (1 << 24) | (1 << 22)
+        );
         // Supports everything.
         let flags = Support {
             simulation: true,
@@ -169,6 +200,8 @@ pub mod test {
             rotate_context: true,
             certify_key: true,
             certify_csr: true,
+            is_symmetric: true,
+            nd_derivation: true,
             internal_info: true,
             internal_dice: true,
         }
@@ -184,6 +217,8 @@ pub mod test {
                 | (1 << 25)
                 | (1 << 24)
                 | (1 << 23)
+                | (1 << 22)
+                | (1 << 21)
         );
     }
 }

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -79,6 +79,14 @@ struct Args {
     #[arg(long)]
     supports_certify_csr: bool,
 
+    /// Supports symmetric derivation.
+    #[arg(long)]
+    supports_is_symmetric: bool,
+
+    /// Supports non-deterministic key derivation.
+    #[arg(long)]
+    supports_nd_derivation: bool,
+
     /// Supports the INTERNAL_INPUT_INFO extension to DeriveChild
     #[arg(long)]
     supports_internal_info: bool,
@@ -118,6 +126,8 @@ fn main() -> std::io::Result<()> {
         rotate_context: args.supports_rotate_context,
         certify_key: args.supports_certify_key,
         certify_csr: args.supports_certify_csr,
+        is_symmetric: args.supports_is_symmetric,
+        nd_derivation: args.supports_nd_derivation,
         internal_info: args.supports_internal_info,
         internal_dice: args.supports_internal_dice,
     };

--- a/verification/client.go
+++ b/verification/client.go
@@ -12,6 +12,8 @@ type Support struct {
 	RotateContext bool
 	CertifyKey    bool
 	CertifyCsr    bool
+	IsSymmetric   bool
+	NDDerivation  bool
 	InternalInfo  bool
 	InternalDice  bool
 }
@@ -235,11 +237,17 @@ func (s *Support) ToFlags() uint32 {
 	if s.CertifyCsr {
 		flags |= (1 << 25)
 	}
-	if s.InternalInfo {
+	if s.IsSymmetric {
 		flags |= (1 << 24)
 	}
-	if s.InternalDice {
+	if s.NDDerivation {
 		flags |= (1 << 23)
+	}
+	if s.InternalInfo {
+		flags |= (1 << 22)
+	}
+	if s.InternalDice {
+		flags |= (1 << 21)
 	}
 	return flags
 }

--- a/verification/simulator.go
+++ b/verification/simulator.go
@@ -62,6 +62,12 @@ func (s *DpeSimulator) PowerOn() error {
 	if s.supports.CertifyCsr {
 		args = append(args, "--supports-certify-csr")
 	}
+	if s.supports.IsSymmetric {
+		args = append(args, "--supports-is-symmetric")
+	}
+	if s.supports.NDDerivation {
+		args = append(args, "--supports-nd-derivation")
+	}
 	if s.supports.InternalInfo {
 		args = append(args, "--supports-internal-info")
 	}

--- a/verification/verification_test.go
+++ b/verification/verification_test.go
@@ -66,15 +66,23 @@ func TestGetProfile(t *testing.T) {
 		&DpeSimulator{exe_path: *sim_exe, supports: Support{Tagging: true}},
 		// Supports rotate context.
 		&DpeSimulator{exe_path: *sim_exe, supports: Support{RotateContext: true}},
+		// Supports certify key.
 		&DpeSimulator{exe_path: *sim_exe, supports: Support{CertifyKey: true}},
+		// Supports certify csr.
 		&DpeSimulator{exe_path: *sim_exe, supports: Support{CertifyCsr: true}},
+		// Supports symmetric derivation.
+		&DpeSimulator{exe_path: *sim_exe, supports: Support{IsSymmetric: true}},
+		// Supports non-deterministic key derivation.
+		&DpeSimulator{exe_path: *sim_exe, supports: Support{NDDerivation: true}},
+		// Supports internal info.
 		&DpeSimulator{exe_path: *sim_exe, supports: Support{InternalInfo: true}},
+		// Supports internal DICE.
 		&DpeSimulator{exe_path: *sim_exe, supports: Support{InternalDice: true}},
 		// Supports a couple combos.
 		&DpeSimulator{exe_path: *sim_exe, supports: Support{Simulation: true, AutoInit: true, RotateContext: true, CertifyCsr: true, InternalDice: true}},
 		&DpeSimulator{exe_path: *sim_exe, supports: Support{ExtendTci: true, Tagging: true, CertifyKey: true, InternalInfo: true}},
 		// Supports everything.
-		&DpeSimulator{exe_path: *sim_exe, supports: Support{Simulation: true, ExtendTci: true, AutoInit: true, Tagging: true, RotateContext: true, CertifyKey: true, CertifyCsr: true, InternalInfo: true, InternalDice: true}},
+		&DpeSimulator{exe_path: *sim_exe, supports: Support{Simulation: true, ExtendTci: true, AutoInit: true, Tagging: true, RotateContext: true, CertifyKey: true, CertifyCsr: true, IsSymmetric: true, NDDerivation: true, InternalInfo: true, InternalDice: true}},
 	}
 
 	for _, s := range simulators {


### PR DESCRIPTION
This commit introduces non-deterministic key derivation mode. See more details about the specification here -
https://github.com/TrustedComputingGroup/Server-Internal/blob/main/dpe-irot-profile/main.md#non-deterministic-mode-key-derivation.