### PR TITLE
Introduce symmetric key derivation in sign

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -136,14 +136,16 @@ pub trait Crypto {
         rand_seed: Option<&[u8]>,
     ) -> Result<Self::Cdi, CryptoError>;
 
-    /// Derives a private key using the cdi
+    /// Derives a private key using a cryptographically secure KDF
     ///
     /// # Arguments
     ///
     /// * `algs` - Which length of algorithms to use.
     /// * `cdi` - Caller-supplied private key to use in public key derivation
+    /// * `label` - Caller-supplied label to use in asymmetric key derivation
+    /// * `info` - Caller-supplied info string to use in asymmetric key derivation
     ///
-    fn derive_ecdsa_key(algs: AlgLen, cdi: &Self::Cdi, label: &[u8], info: &[u8]) -> EcdsaPriv;
+    fn derive_private_key(algs: AlgLen, cdi: &Self::Cdi, label: &[u8], info: &[u8]) -> PrivKey;
 
     /// Derives and returns an ECDSA public key using the caller-supplied private key
     ///
@@ -152,7 +154,7 @@ pub trait Crypto {
     /// * `algs` - Which length of algorithms to use.
     /// * `priv_key` - Caller-supplied private key to use in public key derivation
     /// Returns a derived public key
-    fn derive_ecdsa_pub(algs: AlgLen, priv_key: &EcdsaPriv) -> Result<EcdsaPub, CryptoError>;
+    fn derive_ecdsa_pub(algs: AlgLen, priv_key: &PrivKey) -> Result<EcdsaPub, CryptoError>;
 
     /// Sign `digest` with the platform Alias Key
     ///
@@ -172,7 +174,7 @@ pub trait Crypto {
     fn ecdsa_sign_with_derived(
         algs: AlgLen,
         digest: &Digest,
-        priv_key: &EcdsaPriv,
+        priv_key: &PrivKey,
     ) -> Result<EcdsaSig, CryptoError>;
 
     /// Compute the serial number string for the alias public key
@@ -182,6 +184,23 @@ pub trait Crypto {
     /// * `algs` - Length of algorithm to use.
     /// * `serial` - Output buffer to write serial number
     fn get_ecdsa_alias_serial(algs: AlgLen, serial: &mut [u8]) -> Result<(), CryptoError>;
+
+    /// Sign `digest` with a derived HMAC key from the CDI.
+    ///
+    /// # Arguments
+    ///
+    /// * `algs` - Which length of algorithms to use.
+    /// * `cdi` - CDI from which to derive the signing key
+    /// * `label` - Caller-supplied label to use in symmetric key derivation
+    /// * `info` - Caller-supplied info string to use in symmetric key derivation
+    /// * `digest` - Digest of data to be signed.
+    fn hmac_sign_with_derived(
+        algs: AlgLen,
+        cdi: &Self::Cdi,
+        label: &[u8],
+        info: &[u8],
+        digest: &Digest,
+    ) -> Result<HmacSig, CryptoError>;
 }
 
 /// Writer for a static buffer

--- a/crypto/src/signer.rs
+++ b/crypto/src/signer.rs
@@ -32,13 +32,10 @@ impl EcdsaPub {
     }
 }
 
-pub type EcdsaPriv = CryptoBuf;
+pub type PrivKey = CryptoBuf;
 
 /// An HMAC Signature
 pub type HmacSig = CryptoBuf;
-
-/// An HMAC Key
-pub type HmacKey = CryptoBuf;
 
 /// A common base struct that can be used for all digests, signatures, and keys.
 #[derive(Debug, PartialEq)]

--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -49,7 +49,7 @@ impl<C: Crypto> CommandExecution<C> for CertifyKeyCmd {
         let priv_key = if self.uses_nd_derivation() {
             dpe.contexts[idx].cached_priv_key.take().unwrap_or_else({
                 || {
-                    C::derive_ecdsa_key(
+                    C::derive_private_key(
                         algs,
                         &dpe.derive_cdi(idx, true).unwrap(),
                         &self.label,
@@ -59,7 +59,7 @@ impl<C: Crypto> CommandExecution<C> for CertifyKeyCmd {
             })
         } else {
             let cdi = dpe.derive_cdi(idx, false)?;
-            C::derive_ecdsa_key(algs, &cdi, &self.label, b"ECC")
+            C::derive_private_key(algs, &cdi, &self.label, b"ECC")
         };
 
         let pub_key = C::derive_ecdsa_pub(DPE_PROFILE.alg_len(), &priv_key)

--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license.
 use crate::{response::DpeErrorCode, tci::TciNodeData, MAX_HANDLES};
 use core::mem::size_of;
-use crypto::EcdsaPriv;
+use crypto::PrivKey;
 
 #[repr(C, align(4))]
 pub(crate) struct Context {
@@ -20,7 +20,7 @@ pub(crate) struct Context {
     /// Optional tag assigned to the context.
     pub tag: u32,
     /// Private key which is cached only in non-deterministic key derivation mode
-    pub cached_priv_key: Option<EcdsaPriv>,
+    pub cached_priv_key: Option<PrivKey>,
 }
 
 impl Context {


### PR DESCRIPTION
If the is_symmetric flag is set, we derive a symmetric key and use it for signing.