### PR TITLE
Add (de)serialization for certify csr command

### DIFF
--- a/dpe/src/commands/certify_csr.rs
+++ b/dpe/src/commands/certify_csr.rs
@@ -1,0 +1,135 @@
+// Licensed under the Apache-2.0 license.
+use super::CommandExecution;
+use crate::{
+    context::ContextHandle,
+    dpe_instance::DpeInstance,
+    response::{DpeErrorCode, Response},
+    DPE_PROFILE,
+};
+use crypto::Crypto;
+
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq, zerocopy::FromBytes)]
+#[cfg_attr(test, derive(zerocopy::AsBytes))]
+pub struct CertifyCsrCmd {
+    pub handle: ContextHandle,
+    pub flags: u32,
+    pub label: [u8; DPE_PROFILE.get_hash_size()],
+}
+
+impl CertifyCsrCmd {
+    pub const ND_DERIVATION: u32 = 1 << 31;
+
+    // Uses non-deterministic derivation.
+    const fn uses_nd_derivation(&self) -> bool {
+        self.flags & Self::ND_DERIVATION != 0
+    }
+}
+
+impl<C: Crypto> CommandExecution<C> for CertifyCsrCmd {
+    fn execute(&self, dpe: &mut DpeInstance<C>, locality: u32) -> Result<Response, DpeErrorCode> {
+        // Make sure the operation is supported.
+        if !dpe.support.nd_derivation && self.uses_nd_derivation() {
+            return Err(DpeErrorCode::InvalidArgument);
+        }
+
+        let idx = dpe
+            .get_active_context_pos(&self.handle, locality)
+            .ok_or(DpeErrorCode::InvalidHandle)?;
+        let context = &dpe.contexts[idx];
+
+        // Make sure the command is coming from the right locality.
+        if context.locality != locality {
+            return Err(DpeErrorCode::InvalidHandle);
+        }
+
+        Err(DpeErrorCode::InvalidCommand)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        commands::{Command, CommandHdr},
+        dpe_instance::tests::{SIMULATION_HANDLE, TEST_LOCALITIES},
+        support::test::SUPPORT,
+    };
+    use crypto::OpensslCrypto;
+    use zerocopy::AsBytes;
+
+    const TEST_CERTIFY_CSR_CMD: CertifyCsrCmd = CertifyCsrCmd {
+        handle: SIMULATION_HANDLE,
+        flags: 0x1234_5678,
+        label: [0xaa; DPE_PROFILE.get_hash_size()],
+    };
+
+    #[test]
+    fn test_deserialize_certify_csr() {
+        let mut command = CommandHdr::new(Command::CertifyCsr(TEST_CERTIFY_CSR_CMD))
+            .as_bytes()
+            .to_vec();
+        command.extend(TEST_CERTIFY_CSR_CMD.as_bytes());
+        assert_eq!(
+            Ok(Command::CertifyCsr(TEST_CERTIFY_CSR_CMD)),
+            Command::deserialize(&command)
+        );
+    }
+
+    #[test]
+    fn test_uses_nd_derivation() {
+        // Non-deterministic flag not set
+        assert!(!CertifyCsrCmd {
+            flags: 0,
+            ..TEST_CERTIFY_CSR_CMD
+        }
+        .uses_nd_derivation());
+
+        // Non-deterministic flag set.
+        assert!(CertifyCsrCmd {
+            flags: CertifyCsrCmd::ND_DERIVATION,
+            ..TEST_CERTIFY_CSR_CMD
+        }
+        .uses_nd_derivation());
+    }
+
+    #[test]
+    fn test_bad_command_inputs() {
+        let mut dpe =
+            DpeInstance::<OpensslCrypto>::new_for_test(SUPPORT, &TEST_LOCALITIES).unwrap();
+
+        // Bad argument
+        assert_eq!(
+            Err(DpeErrorCode::InvalidArgument),
+            CertifyCsrCmd {
+                handle: ContextHandle([0xff; ContextHandle::SIZE]),
+                flags: CertifyCsrCmd::ND_DERIVATION,
+                ..TEST_CERTIFY_CSR_CMD
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+        );
+
+        // Bad handle.
+        assert_eq!(
+            Err(DpeErrorCode::InvalidHandle),
+            CertifyCsrCmd {
+                handle: ContextHandle([0xff; ContextHandle::SIZE]),
+                ..TEST_CERTIFY_CSR_CMD
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[0])
+        );
+
+        // Wrong locality.
+        assert!(dpe
+            .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[0])
+            .is_some());
+        assert_eq!(
+            Err(DpeErrorCode::InvalidHandle),
+            CertifyCsrCmd {
+                handle: ContextHandle::default(),
+                ..TEST_CERTIFY_CSR_CMD
+            }
+            .execute(&mut dpe, TEST_LOCALITIES[1])
+        );
+    }
+}

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub(crate) use self::initialize_context::InitCtxCmd;
 
 pub(in crate::commands) use self::certify_key::CertifyKeyCmd;
 
+use self::certify_csr::CertifyCsrCmd;
 use self::extend_tci::ExtendTciCmd;
 use self::get_tagged_tci::GetTaggedTciCmd;
 use self::rotate_context::RotateCtxCmd;
@@ -25,6 +26,7 @@ use core::mem::size_of;
 use crypto::Crypto;
 use zerocopy::FromBytes;
 
+mod certify_csr;
 mod certify_key;
 mod derive_child;
 mod destroy_context;
@@ -47,6 +49,7 @@ pub enum Command {
     ExtendTci(ExtendTciCmd),
     TagTci(TagTciCmd),
     GetTaggedTci(GetTaggedTciCmd),
+    CertifyCsr(CertifyCsrCmd),
 }
 
 impl Command {
@@ -61,6 +64,7 @@ impl Command {
     const EXTEND_TCI: u32 = 0x1001;
     const TAG_TCI: u32 = 0x1002;
     const GET_TAGGED_TCI: u32 = 0x1003;
+    const CERTIFY_CSR: u32 = 0x1004;
 
     /// Returns the command with its parameters given a slice of bytes.
     ///
@@ -83,6 +87,7 @@ impl Command {
             Command::EXTEND_TCI => Self::parse_command(Command::ExtendTci, bytes),
             Command::TAG_TCI => Self::parse_command(Command::TagTci, bytes),
             Command::GET_TAGGED_TCI => Self::parse_command(Command::GetTaggedTci, bytes),
+            Command::CERTIFY_CSR => Self::parse_command(Command::CertifyCsr, bytes),
             _ => Err(DpeErrorCode::InvalidCommand),
         }
     }
@@ -256,6 +261,7 @@ pub mod tests {
                 Command::ExtendTci(_) => Command::EXTEND_TCI,
                 Command::TagTci(_) => Command::TAG_TCI,
                 Command::GetTaggedTci(_) => Command::GET_TAGGED_TCI,
+                Command::CertifyCsr(_) => Command::CERTIFY_CSR,
             };
             CommandHdr {
                 magic: Self::DPE_COMMAND_MAGIC,

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -110,6 +110,7 @@ impl<C: Crypto> DpeInstance<'_, C> {
             Command::ExtendTci(cmd) => cmd.execute(self, locality),
             Command::TagTci(cmd) => cmd.execute(self, locality),
             Command::GetTaggedTci(cmd) => cmd.execute(self, locality),
+            Command::CertifyCsr(cmd) => cmd.execute(self, locality),
         }
     }
 


### PR DESCRIPTION
This commit adds (de)serialization for the certify csr dpe command and adds other boiler plate code
to support this command.