### PR TITLE
Make DPE cmd execution return the response struct with a response hdr

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -3,7 +3,7 @@ use super::CommandExecution;
 use crate::{
     context::ContextHandle,
     dpe_instance::DpeInstance,
-    response::{CertifyKeyResp, DpeErrorCode, Response},
+    response::{CertifyKeyResp, DpeErrorCode, Response, ResponseHdr},
     tci::TciNodeData,
     x509::{MeasurementData, Name, X509CertWriter},
     DPE_PROFILE, MAX_CERT_SIZE, MAX_HANDLES,
@@ -143,6 +143,7 @@ impl<C: Crypto, P: Platform> CommandExecution<C, P> for CertifyKeyCmd {
             derived_pubkey_y: pub_key.y.bytes().try_into().unwrap(),
             cert_size,
             cert,
+            resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
         }))
     }
 }

--- a/dpe/src/commands/derive_child.rs
+++ b/dpe/src/commands/derive_child.rs
@@ -3,7 +3,7 @@ use super::CommandExecution;
 use crate::{
     context::{ActiveContextArgs, ContextHandle, ContextState, ContextType},
     dpe_instance::DpeInstance,
-    response::{DeriveChildResp, DpeErrorCode, Response},
+    response::{DeriveChildResp, DpeErrorCode, Response, ResponseHdr},
     tci::TciMeasurement,
     DPE_PROFILE,
 };
@@ -149,6 +149,7 @@ impl<C: Crypto, P: Platform> CommandExecution<C, P> for DeriveChildCmd {
         Ok(Response::DeriveChild(DeriveChildResp {
             handle: child_handle,
             parent_handle: dpe.contexts[parent_idx].handle,
+            resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
         }))
     }
 }
@@ -316,7 +317,8 @@ mod tests {
         assert_eq!(
             Ok(Response::DeriveChild(DeriveChildResp {
                 handle: ContextHandle::default(),
-                parent_handle: ContextHandle([0xff; ContextHandle::SIZE])
+                parent_handle: ContextHandle([0xff; ContextHandle::SIZE]),
+                resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
             })),
             DeriveChildCmd {
                 handle: ContextHandle::default(),
@@ -332,7 +334,8 @@ mod tests {
         assert_eq!(
             Ok(Response::DeriveChild(DeriveChildResp {
                 handle: SIMULATION_HANDLE,
-                parent_handle: ContextHandle([0xff; ContextHandle::SIZE])
+                parent_handle: ContextHandle([0xff; ContextHandle::SIZE]),
+                resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
             })),
             DeriveChildCmd {
                 handle: ContextHandle::default(),
@@ -357,7 +360,8 @@ mod tests {
         assert_eq!(
             Ok(Response::DeriveChild(DeriveChildResp {
                 handle: ContextHandle::default(),
-                parent_handle: ContextHandle([0xff; ContextHandle::SIZE])
+                parent_handle: ContextHandle([0xff; ContextHandle::SIZE]),
+                resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
             })),
             DeriveChildCmd {
                 handle: ContextHandle::default(),
@@ -374,6 +378,7 @@ mod tests {
             Ok(Response::DeriveChild(DeriveChildResp {
                 handle: ContextHandle::default(),
                 parent_handle: ContextHandle::default(),
+                resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
             })),
             DeriveChildCmd {
                 handle: ContextHandle::default(),
@@ -401,6 +406,7 @@ mod tests {
             Ok(Response::DeriveChild(DeriveChildResp {
                 handle: ContextHandle::default(),
                 parent_handle: SIMULATION_HANDLE,
+                resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
             })),
             DeriveChildCmd {
                 handle: dpe.contexts[old_default_idx].handle,

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -3,7 +3,7 @@ use super::CommandExecution;
 use crate::{
     context::ContextHandle,
     dpe_instance::{flags_iter, DpeInstance},
-    response::{DpeErrorCode, Response},
+    response::{DpeErrorCode, Response, ResponseHdr},
     MAX_HANDLES,
 };
 use crypto::Crypto;
@@ -49,7 +49,9 @@ impl<C: Crypto, P: Platform> CommandExecution<C, P> for DestroyCtxCmd {
         for idx in flags_iter(to_destroy, MAX_HANDLES) {
             dpe.contexts[idx].destroy();
         }
-        Ok(Response::DestroyCtx)
+        Ok(Response::DestroyCtx(ResponseHdr::new(
+            DpeErrorCode::NoError,
+        )))
     }
 }
 

--- a/dpe/src/commands/extend_tci.rs
+++ b/dpe/src/commands/extend_tci.rs
@@ -3,7 +3,7 @@ use super::CommandExecution;
 use crate::{
     context::ContextHandle,
     dpe_instance::DpeInstance,
-    response::{DpeErrorCode, NewHandleResp, Response},
+    response::{DpeErrorCode, NewHandleResp, Response, ResponseHdr},
     tci::TciMeasurement,
     DPE_PROFILE,
 };
@@ -47,6 +47,7 @@ impl<C: Crypto, P: Platform> CommandExecution<C, P> for ExtendTciCmd {
         dpe.roll_onetime_use_handle(idx)?;
         Ok(Response::ExtendTci(NewHandleResp {
             handle: dpe.contexts[idx].handle,
+            resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
         }))
     }
 }

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -2,7 +2,7 @@
 use super::CommandExecution;
 use crate::{
     dpe_instance::DpeInstance,
-    response::{DpeErrorCode, GetCertificateChainResp, Response},
+    response::{DpeErrorCode, GetCertificateChainResp, Response, ResponseHdr},
     MAX_CERT_SIZE,
 };
 use crypto::Crypto;
@@ -37,6 +37,7 @@ impl<C: Crypto, P: Platform> CommandExecution<C, P> for GetCertificateChainCmd {
         Ok(Response::GetCertificateChain(GetCertificateChainResp {
             certificate_chain: cert_chunk,
             certificate_size: len,
+            resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
         }))
     }
 }

--- a/dpe/src/commands/get_tagged_tci.rs
+++ b/dpe/src/commands/get_tagged_tci.rs
@@ -2,7 +2,7 @@
 use super::CommandExecution;
 use crate::{
     dpe_instance::DpeInstance,
-    response::{DpeErrorCode, GetTaggedTciResp, Response},
+    response::{DpeErrorCode, GetTaggedTciResp, Response, ResponseHdr},
 };
 use crypto::Crypto;
 use platform::Platform;
@@ -32,6 +32,7 @@ impl<C: Crypto, P: Platform> CommandExecution<C, P> for GetTaggedTciCmd {
         Ok(Response::GetTaggedTci(GetTaggedTciResp {
             tci_cumulative: ctx.tci.tci_cumulative,
             tci_current: ctx.tci.tci_current,
+            resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
         }))
     }
 }

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -3,7 +3,7 @@ use super::CommandExecution;
 use crate::{
     context::{ActiveContextArgs, Context, ContextHandle, ContextType},
     dpe_instance::DpeInstance,
-    response::{DpeErrorCode, NewHandleResp, Response},
+    response::{DpeErrorCode, NewHandleResp, Response, ResponseHdr},
 };
 use crypto::Crypto;
 use platform::Platform;
@@ -79,7 +79,10 @@ impl<C: Crypto, P: Platform> CommandExecution<C, P> for InitCtxCmd {
             tci_type: 0,
             parent_idx: Context::<C>::ROOT_INDEX,
         });
-        Ok(Response::InitCtx(NewHandleResp { handle }))
+        Ok(Response::InitCtx(NewHandleResp {
+            handle,
+            resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
+        }))
     }
 }
 

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -3,7 +3,7 @@ use super::CommandExecution;
 use crate::{
     context::ContextHandle,
     dpe_instance::DpeInstance,
-    response::{DpeErrorCode, NewHandleResp, Response},
+    response::{DpeErrorCode, NewHandleResp, Response, ResponseHdr},
 };
 use crypto::Crypto;
 use platform::Platform;
@@ -58,7 +58,10 @@ impl<C: Crypto, P: Platform> CommandExecution<C, P> for RotateCtxCmd {
             dpe.generate_new_handle()?
         };
         dpe.contexts[idx].handle = new_handle;
-        Ok(Response::RotateCtx(NewHandleResp { handle: new_handle }))
+        Ok(Response::RotateCtx(NewHandleResp {
+            handle: new_handle,
+            resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
+        }))
     }
 }
 
@@ -154,7 +157,8 @@ mod tests {
         // Rotate default handle.
         assert_eq!(
             Ok(Response::RotateCtx(NewHandleResp {
-                handle: SIMULATION_HANDLE
+                handle: SIMULATION_HANDLE,
+                resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
             })),
             RotateCtxCmd {
                 handle: ContextHandle::default(),
@@ -167,7 +171,8 @@ mod tests {
         // New handle is all 0s if caller requests default handle
         assert_eq!(
             Ok(Response::RotateCtx(NewHandleResp {
-                handle: ContextHandle::default()
+                handle: ContextHandle::default(),
+                resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
             })),
             RotateCtxCmd {
                 handle: SIMULATION_HANDLE,

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -3,7 +3,7 @@ use super::CommandExecution;
 use crate::{
     context::{ContextHandle, ContextType},
     dpe_instance::DpeInstance,
-    response::{DpeErrorCode, Response, SignResp},
+    response::{DpeErrorCode, Response, ResponseHdr, SignResp},
     DPE_PROFILE,
 };
 use crypto::{Crypto, CryptoBuf, Digest, EcdsaSig, HmacSig};
@@ -118,6 +118,7 @@ impl<C: Crypto, P: Platform> CommandExecution<C, P> for SignCmd {
             new_context_handle: dpe.contexts[idx].handle,
             sig_r_or_hmac: r.bytes().try_into().unwrap(),
             sig_s: s.bytes().try_into().unwrap(),
+            resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
         }))
     }
 }

--- a/dpe/src/commands/tag_tci.rs
+++ b/dpe/src/commands/tag_tci.rs
@@ -3,7 +3,7 @@ use super::CommandExecution;
 use crate::{
     context::ContextHandle,
     dpe_instance::DpeInstance,
-    response::{DpeErrorCode, NewHandleResp, Response},
+    response::{DpeErrorCode, NewHandleResp, Response, ResponseHdr},
 };
 use crypto::Crypto;
 use platform::Platform;
@@ -51,6 +51,7 @@ impl<C: Crypto, P: Platform> CommandExecution<C, P> for TagTciCmd {
 
         Ok(Response::TagTci(NewHandleResp {
             handle: context.handle,
+            resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
         }))
     }
 }
@@ -139,6 +140,7 @@ mod tests {
         assert_eq!(
             Ok(Response::TagTci(NewHandleResp {
                 handle: ContextHandle::default(),
+                resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
             })),
             TagTciCmd {
                 handle: ContextHandle::default(),
@@ -182,6 +184,7 @@ mod tests {
         assert_eq!(
             Ok(Response::TagTci(NewHandleResp {
                 handle: SIMULATION_HANDLE,
+                resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
             })),
             TagTciCmd {
                 handle: sim_tmp_handle,

--- a/dpe/src/response.rs
+++ b/dpe/src/response.rs
@@ -19,11 +19,12 @@ pub enum Response {
     RotateCtx(NewHandleResp),
     CertifyKey(CertifyKeyResp),
     Sign(SignResp),
-    DestroyCtx,
+    DestroyCtx(ResponseHdr),
     ExtendTci(NewHandleResp),
     TagTci(NewHandleResp),
     GetTaggedTci(GetTaggedTciResp),
     GetCertificateChain(GetCertificateChainResp),
+    Error(ResponseHdr),
 }
 
 impl Response {
@@ -35,11 +36,12 @@ impl Response {
             Response::RotateCtx(res) => res.as_bytes(),
             Response::CertifyKey(res) => res.as_bytes(),
             Response::Sign(res) => res.as_bytes(),
-            Response::DestroyCtx => &[],
+            Response::DestroyCtx(res) => res.as_bytes(),
             Response::ExtendTci(res) => res.as_bytes(),
             Response::TagTci(res) => res.as_bytes(),
             Response::GetTaggedTci(res) => res.as_bytes(),
             Response::GetCertificateChain(res) => res.as_bytes(),
+            Response::Error(res) => res.as_bytes(),
         }
     }
 }
@@ -56,7 +58,7 @@ pub struct ResponseHdr {
 }
 
 impl ResponseHdr {
-    const DPE_RESPONSE_MAGIC: u32 = u32::from_be_bytes(*b"DPER");
+    pub const DPE_RESPONSE_MAGIC: u32 = u32::from_be_bytes(*b"DPER");
 
     pub fn new(error_code: DpeErrorCode) -> ResponseHdr {
         ResponseHdr {
@@ -71,6 +73,7 @@ impl ResponseHdr {
 #[derive(Debug, PartialEq, Eq, zerocopy::AsBytes)]
 #[cfg_attr(test, derive(zerocopy::FromBytes))]
 pub struct GetProfileResp {
+    pub resp_hdr: ResponseHdr,
     pub major_version: u16,
     pub minor_version: u16,
     pub vendor_id: u32,
@@ -88,6 +91,11 @@ impl GetProfileResp {
             vendor_sku,
             max_tci_nodes: MAX_HANDLES as u32,
             flags,
+            resp_hdr: ResponseHdr {
+                magic: ResponseHdr::DPE_RESPONSE_MAGIC,
+                status: DpeErrorCode::NoError as u32,
+                profile: DPE_PROFILE as u32,
+            },
         }
     }
 }
@@ -96,6 +104,7 @@ impl GetProfileResp {
 #[derive(Debug, PartialEq, Eq, zerocopy::AsBytes)]
 #[cfg_attr(test, derive(zerocopy::FromBytes))]
 pub struct NewHandleResp {
+    pub resp_hdr: ResponseHdr,
     pub handle: ContextHandle,
 }
 
@@ -103,6 +112,7 @@ pub struct NewHandleResp {
 #[derive(Debug, PartialEq, Eq, zerocopy::AsBytes)]
 #[cfg_attr(test, derive(zerocopy::FromBytes))]
 pub struct DeriveChildResp {
+    pub resp_hdr: ResponseHdr,
     pub handle: ContextHandle,
     pub parent_handle: ContextHandle,
 }
@@ -110,6 +120,7 @@ pub struct DeriveChildResp {
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, zerocopy::AsBytes)]
 pub struct CertifyKeyResp {
+    pub resp_hdr: ResponseHdr,
     pub new_context_handle: ContextHandle,
     pub derived_pubkey_x: [u8; DPE_PROFILE.get_ecc_int_size()],
     pub derived_pubkey_y: [u8; DPE_PROFILE.get_ecc_int_size()],
@@ -120,6 +131,7 @@ pub struct CertifyKeyResp {
 impl Default for CertifyKeyResp {
     fn default() -> Self {
         Self {
+            resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
             new_context_handle: ContextHandle::default(),
             derived_pubkey_x: [0; DPE_PROFILE.get_ecc_int_size()],
             derived_pubkey_y: [0; DPE_PROFILE.get_ecc_int_size()],
@@ -133,6 +145,7 @@ impl Default for CertifyKeyResp {
 #[derive(Debug, PartialEq, Eq, zerocopy::AsBytes)]
 #[cfg_attr(test, derive(zerocopy::FromBytes))]
 pub struct SignResp {
+    pub resp_hdr: ResponseHdr,
     pub new_context_handle: ContextHandle,
     pub sig_r_or_hmac: [u8; DPE_PROFILE.get_ecc_int_size()],
     pub sig_s: [u8; DPE_PROFILE.get_ecc_int_size()],
@@ -142,6 +155,7 @@ pub struct SignResp {
 #[derive(Debug, zerocopy::AsBytes)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct GetTaggedTciResp {
+    pub resp_hdr: ResponseHdr,
     pub tci_cumulative: TciMeasurement,
     pub tci_current: TciMeasurement,
 }
@@ -150,6 +164,7 @@ pub struct GetTaggedTciResp {
 #[derive(Debug, PartialEq, Eq, zerocopy::AsBytes)]
 #[cfg_attr(test, derive(zerocopy::FromBytes))]
 pub struct GetCertificateChainResp {
+    pub resp_hdr: ResponseHdr,
     pub certificate_size: u32,
     pub certificate_chain: [u8; MAX_CERT_SIZE],
 }
@@ -159,6 +174,7 @@ impl Default for GetCertificateChainResp {
         Self {
             certificate_size: 0,
             certificate_chain: [0; MAX_CERT_SIZE],
+            resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
         }
     }
 }


### PR DESCRIPTION
Instead of serializing the DPE response, this change makes DPE command execution return the response struct itself with a response header, so that the caller can decide what to do with it. We need to add the header to each DPE response struct so that if and when we serialize it using as_bytes, the header exists in the serialized buffer.