### PR TITLE
Set X.509 TcbInfo vendor_info to target_locality of the TCI

### DIFF
--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -65,6 +65,7 @@ impl<C: Crypto> Context<C> {
         self.handle = *args.handle;
         self.tci = TciNodeData::new();
         self.tci.tci_type = args.tci_type;
+        self.tci.locality = args.locality;
         self.children = 0;
         self.parent_idx = args.parent_idx;
         self.context_type = args.context_type;

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -61,7 +61,3 @@ pub const DPE_PROFILE: DpeProfile = DpeProfile::P256Sha256;
 
 #[cfg(feature = "dpe_profile_p384_sha384")]
 pub const DPE_PROFILE: DpeProfile = DpeProfile::P384Sha384;
-
-fn _set_flag(field: &mut u32, mask: u32, value: bool) {
-    *field = if value { *field | mask } else { *field & !mask };
-}


### PR DESCRIPTION
Also removes internal flag from TciNodeData since we don't use this in setting vendor_info anymore.