### PR TITLE
Refactor Hasher

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -40,28 +40,17 @@ pub enum CryptoError {
     CryptoLibError,
     Size,
     NotImplemented,
+    NotInitialized,
+    HashError,
 }
 
-pub trait Hasher: Sized {
-    /// Adds a chunk to the running hash.
-    ///
-    /// # Arguments
-    ///
-    /// * `bytes` - Value to add to hash.
-    fn update(&mut self, bytes: &[u8]) -> Result<(), CryptoError>;
-
-    /// Finish a running hash operation and return the result.
-    ///
-    /// Once this function has been called, the object can no longer be used and
-    /// a new one must be created to hash more data.
-    fn finish(self) -> Result<Digest, CryptoError>;
-}
+pub trait Hasher: Sized {}
 
 pub type Digest = CryptoBuf;
 
 pub trait Crypto {
     type Cdi;
-    type Hasher: Hasher;
+    type HashCtx;
     type PrivKey;
 
     /// Fills the buffer with random values.
@@ -78,9 +67,9 @@ pub trait Crypto {
     /// * `algs` - Which length of algorithm to use.
     /// * `bytes` - Value to be hashed.
     fn hash(&mut self, algs: AlgLen, bytes: &[u8]) -> Result<Digest, CryptoError> {
-        let mut hasher = self.hash_initialize(algs)?;
-        hasher.update(bytes)?;
-        hasher.finish()
+        let mut hash_ctx = self.hash_initialize(algs)?;
+        self.hash_update(&mut hash_ctx, bytes)?;
+        self.hash_finish(&mut hash_ctx)
     }
 
     /// Compute the serial number of an ECDSA public key by computing the hash
@@ -103,11 +92,11 @@ pub trait Crypto {
             return Err(CryptoError::CryptoLibError);
         }
 
-        let mut hasher = self.hash_initialize(algs)?;
-        hasher.update(&[0x4u8])?;
-        hasher.update(pub_key.x.bytes())?;
-        hasher.update(pub_key.y.bytes())?;
-        let digest = hasher.finish()?;
+        let mut hash_ctx = self.hash_initialize(algs)?;
+        self.hash_update(&mut hash_ctx, &[0x4u8])?;
+        self.hash_update(&mut hash_ctx, pub_key.x.bytes())?;
+        self.hash_update(&mut hash_ctx, pub_key.y.bytes())?;
+        let digest = self.hash_finish(&mut hash_ctx)?;
 
         let mut w = BufWriter {
             buf: serial,
@@ -123,7 +112,20 @@ pub trait Crypto {
     /// # Arguments
     ///
     /// * `algs` - Which length of algorithm to use.
-    fn hash_initialize(&mut self, algs: AlgLen) -> Result<Self::Hasher, CryptoError>;
+    fn hash_initialize(&mut self, algs: AlgLen) -> Result<Self::HashCtx, CryptoError>;
+
+    /// Adds a chunk to the running hash.
+    ///
+    /// # Arguments
+    ///
+    /// * `bytes` - Value to add to hash.
+    fn hash_update(&mut self, ctx: &mut Self::HashCtx, bytes: &[u8]) -> Result<(), CryptoError>;
+
+    /// Finish a running hash operation and return the result.
+    ///
+    /// Once this function has been called, the object can no longer be used and
+    /// a new one must be created to hash more data.
+    fn hash_finish(&mut self, ctx: &mut Self::HashCtx) -> Result<Digest, CryptoError>;
 
     /// Derive a CDI based on the current base CDI and measurements
     ///

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -13,7 +13,7 @@ use crate::{
     DPE_PROFILE, INTERNAL_INPUT_INFO_SIZE, MAX_HANDLES,
 };
 use core::mem::size_of;
-use crypto::{Crypto, Digest, Hasher};
+use crypto::{Crypto, Digest};
 use platform::{Platform, MAX_CHUNK_SIZE};
 use zerocopy::AsBytes;
 
@@ -263,17 +263,20 @@ impl DpeInstance<'_> {
         }
 
         // Derive the new TCI as HASH(TCI_CUMULATIVE || INPUT_DATA).
-        let mut hasher = env
+        let mut hash_ctx = env
             .crypto()
             .hash_initialize(DPE_PROFILE.alg_len())
             .map_err(|_| DpeErrorCode::HashError)?;
-        hasher
-            .update(&context.tci.tci_cumulative.0)
+        env.crypto()
+            .hash_update(&mut hash_ctx, &context.tci.tci_cumulative.0)
             .map_err(|_| DpeErrorCode::HashError)?;
-        hasher
-            .update(&measurement.0)
+        env.crypto()
+            .hash_update(&mut hash_ctx, &measurement.0)
             .map_err(|_| DpeErrorCode::HashError)?;
-        let digest = hasher.finish().map_err(|_| DpeErrorCode::HashError)?;
+        let digest = env
+            .crypto()
+            .hash_finish(&mut hash_ctx)
+            .map_err(|_| DpeErrorCode::HashError)?;
 
         context.tci.tci_cumulative.0.copy_from_slice(digest.bytes());
         context.tci.tci_current = *measurement;
@@ -313,7 +316,7 @@ impl DpeInstance<'_> {
         env: &mut impl DpeEnv,
         start_idx: usize,
     ) -> Result<Digest, DpeErrorCode> {
-        let mut hasher = env
+        let mut hash_ctx = env
             .crypto()
             .hash_initialize(DPE_PROFILE.alg_len())
             .map_err(|_| DpeErrorCode::HashError)?;
@@ -327,8 +330,8 @@ impl DpeInstance<'_> {
 
             let mut tci_bytes = [0u8; size_of::<TciNodeData>()];
             let len = context.tci.serialize(&mut tci_bytes)?;
-            hasher
-                .update(&tci_bytes[..len])
+            env.crypto()
+                .hash_update(&mut hash_ctx, &tci_bytes[..len])
                 .map_err(|_| DpeErrorCode::HashError)?;
 
             // Check if any context uses internal inputs
@@ -340,8 +343,11 @@ impl DpeInstance<'_> {
         if uses_internal_input_info {
             let mut internal_input_info = [0u8; INTERNAL_INPUT_INFO_SIZE];
             self.serialize_internal_input_info(env, &mut internal_input_info)?;
-            hasher
-                .update(&internal_input_info[..INTERNAL_INPUT_INFO_SIZE])
+            env.crypto()
+                .hash_update(
+                    &mut hash_ctx,
+                    &internal_input_info[..INTERNAL_INPUT_INFO_SIZE],
+                )
                 .map_err(|_| DpeErrorCode::HashError)?;
         }
 
@@ -353,14 +359,16 @@ impl DpeInstance<'_> {
                 env.platform()
                     .get_certificate_chain(offset, MAX_CHUNK_SIZE as u32, &mut cert_chunk)
             {
-                hasher
-                    .update(&cert_chunk[..len as usize])
+                env.crypto()
+                    .hash_update(&mut hash_ctx, &cert_chunk[..len as usize])
                     .map_err(|_| DpeErrorCode::HashError)?;
                 offset += len;
             }
         }
 
-        hasher.finish().map_err(|_| DpeErrorCode::HashError)
+        env.crypto()
+            .hash_finish(&mut hash_ctx)
+            .map_err(|_| DpeErrorCode::HashError)
     }
 }
 
@@ -552,10 +560,12 @@ pub mod tests {
         assert_eq!(data, context.tci.tci_current.0);
 
         // Compute cumulative.
-        let mut hasher = env.crypto().hash_initialize(DPE_PROFILE.alg_len()).unwrap();
-        hasher.update(&[0; DPE_PROFILE.get_hash_size()]).unwrap();
-        hasher.update(&data).unwrap();
-        let first_cumulative = hasher.finish().unwrap();
+        let mut hash_ctx = env.crypto().hash_initialize(DPE_PROFILE.alg_len()).unwrap();
+        env.crypto()
+            .hash_update(&mut hash_ctx, &[0; DPE_PROFILE.get_hash_size()])
+            .unwrap();
+        env.crypto().hash_update(&mut hash_ctx, &data).unwrap();
+        let first_cumulative = env.crypto().hash_finish(&mut hash_ctx).unwrap();
 
         // Make sure the cumulative was computed correctly.
         assert_eq!(first_cumulative.bytes(), context.tci.tci_cumulative.0);
@@ -567,10 +577,12 @@ pub mod tests {
         let context = &dpe.contexts[0];
         assert_eq!(data, context.tci.tci_current.0);
 
-        let mut hasher = env.crypto().hash_initialize(DPE_PROFILE.alg_len()).unwrap();
-        hasher.update(first_cumulative.bytes()).unwrap();
-        hasher.update(&data).unwrap();
-        let second_cumulative = hasher.finish().unwrap();
+        let mut hash_ctx = env.crypto().hash_initialize(DPE_PROFILE.alg_len()).unwrap();
+        env.crypto()
+            .hash_update(&mut hash_ctx, first_cumulative.bytes())
+            .unwrap();
+        env.crypto().hash_update(&mut hash_ctx, &data).unwrap();
+        let second_cumulative = env.crypto().hash_finish(&mut hash_ctx).unwrap();
 
         // Make sure the cumulative was computed correctly.
         assert_eq!(second_cumulative.bytes(), context.tci.tci_cumulative.0);
@@ -668,17 +680,19 @@ pub mod tests {
             last_cdi = curr_cdi;
         }
 
-        let mut hasher = env.crypto().hash_initialize(DPE_PROFILE.alg_len()).unwrap();
+        let mut hash_ctx = env.crypto().hash_initialize(DPE_PROFILE.alg_len()).unwrap();
         let leaf_idx = dpe
             .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[0])
             .unwrap();
 
         for result in ChildToRootIter::new(leaf_idx, &dpe.contexts) {
             let context = result.unwrap();
-            hasher.update(context.tci.as_bytes()).unwrap();
+            env.crypto()
+                .hash_update(&mut hash_ctx, context.tci.as_bytes())
+                .unwrap();
         }
 
-        let digest = hasher.finish().unwrap();
+        let digest = env.crypto().hash_finish(&mut hash_ctx).unwrap();
         let answer = env
             .crypto()
             .derive_cdi(DPE_PROFILE.alg_len(), &digest, b"DPE")
@@ -724,18 +738,23 @@ pub mod tests {
         let context = &dpe.contexts[parent_context_idx];
         assert!(context.uses_internal_input_info);
 
-        let mut hasher = env.crypto().hash_initialize(DPE_PROFILE.alg_len()).unwrap();
+        let mut hash_ctx = env.crypto().hash_initialize(DPE_PROFILE.alg_len()).unwrap();
 
-        hasher.update(context.tci.as_bytes()).unwrap();
+        env.crypto()
+            .hash_update(&mut hash_ctx, context.tci.as_bytes())
+            .unwrap();
         let mut internal_input_info = [0u8; INTERNAL_INPUT_INFO_SIZE];
         dpe.serialize_internal_input_info(&mut env, &mut internal_input_info)
             .unwrap();
 
-        hasher
-            .update(&internal_input_info[..INTERNAL_INPUT_INFO_SIZE])
+        env.crypto()
+            .hash_update(
+                &mut hash_ctx,
+                &internal_input_info[..INTERNAL_INPUT_INFO_SIZE],
+            )
             .unwrap();
 
-        let digest = hasher.finish().unwrap();
+        let digest = env.crypto().hash_finish(&mut hash_ctx).unwrap();
         let answer = env
             .crypto()
             .derive_cdi(DPE_PROFILE.alg_len(), &digest, b"DPE")
@@ -781,12 +800,16 @@ pub mod tests {
         let context = &dpe.contexts[parent_context_idx];
         assert!(context.uses_internal_input_dice);
 
-        let mut hasher = env.crypto().hash_initialize(DPE_PROFILE.alg_len()).unwrap();
+        let mut hash_ctx = env.crypto().hash_initialize(DPE_PROFILE.alg_len()).unwrap();
 
-        hasher.update(context.tci.as_bytes()).unwrap();
-        hasher.update(&TEST_CERT_CHAIN[..MAX_CHUNK_SIZE]).unwrap();
+        env.crypto()
+            .hash_update(&mut hash_ctx, context.tci.as_bytes())
+            .unwrap();
+        env.crypto()
+            .hash_update(&mut hash_ctx, &TEST_CERT_CHAIN[..MAX_CHUNK_SIZE])
+            .unwrap();
 
-        let digest = hasher.finish().unwrap();
+        let digest = env.crypto().hash_finish(&mut hash_ctx).unwrap();
         let answer = env
             .crypto()
             .derive_cdi(DPE_PROFILE.alg_len(), &digest, b"DPE")


### PR DESCRIPTION
The ownership of the Hasher interface was very difficult to implement in practice. In particular, if the hasher needs to hold references to shared data, the lifetime of the returned hasher if very complicated.

Update this interface to return a HashCtx. The idea is that this can hold data, but does not need to own the actual hasher interface (which may be a hardware interface).