### PR TITLE
Remove ND Derivation

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -125,20 +125,18 @@ pub trait Crypto {
     /// * `algs` - Which length of algorithm to use.
     fn hash_initialize(&mut self, algs: AlgLen) -> Result<Self::Hasher, CryptoError>;
 
-    /// Derive a CDI based on the current base CDI and measurements as well as an optional random seed value.
+    /// Derive a CDI based on the current base CDI and measurements
     ///
     /// # Arguments
     ///
     /// * `algs` - Which length of algorithms to use.
     /// * `measurement` - A digest of the measurements which should be used for CDI derivation
     /// * `info` - Caller-supplied info string to use in CDI derivation
-    /// * `rand_seed` - Caller-supplied optional random seed to use in CDI derivation
     fn derive_cdi(
         &mut self,
         algs: AlgLen,
         measurement: &Digest,
         info: &[u8],
-        rand_seed: Option<&[u8]>,
     ) -> Result<Self::Cdi, CryptoError>;
 
     /// Derives a private key using a cryptographically secure KDF
@@ -237,7 +235,7 @@ struct BufWriter<'a> {
 impl Write for BufWriter<'_> {
     fn write_str(&mut self, s: &str) -> Result<(), Error> {
         if s.len() > self.buf.len().saturating_sub(self.offset) {
-            return Err(Error::default());
+            return Err(Error);
         }
 
         self.buf[self.offset..self.offset + s.len()].copy_from_slice(s.as_bytes());

--- a/crypto/src/openssl.rs
+++ b/crypto/src/openssl.rs
@@ -111,7 +111,6 @@ impl Crypto for OpensslCrypto {
         algs: AlgLen,
         measurement: &Digest,
         info: &[u8],
-        rand_seed: Option<&[u8]>,
     ) -> Result<Self::Cdi, CryptoError> {
         match algs {
             AlgLen::Bit256 => {
@@ -119,10 +118,6 @@ impl Crypto for OpensslCrypto {
                 let mut cdi = [0u8; AlgLen::Bit256.size()];
                 hk.expand(measurement.bytes(), &mut cdi)
                     .map_err(|_| CryptoError::CryptoLibError)?;
-                if let Some(seed) = rand_seed {
-                    hk.expand(seed, &mut cdi)
-                        .map_err(|_| CryptoError::CryptoLibError)?;
-                }
 
                 Ok(cdi.to_vec())
             }
@@ -131,10 +126,6 @@ impl Crypto for OpensslCrypto {
                 let mut cdi = [0u8; AlgLen::Bit384.size()];
                 hk.expand(measurement.bytes(), &mut cdi)
                     .map_err(|_| CryptoError::CryptoLibError)?;
-                if let Some(seed) = rand_seed {
-                    hk.expand(seed, &mut cdi)
-                        .map_err(|_| CryptoError::CryptoLibError)?;
-                }
 
                 Ok(cdi.to_vec())
             }

--- a/dpe/src/commands/extend_tci.rs
+++ b/dpe/src/commands/extend_tci.rs
@@ -29,12 +29,8 @@ impl<C: Crypto, P: Platform> CommandExecution<C, P> for ExtendTciCmd {
         if !dpe.support.extend_tci {
             return Err(DpeErrorCode::InvalidCommand);
         }
+
         let idx = dpe.get_active_context_pos(&self.handle, locality)?;
-        let context = &mut dpe.contexts[idx];
-
-        // invalidate cached private key
-        context.cached_priv_key = None;
-
         dpe.add_tci_measurement(idx, &TciMeasurement(self.data), locality, crypto)?;
 
         // Rotate the handle if it isn't the default context.
@@ -131,7 +127,6 @@ mod tests {
         // Make sure the current TCI was updated correctly.
         assert_eq!(data, default_context.tci.tci_current.0);
         // Make sure cached private key is invalidated
-        assert_eq!(None, default_context.cached_priv_key);
 
         let sim_local = TEST_LOCALITIES[1];
         dpe.support.simulation = true;

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -78,7 +78,7 @@ impl<C: Crypto, P: Platform> CommandExecution<C, P> for InitCtxCmd {
             locality,
             handle: &handle,
             tci_type: 0,
-            parent_idx: Context::<C>::ROOT_INDEX,
+            parent_idx: Context::ROOT_INDEX,
             allow_ca: true,
             allow_x509: true,
         });

--- a/dpe/src/support.rs
+++ b/dpe/src/support.rs
@@ -10,7 +10,6 @@ pub struct Support {
     pub x509: bool,
     pub csr: bool,
     pub is_symmetric: bool,
-    pub nd_derivation: bool,
     pub internal_info: bool,
     pub internal_dice: bool,
     pub is_ca: bool,
@@ -28,7 +27,6 @@ impl Support {
             | self.get_x509_flag()
             | self.get_csr_flag()
             | self.get_is_symmetric_flag()
-            | self.get_nd_derivation_flag()
             | self.get_internal_info_flag()
             | self.get_internal_dice_flag()
             | self.get_is_ca_flag()
@@ -57,17 +55,14 @@ impl Support {
     fn get_is_symmetric_flag(&self) -> u32 {
         u32::from(self.is_symmetric) << 24
     }
-    fn get_nd_derivation_flag(&self) -> u32 {
-        u32::from(self.nd_derivation) << 23
-    }
     fn get_internal_info_flag(&self) -> u32 {
-        u32::from(self.internal_info) << 22
+        u32::from(self.internal_info) << 23
     }
     fn get_internal_dice_flag(&self) -> u32 {
-        u32::from(self.internal_dice) << 21
+        u32::from(self.internal_dice) << 22
     }
     fn get_is_ca_flag(&self) -> u32 {
-        u32::from(self.is_ca) << 20
+        u32::from(self.is_ca) << 21
     }
 }
 
@@ -84,7 +79,6 @@ pub mod test {
         x509: true,
         csr: false,
         is_symmetric: false,
-        nd_derivation: false,
         internal_info: false,
         internal_dice: false,
         is_ca: false,
@@ -148,41 +142,33 @@ pub mod test {
         }
         .get_flags();
         assert_eq!(flags, 1 << 24);
-        // Supports nd derivation.
-        let flags = Support {
-            nd_derivation: true,
-            ..Support::default()
-        }
-        .get_flags();
-        assert_eq!(flags, 1 << 23);
         // Supports internal info.
         let flags = Support {
             internal_info: true,
             ..Support::default()
         }
         .get_flags();
-        assert_eq!(flags, 1 << 22);
+        assert_eq!(flags, 1 << 23);
         // Supports internal DICE.
         let flags = Support {
             internal_dice: true,
             ..Support::default()
         }
         .get_flags();
-        assert_eq!(flags, 1 << 21);
+        assert_eq!(flags, 1 << 22);
         // Supports a couple combos.
         let flags = Support {
             simulation: true,
             auto_init: true,
             rotate_context: true,
             csr: true,
-            nd_derivation: true,
             internal_dice: true,
             ..Support::default()
         }
         .get_flags();
         assert_eq!(
             flags,
-            (1 << 31) | (1 << 29) | (1 << 27) | (1 << 25) | (1 << 23) | (1 << 21)
+            (1 << 31) | (1 << 29) | (1 << 27) | (1 << 25) | (1 << 22)
         );
         let flags = Support {
             extend_tci: true,
@@ -195,7 +181,7 @@ pub mod test {
         .get_flags();
         assert_eq!(
             flags,
-            (1 << 30) | (1 << 28) | (1 << 26) | (1 << 24) | (1 << 22)
+            (1 << 30) | (1 << 28) | (1 << 26) | (1 << 24) | (1 << 23)
         );
         // Supports everything.
         let flags = Support {
@@ -207,7 +193,6 @@ pub mod test {
             x509: true,
             csr: true,
             is_symmetric: true,
-            nd_derivation: true,
             internal_info: true,
             internal_dice: true,
             is_ca: true,
@@ -226,7 +211,6 @@ pub mod test {
                 | (1 << 23)
                 | (1 << 22)
                 | (1 << 21)
-                | (1 << 20)
         );
     }
 }

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -107,10 +107,6 @@ struct Args {
     #[arg(long)]
     supports_is_symmetric: bool,
 
-    /// Supports non-deterministic key derivation.
-    #[arg(long)]
-    supports_nd_derivation: bool,
-
     /// Supports the INTERNAL_INPUT_INFO extension to DeriveChild
     #[arg(long)]
     supports_internal_info: bool,
@@ -149,7 +145,6 @@ fn main() -> std::io::Result<()> {
         csr: args.supports_csr,
         is_ca: args.supports_is_ca,
         is_symmetric: args.supports_is_symmetric,
-        nd_derivation: args.supports_nd_derivation,
         internal_info: args.supports_internal_info,
         internal_dice: args.supports_internal_dice,
     };

--- a/verification/abi.go
+++ b/verification/abi.go
@@ -74,10 +74,6 @@ type GetProfileResp struct {
 
 type CertifyKeyFlags uint32
 
-const (
-	CertifyKeyNDDerivation CertifyKeyFlags = 0x800000
-)
-
 type CertifyKeyFormat uint32
 
 const (

--- a/verification/client.go
+++ b/verification/client.go
@@ -13,7 +13,6 @@ type Support struct {
 	X509          bool
 	Csr           bool
 	IsSymmetric   bool
-	NDDerivation  bool
 	InternalInfo  bool
 	InternalDice  bool
 	IsCA          bool
@@ -241,17 +240,14 @@ func (s *Support) ToFlags() uint32 {
 	if s.IsSymmetric {
 		flags |= (1 << 24)
 	}
-	if s.NDDerivation {
+	if s.InternalInfo {
 		flags |= (1 << 23)
 	}
-	if s.InternalInfo {
+	if s.InternalDice {
 		flags |= (1 << 22)
 	}
-	if s.InternalDice {
-		flags |= (1 << 21)
-	}
 	if s.IsCA {
-		flags |= (1 << 20)
+		flags |= (1 << 21)
 	}
 	return flags
 }

--- a/verification/simulator.go
+++ b/verification/simulator.go
@@ -68,9 +68,6 @@ func (s *DpeSimulator) PowerOn() error {
 	if s.supports.IsSymmetric {
 		args = append(args, "--supports-is-symmetric")
 	}
-	if s.supports.NDDerivation {
-		args = append(args, "--supports-nd-derivation")
-	}
 	if s.supports.InternalInfo {
 		args = append(args, "--supports-internal-info")
 	}

--- a/verification/verification_test.go
+++ b/verification/verification_test.go
@@ -72,8 +72,6 @@ func TestGetProfile(t *testing.T) {
 		&DpeSimulator{exe_path: *sim_exe, supports: Support{Csr: true}},
 		// Supports symmetric derivation.
 		&DpeSimulator{exe_path: *sim_exe, supports: Support{IsSymmetric: true}},
-		// Supports non-deterministic key derivation.
-		&DpeSimulator{exe_path: *sim_exe, supports: Support{NDDerivation: true}},
 		// Supports internal info.
 		&DpeSimulator{exe_path: *sim_exe, supports: Support{InternalInfo: true}},
 		// Supports internal DICE.
@@ -84,7 +82,7 @@ func TestGetProfile(t *testing.T) {
 		&DpeSimulator{exe_path: *sim_exe, supports: Support{Simulation: true, AutoInit: true, RotateContext: true, Csr: true, InternalDice: true, IsCA: true}},
 		&DpeSimulator{exe_path: *sim_exe, supports: Support{ExtendTci: true, Tagging: true, X509: true, InternalInfo: true}},
 		// Supports everything.
-		&DpeSimulator{exe_path: *sim_exe, supports: Support{Simulation: true, ExtendTci: true, AutoInit: true, Tagging: true, RotateContext: true, X509: true, Csr: true, IsSymmetric: true, NDDerivation: true, InternalInfo: true, InternalDice: true, IsCA: true}},
+		&DpeSimulator{exe_path: *sim_exe, supports: Support{Simulation: true, ExtendTci: true, AutoInit: true, Tagging: true, RotateContext: true, X509: true, Csr: true, IsSymmetric: true, InternalInfo: true, InternalDice: true, IsCA: true}},
 	}
 
 	for _, s := range simulators {


### PR DESCRIPTION
DICE deterministic key derivation is now considered sufficient for all DPE use-cases. Remove the ND Derviation feature.