### PR TITLE
Remove Crypto and Platform templating from DpeInstance

### DIFF
--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -2,12 +2,10 @@
 use super::CommandExecution;
 use crate::{
     context::ContextHandle,
-    dpe_instance::{flags_iter, DpeInstance},
+    dpe_instance::{flags_iter, DpeEnv, DpeInstance},
     response::{DpeErrorCode, Response, ResponseHdr},
     MAX_HANDLES,
 };
-use crypto::Crypto;
-use platform::Platform;
 
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, zerocopy::FromBytes)]
@@ -25,12 +23,12 @@ impl DestroyCtxCmd {
     }
 }
 
-impl<C: Crypto, P: Platform> CommandExecution<C, P> for DestroyCtxCmd {
+impl CommandExecution for DestroyCtxCmd {
     fn execute(
         &self,
-        dpe: &mut DpeInstance<C, P>,
+        dpe: &mut DpeInstance,
+        _env: &mut impl DpeEnv,
         locality: u32,
-        _crypto: &mut C,
     ) -> Result<Response, DpeErrorCode> {
         let idx = dpe.get_active_context_pos(&self.handle, locality)?;
         let context = &dpe.contexts[idx];

--- a/dpe/src/commands/get_tagged_tci.rs
+++ b/dpe/src/commands/get_tagged_tci.rs
@@ -1,11 +1,9 @@
 // Licensed under the Apache-2.0 license.
 use super::CommandExecution;
 use crate::{
-    dpe_instance::DpeInstance,
+    dpe_instance::{DpeEnv, DpeInstance},
     response::{DpeErrorCode, GetTaggedTciResp, Response, ResponseHdr},
 };
-use crypto::Crypto;
-use platform::Platform;
 
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, zerocopy::FromBytes)]
@@ -14,12 +12,12 @@ pub struct GetTaggedTciCmd {
     tag: u32,
 }
 
-impl<C: Crypto, P: Platform> CommandExecution<C, P> for GetTaggedTciCmd {
+impl CommandExecution for GetTaggedTciCmd {
     fn execute(
         &self,
-        dpe: &mut DpeInstance<C, P>,
+        dpe: &mut DpeInstance,
+        _env: &mut impl DpeEnv,
         _: u32,
-        _crypto: &mut C,
     ) -> Result<Response, DpeErrorCode> {
         // Make sure this command is supported.
         if !dpe.support.tagging {

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -18,13 +18,11 @@ use self::sign::SignCmd;
 use self::tag_tci::TagTciCmd;
 
 use crate::{
-    dpe_instance::DpeInstance,
+    dpe_instance::{DpeEnv, DpeInstance},
     response::{DpeErrorCode, Response},
     DPE_PROFILE,
 };
 use core::mem::size_of;
-use crypto::Crypto;
-use platform::Platform;
 use zerocopy::FromBytes;
 
 mod certify_key;
@@ -121,12 +119,12 @@ impl From<Command> for u32 {
     }
 }
 
-pub trait CommandExecution<C: Crypto, P: Platform> {
+pub trait CommandExecution {
     fn execute(
         &self,
-        dpe: &mut DpeInstance<C, P>,
+        dpe: &mut DpeInstance,
+        env: &mut impl DpeEnv,
         locality: u32,
-        crypto: &mut C,
     ) -> Result<Response, DpeErrorCode>;
 }
 

--- a/platform/src/default.rs
+++ b/platform/src/default.rs
@@ -145,6 +145,7 @@ pub const TEST_CERT_CHAIN: [u8; 2048] = [
 
 impl Platform for DefaultPlatform {
     fn get_certificate_chain(
+        &mut self,
         offset: u32,
         size: u32,
         out: &mut [u8; MAX_CHUNK_SIZE],
@@ -158,15 +159,15 @@ impl Platform for DefaultPlatform {
         Ok(cert_chunk_range_end - offset)
     }
 
-    fn get_vendor_id() -> Result<u32, PlatformError> {
+    fn get_vendor_id(&mut self) -> Result<u32, PlatformError> {
         Ok(VENDOR_ID)
     }
 
-    fn get_vendor_sku() -> Result<u32, PlatformError> {
+    fn get_vendor_sku(&mut self) -> Result<u32, PlatformError> {
         Ok(VENDOR_SKU)
     }
 
-    fn get_auto_init_locality() -> Result<u32, PlatformError> {
+    fn get_auto_init_locality(&mut self) -> Result<u32, PlatformError> {
         Ok(AUTO_INIT_LOCALITY)
     }
 }

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -17,7 +17,7 @@ pub enum PlatformError {
 }
 
 pub trait Platform {
-    /// Retrieves a chunk of the parent certificates in the certificate chain.  
+    /// Retrieves a chunk of the parent certificates in the certificate chain.
     ///
     /// # Arguments
     ///
@@ -25,14 +25,15 @@ pub trait Platform {
     /// * `size` - The requested size of the chunk. Actual written number of bytes could be smaller, depending on size of chain.
     /// * `out` - Output buffer for cert chain chunk to be written to
     fn get_certificate_chain(
+        &mut self,
         offset: u32,
         size: u32,
         out: &mut [u8; MAX_CHUNK_SIZE],
     ) -> Result<u32, PlatformError>;
 
-    fn get_vendor_id() -> Result<u32, PlatformError>;
+    fn get_vendor_id(&mut self) -> Result<u32, PlatformError>;
 
-    fn get_vendor_sku() -> Result<u32, PlatformError>;
+    fn get_vendor_sku(&mut self) -> Result<u32, PlatformError>;
 
-    fn get_auto_init_locality() -> Result<u32, PlatformError>;
+    fn get_auto_init_locality(&mut self) -> Result<u32, PlatformError>;
 }

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -10,15 +10,11 @@ use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::Path;
 use std::process;
 
-use dpe::{commands::Command, response::Response, DpeInstance, Support};
+use dpe::{commands::Command, dpe_instance::DpeEnv, response::Response, DpeInstance, Support};
 
 const SOCKET_PATH: &str = "/tmp/dpe-sim.socket";
 
-fn handle_request(
-    dpe: &mut DpeInstance<OpensslCrypto, DefaultPlatform>,
-    stream: &mut UnixStream,
-    crypto: &mut OpensslCrypto,
-) {
+fn handle_request(dpe: &mut DpeInstance, env: &mut SimEnv, stream: &mut UnixStream) {
     let mut buf = [0u8; 4096];
     let (locality, cmd) = {
         let len = stream.read(&mut buf).unwrap();
@@ -36,9 +32,7 @@ fn handle_request(
     }
     trace!("|");
 
-    let response = dpe
-        .execute_serialized_command(locality, cmd, crypto)
-        .unwrap();
+    let response = dpe.execute_serialized_command(env, locality, cmd).unwrap();
 
     let response_code = match response {
         Response::GetProfile(ref res) => res.resp_hdr.status,
@@ -116,6 +110,24 @@ struct Args {
     supports_internal_dice: bool,
 }
 
+struct SimEnv {
+    platform: DefaultPlatform,
+    crypto: OpensslCrypto,
+}
+
+impl DpeEnv for SimEnv {
+    type Crypto = OpensslCrypto;
+    type Platform = DefaultPlatform;
+
+    fn crypto(&mut self) -> &mut OpensslCrypto {
+        &mut self.crypto
+    }
+
+    fn platform(&mut self) -> &mut DefaultPlatform {
+        &mut self.platform
+    }
+}
+
 fn main() -> std::io::Result<()> {
     env_logger::init();
     let args = Args::parse();
@@ -134,7 +146,6 @@ fn main() -> std::io::Result<()> {
     })
     .unwrap();
 
-    let mut crypto = OpensslCrypto::new();
     let support = Support {
         simulation: args.supports_simulation,
         extend_tci: args.supports_extend_tci,
@@ -148,20 +159,25 @@ fn main() -> std::io::Result<()> {
         internal_info: args.supports_internal_info,
         internal_dice: args.supports_internal_dice,
     };
-    let mut dpe = DpeInstance::<OpensslCrypto, DefaultPlatform>::new_for_test(support, &mut crypto)
-        .map_err(|err| {
-            Error::new(
-                ErrorKind::Other,
-                format!("{err:?} while creating new DPE instance"),
-            )
-        })?;
+
+    let mut env = SimEnv {
+        crypto: OpensslCrypto::new(),
+        platform: DefaultPlatform,
+    };
+
+    let mut dpe = DpeInstance::new_for_test(&mut env, support).map_err(|err| {
+        Error::new(
+            ErrorKind::Other,
+            format!("{err:?} while creating new DPE instance"),
+        )
+    })?;
 
     info!("DPE listening to socket {SOCKET_PATH}");
 
     for stream in listener.incoming() {
         match stream {
             Ok(mut stream) => {
-                handle_request(&mut dpe, &mut stream, &mut crypto);
+                handle_request(&mut dpe, &mut env, &mut stream);
             }
             Err(err) => {
                 error!("Failed to open socket: {err}");


### PR DESCRIPTION
Remove generics for Crypto/Platform from the codebase. Instead pass a DpeEnv around where needed.