### PR TITLE
Extend Platform trait and remove locality array from DPE instance

### DIFF
--- a/dpe/src/commands/certify_csr.rs
+++ b/dpe/src/commands/certify_csr.rs
@@ -101,9 +101,7 @@ mod tests {
 
     #[test]
     fn test_bad_command_inputs() {
-        let mut dpe =
-            DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(SUPPORT, &TEST_LOCALITIES)
-                .unwrap();
+        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(SUPPORT).unwrap();
 
         // Bad argument
         assert_eq!(

--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -165,11 +165,9 @@ mod tests {
 
     #[test]
     fn test_certify_key() {
-        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(
-            Support::default(),
-            &TEST_LOCALITIES,
-        )
-        .unwrap();
+        let mut dpe =
+            DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(Support::default())
+                .unwrap();
 
         let init_resp = match InitCtxCmd::new_use_default()
             .execute(&mut dpe, TEST_LOCALITIES[0])

--- a/dpe/src/commands/derive_child.rs
+++ b/dpe/src/commands/derive_child.rs
@@ -94,10 +94,6 @@ impl<C: Crypto, P: Platform> CommandExecution<C, P> for DeriveChildCmd {
         let target_locality = if !self.changes_locality() {
             locality
         } else {
-            // Make sure the target locality is valid.
-            if !dpe.localities.iter().any(|&l| l == self.target_locality) {
-                return Err(DpeErrorCode::InvalidLocality);
-            }
             self.target_locality
         };
 
@@ -179,37 +175,9 @@ mod tests {
 
     #[test]
     fn test_initial_conditions() {
-        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(
-            Support::default(),
-            &TEST_LOCALITIES,
-        )
-        .unwrap();
-
-        // Right now this command doesn't support INTERNAL_INPUT_INFO, make sure it errors.
-        assert_eq!(
-            Err(DpeErrorCode::InvalidArgument),
-            DeriveChildCmd {
-                handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
-                flags: DeriveChildCmd::INTERNAL_INPUT_INFO,
-                tci_type: 0,
-                target_locality: 0
-            }
-            .execute(&mut dpe, 0)
-        );
-
-        // Right now this command doesn't support INTERNAL_INPUT_DICE, make sure it errors.
-        assert_eq!(
-            Err(DpeErrorCode::InvalidArgument),
-            DeriveChildCmd {
-                handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
-                flags: DeriveChildCmd::INTERNAL_INPUT_DICE,
-                tci_type: 0,
-                target_locality: 0
-            }
-            .execute(&mut dpe, 0)
-        );
+        let mut dpe =
+            DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(Support::default())
+                .unwrap();
 
         InitCtxCmd::new_use_default().execute(&mut dpe, 0).unwrap();
 
@@ -225,30 +193,14 @@ mod tests {
             }
             .execute(&mut dpe, 1)
         );
-
-        // Make sure it can detect an invalid locality.
-        assert_eq!(
-            Err(DpeErrorCode::InvalidLocality),
-            DeriveChildCmd {
-                handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
-                flags: DeriveChildCmd::CHANGE_LOCALITY,
-                tci_type: 0,
-                target_locality: 2
-            }
-            .execute(&mut dpe, 0)
-        );
     }
 
     #[test]
     fn test_max_tcis() {
-        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(
-            Support {
-                auto_init: true,
-                ..Support::default()
-            },
-            &TEST_LOCALITIES,
-        )
+        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(Support {
+            auto_init: true,
+            ..Support::default()
+        })
         .unwrap();
 
         // Fill all contexts with children (minus the auto-init context).
@@ -280,13 +232,10 @@ mod tests {
 
     #[test]
     fn test_set_child_parent_relationship() {
-        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(
-            Support {
-                auto_init: true,
-                ..Support::default()
-            },
-            &TEST_LOCALITIES,
-        )
+        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(Support {
+            auto_init: true,
+            ..Support::default()
+        })
         .unwrap();
 
         let parent_idx = dpe
@@ -317,13 +266,10 @@ mod tests {
 
     #[test]
     fn test_set_other_values() {
-        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(
-            Support {
-                auto_init: true,
-                ..Support::default()
-            },
-            &TEST_LOCALITIES,
-        )
+        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(Support {
+            auto_init: true,
+            ..Support::default()
+        })
         .unwrap();
 
         DeriveChildCmd {
@@ -347,13 +293,10 @@ mod tests {
 
     #[test]
     fn test_correct_child_handle() {
-        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(
-            Support {
-                auto_init: true,
-                ..Support::default()
-            },
-            &TEST_LOCALITIES,
-        )
+        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(Support {
+            auto_init: true,
+            ..Support::default()
+        })
         .unwrap();
 
         // Make sure child handle is default when creating default child.
@@ -391,13 +334,10 @@ mod tests {
 
     #[test]
     fn test_correct_parent_handle() {
-        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(
-            Support {
-                auto_init: true,
-                ..Support::default()
-            },
-            &TEST_LOCALITIES,
-        )
+        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(Support {
+            auto_init: true,
+            ..Support::default()
+        })
         .unwrap();
 
         // Make sure the parent handle is non-sense when not retaining.

--- a/dpe/src/commands/extend_tci.rs
+++ b/dpe/src/commands/extend_tci.rs
@@ -60,7 +60,7 @@ mod tests {
         support::Support,
     };
     use crypto::OpensslCrypto;
-    use platform::DefaultPlatform;
+    use platform::{DefaultPlatform, AUTO_INIT_LOCALITY};
     use zerocopy::AsBytes;
 
     const TEST_EXTEND_TCI_CMD: ExtendTciCmd = ExtendTciCmd {
@@ -82,11 +82,9 @@ mod tests {
 
     #[test]
     fn test_extend_tci() {
-        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(
-            Support::default(),
-            &TEST_LOCALITIES,
-        )
-        .unwrap();
+        let mut dpe =
+            DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(Support::default())
+                .unwrap();
         // Make sure it returns an error if the command is marked unsupported.
         assert_eq!(
             Err(DpeErrorCode::InvalidCommand),
@@ -113,7 +111,7 @@ mod tests {
             .execute(&mut dpe, TEST_LOCALITIES[1])
         );
 
-        let locality = DpeInstance::<OpensslCrypto, DefaultPlatform>::AUTO_INIT_LOCALITY;
+        let locality = AUTO_INIT_LOCALITY;
         let default_handle = ContextHandle::default();
         let handle = dpe.contexts[dpe
             .get_active_context_pos(&default_handle, locality)

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -73,9 +73,7 @@ mod tests {
 
     #[test]
     fn test_fails_if_size_greater_than_max_cert_size() {
-        let mut dpe =
-            DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(SUPPORT, &TEST_LOCALITIES)
-                .unwrap();
+        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(SUPPORT).unwrap();
 
         assert_eq!(
             Err(DpeErrorCode::InvalidArgument),

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -112,11 +112,9 @@ mod tests {
 
     #[test]
     fn test_initialize_context() {
-        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(
-            Support::default(),
-            &TEST_LOCALITIES,
-        )
-        .unwrap();
+        let mut dpe =
+            DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(Support::default())
+                .unwrap();
 
         let handle = match InitCtxCmd::new_use_default()
             .execute(&mut dpe, TEST_LOCALITIES[0])
@@ -147,13 +145,10 @@ mod tests {
         );
 
         // Change to support simulation.
-        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(
-            Support {
-                simulation: true,
-                ..Support::default()
-            },
-            &TEST_LOCALITIES,
-        )
+        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(Support {
+            simulation: true,
+            ..Support::default()
+        })
         .unwrap();
 
         // Try setting both flags.

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -94,11 +94,9 @@ mod tests {
 
     #[test]
     fn test_rotate_context() {
-        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(
-            Support::default(),
-            &TEST_LOCALITIES,
-        )
-        .unwrap();
+        let mut dpe =
+            DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(Support::default())
+                .unwrap();
         // Make sure it returns an error if the command is marked unsupported.
         assert_eq!(
             Err(DpeErrorCode::InvalidCommand),
@@ -111,13 +109,10 @@ mod tests {
         );
 
         // Make a new instance that supports RotateContext.
-        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(
-            Support {
-                rotate_context: true,
-                ..Support::default()
-            },
-            &TEST_LOCALITIES,
-        )
+        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(Support {
+            rotate_context: true,
+            ..Support::default()
+        })
         .unwrap();
         InitCtxCmd::new_use_default()
             .execute(&mut dpe, TEST_LOCALITIES[0])

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -226,9 +226,7 @@ mod tests {
 
     #[test]
     fn test_bad_command_inputs() {
-        let mut dpe =
-            DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(SUPPORT, &TEST_LOCALITIES)
-                .unwrap();
+        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(SUPPORT).unwrap();
 
         // Bad argument
         assert_eq!(
@@ -302,9 +300,7 @@ mod tests {
 
     #[test]
     fn test_asymmetric_deterministic() {
-        let mut dpe =
-            DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(SUPPORT, &TEST_LOCALITIES)
-                .unwrap();
+        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(SUPPORT).unwrap();
 
         for i in 0..3 {
             DeriveChildCmd {
@@ -358,14 +354,11 @@ mod tests {
 
     #[test]
     fn test_symmetric() {
-        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(
-            Support {
-                auto_init: true,
-                is_symmetric: true,
-                ..Support::default()
-            },
-            &TEST_LOCALITIES,
-        )
+        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(Support {
+            auto_init: true,
+            is_symmetric: true,
+            ..Support::default()
+        })
         .unwrap();
 
         let cmd = SignCmd {
@@ -400,14 +393,11 @@ mod tests {
 
     #[test]
     fn test_asymmetric_non_deterministic() {
-        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(
-            Support {
-                auto_init: true,
-                nd_derivation: true,
-                ..Support::default()
-            },
-            &TEST_LOCALITIES,
-        )
+        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(Support {
+            auto_init: true,
+            nd_derivation: true,
+            ..Support::default()
+        })
         .unwrap();
 
         for i in 0..3 {

--- a/dpe/src/commands/tag_tci.rs
+++ b/dpe/src/commands/tag_tci.rs
@@ -86,11 +86,9 @@ mod tests {
 
     #[test]
     fn test_tag_tci() {
-        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(
-            Support::default(),
-            &TEST_LOCALITIES,
-        )
-        .unwrap();
+        let mut dpe =
+            DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(Support::default())
+                .unwrap();
         // Make sure it returns an error if the command is marked unsupported.
         assert_eq!(
             Err(DpeErrorCode::InvalidCommand),
@@ -102,14 +100,11 @@ mod tests {
         );
 
         // Make a new instance that supports tagging.
-        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(
-            Support {
-                tagging: true,
-                simulation: true,
-                ..Support::default()
-            },
-            &TEST_LOCALITIES,
-        )
+        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(Support {
+            tagging: true,
+            simulation: true,
+            ..Support::default()
+        })
         .unwrap();
         InitCtxCmd::new_use_default()
             .execute(&mut dpe, TEST_LOCALITIES[0])

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -26,8 +26,6 @@ const MAX_CERT_SIZE: usize = 2048;
 const MAX_HANDLES: usize = 24;
 const CURRENT_PROFILE_MAJOR_VERSION: u16 = 0;
 const CURRENT_PROFILE_MINOR_VERSION: u16 = 8;
-const VENDOR_ID: u32 = 0;
-const VENDOR_SKU: u32 = 0;
 
 const INTERNAL_INPUT_INFO_SIZE: usize = size_of::<GetProfileResp>() + size_of::<u32>();
 

--- a/dpe/src/response.rs
+++ b/dpe/src/response.rs
@@ -6,7 +6,7 @@ Abstract:
 --*/
 use crate::{
     context::ContextHandle, tci::TciMeasurement, CURRENT_PROFILE_MAJOR_VERSION,
-    CURRENT_PROFILE_MINOR_VERSION, DPE_PROFILE, MAX_CERT_SIZE, MAX_HANDLES, VENDOR_ID, VENDOR_SKU,
+    CURRENT_PROFILE_MINOR_VERSION, DPE_PROFILE, MAX_CERT_SIZE, MAX_HANDLES,
 };
 use core::mem::size_of;
 
@@ -100,12 +100,12 @@ pub struct GetProfileResp {
 }
 
 impl GetProfileResp {
-    pub const fn new(flags: u32) -> GetProfileResp {
+    pub const fn new(flags: u32, vendor_id: u32, vendor_sku: u32) -> GetProfileResp {
         GetProfileResp {
             major_version: CURRENT_PROFILE_MAJOR_VERSION,
             minor_version: CURRENT_PROFILE_MINOR_VERSION,
-            vendor_id: VENDOR_ID,
-            vendor_sku: VENDOR_SKU,
+            vendor_id,
+            vendor_sku,
             max_tci_nodes: MAX_HANDLES as u32,
             flags,
         }
@@ -369,10 +369,12 @@ pub enum DpeErrorCode {
 mod tests {
     use super::*;
     use crate::dpe_instance::tests::{SIMULATION_HANDLE, TEST_HANDLE};
+    use platform::{VENDOR_ID, VENDOR_SKU};
     use zerocopy::AsBytes;
 
     const TEST_FLAGS: u32 = 0x7E57_B175;
-    const DEFAULT_GET_PROFILE_RESPONSE: GetProfileResp = GetProfileResp::new(TEST_FLAGS);
+    const DEFAULT_GET_PROFILE_RESPONSE: GetProfileResp =
+        GetProfileResp::new(TEST_FLAGS, VENDOR_ID, VENDOR_SKU);
     const TEST_NEW_HANDLE_RESP: NewHandleResp = NewHandleResp {
         handle: TEST_HANDLE,
     };

--- a/platform/src/default.rs
+++ b/platform/src/default.rs
@@ -5,6 +5,10 @@ use core::cmp::min;
 
 pub struct DefaultPlatform;
 
+pub const AUTO_INIT_LOCALITY: u32 = 0;
+pub const VENDOR_ID: u32 = 0;
+pub const VENDOR_SKU: u32 = 0;
+
 // Generated with openssl using the command openssl req -new -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -x509 -nodes -days 365 -out cert.pem -keyout cert.pem
 // Used https://onlinestringtools.com/convert-string-to-bytes to convert the certificate string to bytes
 // Used a haskell script to format the bytes into an array, and pad until max cert cize with 0 bytes
@@ -152,5 +156,17 @@ impl Platform for DefaultPlatform {
         let cert_chunk_range_end = min(offset + size, len);
         out.copy_from_slice(&TEST_CERT_CHAIN[offset as usize..cert_chunk_range_end as usize]);
         Ok(cert_chunk_range_end - offset)
+    }
+
+    fn get_vendor_id() -> Result<u32, PlatformError> {
+        Ok(VENDOR_ID)
+    }
+
+    fn get_vendor_sku() -> Result<u32, PlatformError> {
+        Ok(VENDOR_SKU)
+    }
+
+    fn get_auto_init_locality() -> Result<u32, PlatformError> {
+        Ok(AUTO_INIT_LOCALITY)
     }
 }

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -10,6 +10,7 @@ mod default;
 
 pub const MAX_CHUNK_SIZE: usize = 2048;
 
+#[derive(Debug)]
 pub enum PlatformError {
     CertificateChainError,
     NotImplemented,
@@ -28,4 +29,10 @@ pub trait Platform {
         size: u32,
         out: &mut [u8; MAX_CHUNK_SIZE],
     ) -> Result<u32, PlatformError>;
+
+    fn get_vendor_id() -> Result<u32, PlatformError>;
+
+    fn get_vendor_sku() -> Result<u32, PlatformError>;
+
+    fn get_auto_init_locality() -> Result<u32, PlatformError>;
 }

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -101,10 +101,6 @@ struct Args {
 
 fn main() -> std::io::Result<()> {
     env_logger::init();
-    const LOCALITIES: [u32; 2] = [
-        DpeInstance::<OpensslCrypto, DefaultPlatform>::AUTO_INIT_LOCALITY,
-        u32::from_be_bytes(*b"OTHR"),
-    ];
     let args = Args::parse();
 
     let socket = Path::new(SOCKET_PATH);
@@ -134,8 +130,8 @@ fn main() -> std::io::Result<()> {
         internal_info: args.supports_internal_info,
         internal_dice: args.supports_internal_dice,
     };
-    let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(support, &LOCALITIES)
-        .map_err(|err| {
+    let mut dpe =
+        DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(support).map_err(|err| {
             Error::new(
                 ErrorKind::Other,
                 format!("{err:?} while creating new DPE instance"),


### PR DESCRIPTION
This commit extends the platform trait so that the implementation can define the vendor_id, vendor_sku, and auto_init_locality. We also remove localities from DpeInstance. This means that DPE no longer knows about all the available localities at startup, and it now just trusts that each command is called with a valid locality.