### PR TITLE
Only include alias key from file if openssl is enabled

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -19,4 +19,4 @@ strum = "0.24"
 strum_macros = "0.24"
 
 [build-dependencies]
-openssl = "0.10"
+openssl = {version = "0.10", optional = true}

--- a/crypto/build.rs
+++ b/crypto/build.rs
@@ -1,32 +1,35 @@
 // Licensed under the Apache-2.0 license
 
-use {
-    fs::File,
-    openssl::{ec, nid, pkey},
-    std::env,
-    std::fs,
-    std::io::Write,
-    std::path::Path,
-};
-
 fn main() {
-    const ALIAS_PRIV: &str = "data/alias_priv.pem";
-    println!("cargo:rerun-if-changed={ALIAS_PRIV}");
+    #[cfg(feature = "openssl")]
+    {
+        use {
+            fs::File,
+            openssl::{ec, nid, pkey},
+            std::env,
+            std::fs,
+            std::io::Write,
+            std::path::Path,
+        };
 
-    let out_dir = env::var_os("OUT_DIR").unwrap();
+        const ALIAS_PRIV: &str = "data/alias_priv.pem";
+        println!("cargo:rerun-if-changed={ALIAS_PRIV}");
 
-    let pem = if Path::new(ALIAS_PRIV).exists() {
-        let input_pem = fs::read(ALIAS_PRIV).unwrap();
-        let ec_priv: ec::EcKey<pkey::Private> =
-            ec::EcKey::private_key_from_pem(&input_pem).unwrap();
-        ec_priv.private_key_to_pem().unwrap()
-    } else {
-        let group = ec::EcGroup::from_curve_name(nid::Nid::X9_62_PRIME256V1).unwrap();
-        let ec_key = ec::EcKey::generate(&group).unwrap();
-        ec_key.private_key_to_pem().unwrap()
-    };
+        let out_dir = env::var_os("OUT_DIR").unwrap();
 
-    let path = Path::new(&out_dir).join("alias_priv.pem");
-    let mut sample_alias_key_file = File::create(path).unwrap();
-    sample_alias_key_file.write_all(&pem).unwrap();
+        let pem = if Path::new(ALIAS_PRIV).exists() {
+            let input_pem = fs::read(ALIAS_PRIV).unwrap();
+            let ec_priv: ec::EcKey<pkey::Private> =
+                ec::EcKey::private_key_from_pem(&input_pem).unwrap();
+            ec_priv.private_key_to_pem().unwrap()
+        } else {
+            let group = ec::EcGroup::from_curve_name(nid::Nid::X9_62_PRIME256V1).unwrap();
+            let ec_key = ec::EcKey::generate(&group).unwrap();
+            ec_key.private_key_to_pem().unwrap()
+        };
+
+        let path = Path::new(&out_dir).join("alias_priv.pem");
+        let mut sample_alias_key_file = File::create(path).unwrap();
+        sample_alias_key_file.write_all(&pem).unwrap();
+    }
 }


### PR DESCRIPTION
Make openssl an optional feature even at build time by only including an alias key from a file when the openssl feature is enabled. This is only used with the openssl-based test crypto implementation anyway.