### PR TITLE
Remove get_ecdsa_alias_serial from Crypto trait

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -198,18 +198,6 @@ pub trait Crypto {
         priv_key: &Self::PrivKey,
     ) -> Result<EcdsaSig, CryptoError>;
 
-    /// Compute the serial number string for the alias public key
-    ///
-    /// # Arguments
-    ///
-    /// * `algs` - Length of algorithm to use.
-    /// * `serial` - Output buffer to write serial number
-    fn get_ecdsa_alias_serial(
-        &mut self,
-        algs: AlgLen,
-        serial: &mut [u8],
-    ) -> Result<(), CryptoError>;
-
     /// Sign `digest` with a derived HMAC key from the CDI.
     ///
     /// # Arguments


### PR DESCRIPTION
This function is unused since we now make the platform API
provide the whole DER-encoded name for the alias key.