### PR TITLE
Mark crypto/platform crates as no_std if openssl isn't being used

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -3,6 +3,7 @@ Licensed under the Apache-2.0 license.
 Abstract:
     Generic trait definition of Cryptographic functions.
 --*/
+#![cfg_attr(not(any(feature = "openssl", test)), no_std)]
 
 #[cfg(feature = "openssl")]
 pub use crate::openssl::*;

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -1,4 +1,9 @@
-// Licensed under the Apache-2.0 license
+/*++
+Licensed under the Apache-2.0 license.
+Abstract:
+    Generic trait definition of platform.
+--*/
+#![cfg_attr(not(test), no_std)]
 
 pub use default::*;
 mod default;


### PR DESCRIPTION
Needed to use DPE in caliptra