### PR TITLE
Move CommandHdr::new outside test block

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -171,7 +171,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_certify_key() {
-        let mut command = CommandHdr::new(Command::CertifyKey(TEST_CERTIFY_KEY_CMD))
+        let mut command = CommandHdr::new_for_test(Command::CertifyKey(TEST_CERTIFY_KEY_CMD))
             .as_bytes()
             .to_vec();
         command.extend(TEST_CERTIFY_KEY_CMD.as_bytes());

--- a/dpe/src/commands/derive_child.rs
+++ b/dpe/src/commands/derive_child.rs
@@ -176,7 +176,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_derive_child() {
-        let mut command = CommandHdr::new(Command::DeriveChild(TEST_DERIVE_CHILD_CMD))
+        let mut command = CommandHdr::new_for_test(Command::DeriveChild(TEST_DERIVE_CHILD_CMD))
             .as_bytes()
             .to_vec();
         command.extend(TEST_DERIVE_CHILD_CMD.as_bytes());

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -69,7 +69,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_destroy_context() {
-        let mut command = CommandHdr::new(Command::DestroyCtx(TEST_DESTROY_CTX_CMD))
+        let mut command = CommandHdr::new_for_test(Command::DestroyCtx(TEST_DESTROY_CTX_CMD))
             .as_bytes()
             .to_vec();
         command.extend(TEST_DESTROY_CTX_CMD.as_bytes());

--- a/dpe/src/commands/extend_tci.rs
+++ b/dpe/src/commands/extend_tci.rs
@@ -70,7 +70,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_extend_tci() {
-        let mut command = CommandHdr::new(Command::ExtendTci(TEST_EXTEND_TCI_CMD))
+        let mut command = CommandHdr::new_for_test(Command::ExtendTci(TEST_EXTEND_TCI_CMD))
             .as_bytes()
             .to_vec();
         command.extend(TEST_EXTEND_TCI_CMD.as_bytes());

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -61,7 +61,7 @@ mod tests {
     #[test]
     fn test_deserialize_get_certificate_chain() {
         let mut command =
-            CommandHdr::new(Command::GetCertificateChain(TEST_GET_CERTIFICATE_CHAIN_CMD))
+            CommandHdr::new_for_test(Command::GetCertificateChain(TEST_GET_CERTIFICATE_CHAIN_CMD))
                 .as_bytes()
                 .to_vec();
         command.extend(TEST_GET_CERTIFICATE_CHAIN_CMD.as_bytes());

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -100,7 +100,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_init_ctx() {
-        let mut command = CommandHdr::new(Command::InitCtx(TEST_INIT_CTX_CMD))
+        let mut command = CommandHdr::new_for_test(Command::InitCtx(TEST_INIT_CTX_CMD))
             .as_bytes()
             .to_vec();
         command.extend(TEST_INIT_CTX_CMD.as_bytes());

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -82,7 +82,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_rotate_context() {
-        let mut command = CommandHdr::new(Command::RotateCtx(TEST_ROTATE_CTX_CMD))
+        let mut command = CommandHdr::new_for_test(Command::RotateCtx(TEST_ROTATE_CTX_CMD))
             .as_bytes()
             .to_vec();
         command.extend(TEST_ROTATE_CTX_CMD.as_bytes());

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_sign() {
-        let mut command = CommandHdr::new(Command::Sign(TEST_SIGN_CMD))
+        let mut command = CommandHdr::new_for_test(Command::Sign(TEST_SIGN_CMD))
             .as_bytes()
             .to_vec();
         command.extend(TEST_SIGN_CMD.as_bytes());

--- a/dpe/src/commands/tag_tci.rs
+++ b/dpe/src/commands/tag_tci.rs
@@ -74,7 +74,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_tag_tci() {
-        let mut command = CommandHdr::new(Command::TagTci(TEST_TAG_TCI_CMD))
+        let mut command = CommandHdr::new_for_test(Command::TagTci(TEST_TAG_TCI_CMD))
             .as_bytes()
             .to_vec();
         command.extend(TEST_TAG_TCI_CMD.as_bytes());

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -379,14 +379,14 @@ pub mod tests {
             )),
             dpe.execute_serialized_command(
                 TEST_LOCALITIES[0],
-                CommandHdr::new(Command::GetProfile).as_bytes(),
+                CommandHdr::new_for_test(Command::GetProfile).as_bytes(),
             )
             .unwrap()
         );
 
         // The default context was initialized while creating the instance. Now lets create a
         // simulation context.
-        let mut command = CommandHdr::new(Command::InitCtx(InitCtxCmd::new_simulation()))
+        let mut command = CommandHdr::new_for_test(Command::InitCtx(InitCtxCmd::new_simulation()))
             .as_bytes()
             .to_vec();
         command.extend(InitCtxCmd::new_simulation().as_bytes());


### PR DESCRIPTION
We will need this in runtime integration tests so we move it outside of the test block so we can use in other crates. Also rename it to new_for_test so it is more clear it is only used in tests.