### PR TITLE
Refactor DpeEnv to borrow platform and crypto separately

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -40,6 +40,7 @@ pub enum CryptoError {
     CryptoLibError,
     Size,
     NotImplemented,
+    HashError,
 }
 
 pub trait Hasher: Sized {
@@ -61,7 +62,9 @@ pub type Digest = CryptoBuf;
 
 pub trait Crypto {
     type Cdi;
-    type Hasher: Hasher;
+    type Hasher<'c>: Hasher
+    where
+        Self: 'c;
     type PrivKey;
 
     /// Fills the buffer with random values.
@@ -123,7 +126,7 @@ pub trait Crypto {
     /// # Arguments
     ///
     /// * `algs` - Which length of algorithm to use.
-    fn hash_initialize(&mut self, algs: AlgLen) -> Result<Self::Hasher, CryptoError>;
+    fn hash_initialize(&mut self, algs: AlgLen) -> Result<Self::Hasher<'_>, CryptoError>;
 
     /// Derive a CDI based on the current base CDI and measurements
     ///

--- a/crypto/src/openssl.rs
+++ b/crypto/src/openssl.rs
@@ -76,7 +76,7 @@ type OpensslPrivKey = CryptoBuf;
 
 impl Crypto for OpensslCrypto {
     type Cdi = OpensslCdi;
-    type Hasher = OpensslHasher;
+    type Hasher<'c> = OpensslHasher where Self: 'c;
     type PrivKey = OpensslPrivKey;
 
     #[cfg(feature = "deterministic_rand")]
@@ -92,7 +92,7 @@ impl Crypto for OpensslCrypto {
         openssl::rand::rand_bytes(dst).map_err(|_| CryptoError::CryptoLibError)
     }
 
-    fn hash_initialize(&mut self, algs: AlgLen) -> Result<Self::Hasher, CryptoError> {
+    fn hash_initialize(&mut self, algs: AlgLen) -> Result<Self::Hasher<'_>, CryptoError> {
         let md = Self::get_digest(algs);
         Ok(OpensslHasher(
             openssl::hash::Hasher::new(md).map_err(|_| CryptoError::CryptoLibError)?,

--- a/dpe/src/commands/derive_child.rs
+++ b/dpe/src/commands/derive_child.rs
@@ -2,7 +2,7 @@
 use super::CommandExecution;
 use crate::{
     context::{ActiveContextArgs, ContextHandle, ContextState, ContextType},
-    dpe_instance::{DpeEnv, DpeInstance},
+    dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
     response::{DeriveChildResp, DpeErrorCode, Response, ResponseHdr},
     tci::TciMeasurement,
     DPE_PROFILE,
@@ -84,7 +84,7 @@ impl CommandExecution for DeriveChildCmd {
     fn execute(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut impl DpeEnv,
+        env: &mut DpeEnv<impl DpeTypes>,
         locality: u32,
     ) -> Result<Response, DpeErrorCode> {
         // Make sure the operation is supported.
@@ -169,7 +169,7 @@ mod tests {
     use super::*;
     use crate::{
         commands::{tests::TEST_DIGEST, Command, CommandHdr, InitCtxCmd},
-        dpe_instance::tests::{TestEnv, SIMULATION_HANDLE, TEST_LOCALITIES},
+        dpe_instance::tests::{TestTypes, SIMULATION_HANDLE, TEST_LOCALITIES},
         support::Support,
         MAX_HANDLES,
     };
@@ -199,7 +199,7 @@ mod tests {
 
     #[test]
     fn test_initial_conditions() {
-        let mut env = TestEnv {
+        let mut env = DpeEnv::<TestTypes> {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn test_max_tcis() {
-        let mut env = TestEnv {
+        let mut env = DpeEnv::<TestTypes> {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
@@ -267,7 +267,7 @@ mod tests {
 
     #[test]
     fn test_set_child_parent_relationship() {
-        let mut env = TestEnv {
+        let mut env = DpeEnv::<TestTypes> {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
@@ -308,7 +308,7 @@ mod tests {
 
     #[test]
     fn test_set_other_values() {
-        let mut env = TestEnv {
+        let mut env = DpeEnv::<TestTypes> {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
@@ -342,7 +342,7 @@ mod tests {
 
     #[test]
     fn test_correct_child_handle() {
-        let mut env = TestEnv {
+        let mut env = DpeEnv::<TestTypes> {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
@@ -392,7 +392,7 @@ mod tests {
 
     #[test]
     fn test_correct_parent_handle() {
-        let mut env = TestEnv {
+        let mut env = DpeEnv::<TestTypes> {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -2,7 +2,7 @@
 use super::CommandExecution;
 use crate::{
     context::ContextHandle,
-    dpe_instance::{flags_iter, DpeEnv, DpeInstance},
+    dpe_instance::{flags_iter, DpeEnv, DpeInstance, DpeTypes},
     response::{DpeErrorCode, Response, ResponseHdr},
     MAX_HANDLES,
 };
@@ -27,7 +27,7 @@ impl CommandExecution for DestroyCtxCmd {
     fn execute(
         &self,
         dpe: &mut DpeInstance,
-        _env: &mut impl DpeEnv,
+        _env: &mut DpeEnv<impl DpeTypes>,
         locality: u32,
     ) -> Result<Response, DpeErrorCode> {
         let idx = dpe.get_active_context_pos(&self.handle, locality)?;

--- a/dpe/src/commands/extend_tci.rs
+++ b/dpe/src/commands/extend_tci.rs
@@ -2,7 +2,7 @@
 use super::CommandExecution;
 use crate::{
     context::ContextHandle,
-    dpe_instance::{DpeEnv, DpeInstance},
+    dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
     response::{DpeErrorCode, NewHandleResp, Response, ResponseHdr},
     tci::TciMeasurement,
     DPE_PROFILE,
@@ -20,7 +20,7 @@ impl CommandExecution for ExtendTciCmd {
     fn execute(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut impl DpeEnv,
+        env: &mut DpeEnv<impl DpeTypes>,
         locality: u32,
     ) -> Result<Response, DpeErrorCode> {
         // Make sure this command is supported.
@@ -45,7 +45,7 @@ mod tests {
     use super::*;
     use crate::{
         commands::{tests::TEST_DIGEST, Command, CommandHdr, InitCtxCmd},
-        dpe_instance::tests::{TestEnv, SIMULATION_HANDLE, TEST_LOCALITIES},
+        dpe_instance::tests::{TestTypes, SIMULATION_HANDLE, TEST_LOCALITIES},
         support::Support,
     };
     use crypto::OpensslCrypto;
@@ -71,7 +71,7 @@ mod tests {
 
     #[test]
     fn test_extend_tci() {
-        let mut env = TestEnv {
+        let mut env = DpeEnv::<TestTypes> {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license.
 use super::CommandExecution;
 use crate::{
-    dpe_instance::{DpeEnv, DpeInstance},
+    dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
     response::{DpeErrorCode, GetCertificateChainResp, Response, ResponseHdr},
     MAX_CERT_SIZE,
 };
@@ -19,7 +19,7 @@ impl CommandExecution for GetCertificateChainCmd {
     fn execute(
         &self,
         _dpe: &mut DpeInstance,
-        env: &mut impl DpeEnv,
+        env: &mut DpeEnv<impl DpeTypes>,
         _locality: u32,
     ) -> Result<Response, DpeErrorCode> {
         // Make sure the operation is supported.
@@ -29,7 +29,7 @@ impl CommandExecution for GetCertificateChainCmd {
 
         let mut cert_chunk = [0u8; MAX_CHUNK_SIZE];
         let len = env
-            .platform()
+            .platform
             .get_certificate_chain(self.offset, self.size, &mut cert_chunk)
             .map_err(|platform_error| match platform_error {
                 PlatformError::CertificateChainError => DpeErrorCode::InvalidArgument,
@@ -48,7 +48,7 @@ mod tests {
     use super::*;
     use crate::{
         commands::{Command, CommandHdr},
-        dpe_instance::tests::{TestEnv, TEST_LOCALITIES},
+        dpe_instance::tests::{TestTypes, TEST_LOCALITIES},
         support::test::SUPPORT,
     };
     use crypto::OpensslCrypto;
@@ -75,7 +75,7 @@ mod tests {
 
     #[test]
     fn test_fails_if_size_greater_than_max_cert_size() {
-        let mut env = TestEnv {
+        let mut env = DpeEnv::<TestTypes> {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };

--- a/dpe/src/commands/get_tagged_tci.rs
+++ b/dpe/src/commands/get_tagged_tci.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license.
 use super::CommandExecution;
 use crate::{
-    dpe_instance::{DpeEnv, DpeInstance},
+    dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
     response::{DpeErrorCode, GetTaggedTciResp, Response, ResponseHdr},
 };
 
@@ -16,7 +16,7 @@ impl CommandExecution for GetTaggedTciCmd {
     fn execute(
         &self,
         dpe: &mut DpeInstance,
-        _env: &mut impl DpeEnv,
+        _env: &mut DpeEnv<impl DpeTypes>,
         _: u32,
     ) -> Result<Response, DpeErrorCode> {
         // Make sure this command is supported.

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -2,7 +2,7 @@
 use super::CommandExecution;
 use crate::{
     context::{ActiveContextArgs, Context, ContextHandle, ContextType},
-    dpe_instance::{DpeEnv, DpeInstance},
+    dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
     response::{DpeErrorCode, NewHandleResp, Response, ResponseHdr},
 };
 
@@ -43,7 +43,7 @@ impl CommandExecution for InitCtxCmd {
     fn execute(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut impl DpeEnv,
+        env: &mut DpeEnv<impl DpeTypes>,
         locality: u32,
     ) -> Result<Response, DpeErrorCode> {
         // This function can only be called once for non-simulation contexts.
@@ -93,7 +93,7 @@ mod tests {
     use crate::{
         commands::{Command, CommandHdr},
         context::ContextState,
-        dpe_instance::tests::{TestEnv, TEST_LOCALITIES},
+        dpe_instance::tests::{TestTypes, TEST_LOCALITIES},
         support::Support,
     };
     use crypto::OpensslCrypto;
@@ -116,7 +116,7 @@ mod tests {
 
     #[test]
     fn test_initialize_context() {
-        let mut env = TestEnv {
+        let mut env = DpeEnv::<TestTypes> {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -18,7 +18,7 @@ use self::sign::SignCmd;
 use self::tag_tci::TagTciCmd;
 
 use crate::{
-    dpe_instance::{DpeEnv, DpeInstance},
+    dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
     response::{DpeErrorCode, Response},
     DPE_PROFILE,
 };
@@ -123,7 +123,7 @@ pub trait CommandExecution {
     fn execute(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut impl DpeEnv,
+        env: &mut DpeEnv<impl DpeTypes>,
         locality: u32,
     ) -> Result<Response, DpeErrorCode>;
 }

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -2,7 +2,7 @@
 use super::CommandExecution;
 use crate::{
     context::ContextHandle,
-    dpe_instance::{DpeEnv, DpeInstance},
+    dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
     response::{DpeErrorCode, NewHandleResp, Response, ResponseHdr},
 };
 
@@ -27,7 +27,7 @@ impl CommandExecution for RotateCtxCmd {
     fn execute(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut impl DpeEnv,
+        env: &mut DpeEnv<impl DpeTypes>,
         locality: u32,
     ) -> Result<Response, DpeErrorCode> {
         if !dpe.support.rotate_context {
@@ -62,7 +62,7 @@ mod tests {
     use super::*;
     use crate::{
         commands::{Command, CommandHdr, InitCtxCmd},
-        dpe_instance::tests::{TestEnv, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES},
+        dpe_instance::tests::{TestTypes, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES},
         support::Support,
     };
     use crypto::OpensslCrypto;
@@ -89,7 +89,7 @@ mod tests {
 
     #[test]
     fn test_rotate_context() {
-        let mut env = TestEnv {
+        let mut env = DpeEnv::<TestTypes> {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };

--- a/dpe/src/commands/tag_tci.rs
+++ b/dpe/src/commands/tag_tci.rs
@@ -2,7 +2,7 @@
 use super::CommandExecution;
 use crate::{
     context::ContextHandle,
-    dpe_instance::{DpeEnv, DpeInstance},
+    dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
     response::{DpeErrorCode, NewHandleResp, Response, ResponseHdr},
 };
 
@@ -18,7 +18,7 @@ impl CommandExecution for TagTciCmd {
     fn execute(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut impl DpeEnv,
+        env: &mut DpeEnv<impl DpeTypes>,
         locality: u32,
     ) -> Result<Response, DpeErrorCode> {
         // Make sure this command is supported.
@@ -54,7 +54,7 @@ mod tests {
     use super::*;
     use crate::{
         commands::{Command, CommandHdr, InitCtxCmd},
-        dpe_instance::tests::{TestEnv, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES},
+        dpe_instance::tests::{TestTypes, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES},
         support::Support,
     };
     use crypto::OpensslCrypto;
@@ -80,7 +80,7 @@ mod tests {
 
     #[test]
     fn test_tag_tci() {
-        let mut env = TestEnv {
+        let mut env = DpeEnv::<TestTypes> {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };


### PR DESCRIPTION
Refactor the crypto and DpeEnv traits in the following ways:

1. Make Crypto Hasher a Generic Assoicated Types so it can have a specifified lifetime. This makes it possible to return a Hasher that holds a reference to the crypto type.
2. Make DpeEnv a struct and only make the types a trait. This makes it so platform and crypto are accessable as fields. This is needed so they can be borrowed separately, which allows for instantiating a hasher and still having access to the platform interface.