### PR TITLE
Differentiate DPE errors better

### DIFF
--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -31,13 +31,11 @@ impl<C: Crypto, P: Platform> CommandExecution<C, P> for DestroyCtxCmd {
         dpe: &mut DpeInstance<C, P>,
         locality: u32,
     ) -> Result<Response, DpeErrorCode> {
-        let idx = dpe
-            .get_active_context_pos(&self.handle, locality)
-            .ok_or(DpeErrorCode::InvalidHandle)?;
+        let idx = dpe.get_active_context_pos(&self.handle, locality)?;
         let context = &dpe.contexts[idx];
         // Make sure the command is coming from the right locality.
         if context.locality != locality {
-            return Err(DpeErrorCode::InvalidHandle);
+            return Err(DpeErrorCode::InvalidLocality);
         }
 
         let to_destroy = if self.flag_is_destroy_descendants() {

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -31,7 +31,7 @@ impl<C: Crypto, P: Platform> CommandExecution<C, P> for GetCertificateChainCmd {
         let len = P::get_certificate_chain(self.offset, self.size, &mut cert_chunk).map_err(
             |platform_error| match platform_error {
                 PlatformError::CertificateChainError => DpeErrorCode::InvalidArgument,
-                PlatformError::NotImplemented => DpeErrorCode::InternalError,
+                PlatformError::NotImplemented => DpeErrorCode::PlatformError,
             },
         )?;
         Ok(Response::GetCertificateChain(GetCertificateChainResp {

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -34,20 +34,13 @@ impl<C: Crypto, P: Platform> CommandExecution<C, P> for RotateCtxCmd {
         if !dpe.support.rotate_context {
             return Err(DpeErrorCode::InvalidCommand);
         }
-        let idx = dpe
-            .get_active_context_pos(&self.handle, locality)
-            .ok_or(DpeErrorCode::InvalidHandle)?;
-
-        // Make sure the command is coming from the right locality.
-        if dpe.contexts[idx].locality != locality {
-            return Err(DpeErrorCode::InvalidHandle);
-        }
+        let idx = dpe.get_active_context_pos(&self.handle, locality)?;
 
         // Make sure caller's locality does not already have a default context.
         if self.uses_target_is_default() {
             let default_context_idx =
                 dpe.get_active_context_pos(&ContextHandle::default(), locality);
-            if default_context_idx.is_some() {
+            if default_context_idx.is_ok() {
                 return Err(DpeErrorCode::InvalidArgument);
             }
         }
@@ -134,7 +127,7 @@ mod tests {
 
         // Wrong locality.
         assert_eq!(
-            Err(DpeErrorCode::InvalidHandle),
+            Err(DpeErrorCode::InvalidLocality),
             RotateCtxCmd {
                 handle: ContextHandle::default(),
                 flags: 0,

--- a/dpe/src/commands/tag_tci.rs
+++ b/dpe/src/commands/tag_tci.rs
@@ -31,14 +31,8 @@ impl<C: Crypto, P: Platform> CommandExecution<C, P> for TagTciCmd {
             return Err(DpeErrorCode::BadTag);
         }
 
-        let idx = dpe
-            .get_active_context_pos(&self.handle, locality)
-            .ok_or(DpeErrorCode::InvalidHandle)?;
+        let idx = dpe.get_active_context_pos(&self.handle, locality)?;
 
-        // Make sure the command is coming from the right locality.
-        if dpe.contexts[idx].locality != locality {
-            return Err(DpeErrorCode::InvalidHandle);
-        }
         if dpe.contexts[idx].has_tag {
             return Err(DpeErrorCode::BadTag);
         }
@@ -128,7 +122,7 @@ mod tests {
 
         // Wrong locality.
         assert_eq!(
-            Err(DpeErrorCode::InvalidHandle),
+            Err(DpeErrorCode::InvalidLocality),
             TagTciCmd {
                 handle: ContextHandle::default(),
                 tag: 0,
@@ -178,7 +172,7 @@ mod tests {
         simulation_ctx.handle = sim_tmp_handle;
         assert!(dpe
             .get_active_context_pos(&SIMULATION_HANDLE, sim_local)
-            .is_none());
+            .is_err());
 
         // Tag simulation.
         assert_eq!(
@@ -195,9 +189,9 @@ mod tests {
         // Make sure it rotated back to the deterministic simulation handle.
         assert!(dpe
             .get_active_context_pos(&sim_tmp_handle, sim_local)
-            .is_none());
+            .is_err());
         assert!(dpe
             .get_active_context_pos(&SIMULATION_HANDLE, sim_local)
-            .is_some());
+            .is_ok());
     }
 }

--- a/dpe/src/response.rs
+++ b/dpe/src/response.rs
@@ -191,4 +191,8 @@ pub enum DpeErrorCode {
     BadTag = 0x1002,
     HandleDefined = 0x1003,
     MaxTcis = 0x1004,
+    PlatformError = 0x1005,
+    CryptoError = 0x1006,
+    HashError = 0x1007,
+    RandError = 0x1008,
 }


### PR DESCRIPTION
Fixes #57.

In this PR, we also discovered an issue where the check that ensures the DPE command is coming from the right locality is unused. This was due to how get_active_context_pos was implemented.