### PR TITLE
Refactor crypto to pass as an instance

### DIFF
--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -30,6 +30,7 @@ impl<C: Crypto, P: Platform> CommandExecution<C, P> for DestroyCtxCmd {
         &self,
         dpe: &mut DpeInstance<C, P>,
         locality: u32,
+        _crypto: &mut C,
     ) -> Result<Response, DpeErrorCode> {
         let idx = dpe.get_active_context_pos(&self.handle, locality)?;
         let context = &dpe.contexts[idx];

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -21,6 +21,7 @@ impl<C: Crypto, P: Platform> CommandExecution<C, P> for GetCertificateChainCmd {
         &self,
         _dpe: &mut DpeInstance<C, P>,
         _locality: u32,
+        _crypto: &mut C,
     ) -> Result<Response, DpeErrorCode> {
         // Make sure the operation is supported.
         if self.size > MAX_CERT_SIZE as u32 {
@@ -74,7 +75,10 @@ mod tests {
 
     #[test]
     fn test_fails_if_size_greater_than_max_cert_size() {
-        let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(SUPPORT).unwrap();
+        let mut crypto = OpensslCrypto::new();
+        let mut dpe =
+            DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(SUPPORT, &mut crypto)
+                .unwrap();
 
         assert_eq!(
             Err(DpeErrorCode::InvalidArgument),
@@ -82,7 +86,7 @@ mod tests {
                 size: MAX_CERT_SIZE as u32 + 1,
                 ..TEST_GET_CERTIFICATE_CHAIN_CMD
             }
-            .execute(&mut dpe, TEST_LOCALITIES[0])
+            .execute(&mut dpe, TEST_LOCALITIES[0], &mut crypto)
         );
     }
 }

--- a/dpe/src/commands/get_tagged_tci.rs
+++ b/dpe/src/commands/get_tagged_tci.rs
@@ -15,7 +15,12 @@ pub struct GetTaggedTciCmd {
 }
 
 impl<C: Crypto, P: Platform> CommandExecution<C, P> for GetTaggedTciCmd {
-    fn execute(&self, dpe: &mut DpeInstance<C, P>, _: u32) -> Result<Response, DpeErrorCode> {
+    fn execute(
+        &self,
+        dpe: &mut DpeInstance<C, P>,
+        _: u32,
+        _crypto: &mut C,
+    ) -> Result<Response, DpeErrorCode> {
         // Make sure this command is supported.
         if !dpe.support.tagging {
             return Err(DpeErrorCode::InvalidCommand);

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -122,8 +122,12 @@ impl From<Command> for u32 {
 }
 
 pub trait CommandExecution<C: Crypto, P: Platform> {
-    fn execute(&self, dpe: &mut DpeInstance<C, P>, locality: u32)
-        -> Result<Response, DpeErrorCode>;
+    fn execute(
+        &self,
+        dpe: &mut DpeInstance<C, P>,
+        locality: u32,
+        crypto: &mut C,
+    ) -> Result<Response, DpeErrorCode>;
 }
 
 // ABI Command structures


### PR DESCRIPTION
Some crypto implementations may need to hold intance data, such as driver references. To make this easier, pass the crypto trait as an instance into each DPE operation.