### PR TITLE
Fix warnings that cause Caliptra build to fail

### DIFF
--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -302,7 +302,7 @@ mod tests {
         assert!(iter.next().unwrap().is_ok());
 
         // Root index.
-        contexts[0].parent_idx = Context::<OpensslCrypto>::ROOT_INDEX as u8;
+        contexts[0].parent_idx = Context::<OpensslCrypto>::ROOT_INDEX;
         let mut iter = ChildToRootIter::new(0, &contexts);
         assert!(iter.next().unwrap().is_ok());
     }

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -893,7 +893,6 @@ mod tests {
     use crate::tci::{TciMeasurement, TciNodeData};
     use crate::x509::{MeasurementData, Name, X509CertWriter};
     use crate::DPE_PROFILE;
-    use asn1;
     use crypto::{AlgLen, CryptoBuf, EcdsaPub, EcdsaSig};
     use std::str;
     use x509_parser::certificate::X509CertificateParser;

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -12,6 +12,7 @@ pub const MAX_CHUNK_SIZE: usize = 2048;
 
 pub enum PlatformError {
     CertificateChainError,
+    NotImplemented,
 }
 
 pub trait Platform {


### PR DESCRIPTION
Also add NotImplemented to PlatformError so we can use in stub implementation of Caliptra Platform.