### PR TITLE
Derive zerocopy::FromBytes for CertifyKeyResp

### DIFF
--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -14,7 +14,7 @@ pub use self::certify_key::CertifyKeyCmd;
 use self::extend_tci::ExtendTciCmd;
 use self::get_tagged_tci::GetTaggedTciCmd;
 use self::rotate_context::RotateCtxCmd;
-use self::sign::SignCmd;
+pub use self::sign::SignCmd;
 use self::tag_tci::TagTciCmd;
 
 use crate::{

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -9,13 +9,12 @@ use crate::{
 use crypto::{Crypto, CryptoBuf, Digest, EcdsaSig, HmacSig};
 
 #[repr(C)]
-#[derive(Debug, PartialEq, Eq, zerocopy::FromBytes)]
-#[cfg_attr(test, derive(zerocopy::AsBytes))]
+#[derive(Debug, PartialEq, Eq, zerocopy::AsBytes, zerocopy::FromBytes)]
 pub struct SignCmd {
-    handle: ContextHandle,
-    label: [u8; DPE_PROFILE.get_hash_size()],
-    flags: u32,
-    digest: [u8; DPE_PROFILE.get_hash_size()],
+    pub handle: ContextHandle,
+    pub label: [u8; DPE_PROFILE.get_hash_size()],
+    pub flags: u32,
+    pub digest: [u8; DPE_PROFILE.get_hash_size()],
 }
 
 impl SignCmd {

--- a/dpe/src/response.rs
+++ b/dpe/src/response.rs
@@ -114,7 +114,7 @@ pub struct DeriveChildResp {
 }
 
 #[repr(C)]
-#[derive(Debug, PartialEq, Eq, zerocopy::AsBytes)]
+#[derive(Debug, PartialEq, Eq, zerocopy::AsBytes, zerocopy::FromBytes)]
 pub struct CertifyKeyResp {
     pub resp_hdr: ResponseHdr,
     pub new_context_handle: ContextHandle,


### PR DESCRIPTION
A few small changes made to test sign and certify_key via the invoke_dpe mbox cmd in caliptra