### PR TITLE
Implement handling of INTERNAL_INPUT_INFO flag

### DIFF
--- a/dpe/src/commands/derive_child.rs
+++ b/dpe/src/commands/derive_child.rs
@@ -83,6 +83,10 @@ impl<C: Crypto> CommandExecution<C> for DeriveChildCmd {
             .get_next_inactive_context_pos()
             .ok_or(DpeErrorCode::MaxTcis)?;
 
+        if self.uses_internal_info_input() {
+            dpe.contexts[parent_idx].uses_internal_dpe_info = true;
+        }
+
         let target_locality = if !self.changes_locality() {
             locality
         } else {

--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -21,6 +21,8 @@ pub(crate) struct Context<C: Crypto> {
     pub tag: u32,
     /// Private key which is cached only in non-deterministic key derivation mode
     pub cached_priv_key: Option<C::PrivKey>,
+    /// Whether we should hash internal dpe info consisting of major_version, minor_version, vendor_id, vendor_sku, max_tci_nodes, flags, and DPE_PROFILE when deriving cdi
+    pub uses_internal_dpe_info: bool,
 }
 
 impl<C: Crypto> Context<C> {
@@ -38,6 +40,7 @@ impl<C: Crypto> Context<C> {
             has_tag: false,
             tag: 0,
             cached_priv_key: None,
+            uses_internal_dpe_info: false,
         }
     }
 
@@ -68,6 +71,7 @@ impl<C: Crypto> Context<C> {
         self.tag = 0;
         self.state = ContextState::Inactive;
         self.cached_priv_key = None;
+        self.uses_internal_dpe_info = false;
     }
 
     /// Add a child to list of children in the context.

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -14,8 +14,9 @@ pub mod dpe_instance;
 pub mod response;
 pub mod support;
 
+use core::mem::size_of;
 use crypto::Crypto;
-use response::{DpeErrorCode, ResponseHdr};
+use response::{DpeErrorCode, GetProfileResp, ResponseHdr};
 mod context;
 mod tci;
 mod x509;
@@ -26,6 +27,8 @@ const CURRENT_PROFILE_MAJOR_VERSION: u16 = 0;
 const CURRENT_PROFILE_MINOR_VERSION: u16 = 8;
 const VENDOR_ID: u32 = 0;
 const VENDOR_SKU: u32 = 0;
+
+const INTERNAL_DPE_INFO_SIZE: usize = size_of::<GetProfileResp>() + size_of::<u32>();
 
 pub enum DpeProfile {
     P256Sha256 = 1,


### PR DESCRIPTION
If this flag is set in derive_child, we serialize the attributes of the DPE profile and add it to the hash in derive_cdi. Handling the INTERNAL_INPUT_DICE flag will come later as this is dependent on implementing the get_certificate_chain function first. 