### PR TITLE
Add license headers

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -1,3 +1,5 @@
+# Licensed under the Apache-2.0 license
+
 #!/bin/sh
 set -ex
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,3 +1,5 @@
+# Licensed under the Apache-2.0 license
+
 [package]
 name = "crypto"
 version = "0.1.0"

--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -1,3 +1,5 @@
+# Licensed under the Apache-2.0 license
+
 [package]
 name = "dpe"
 version = "0.1.0"

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -1,3 +1,5 @@
+# Licensed under the Apache-2.0 license
+
 [package]
 name = "simulator"
 version = "0.1.0"

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -1,3 +1,5 @@
+// Licensed under the Apache-2.0 license
+
 use clap::Parser;
 use crypto::OpensslCrypto;
 use log::{error, info, trace, warn};


### PR DESCRIPTION
This is necessary so that the caliptra-sw build passes.