### PR TITLE
Refactor Support to use bitflags

### DIFF
--- a/dpe/Cargo.lock
+++ b/dpe/Cargo.lock
@@ -87,6 +87,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +205,7 @@ name = "dpe"
 version = "0.1.0"
 dependencies = [
  "asn1",
+ "bitflags 2.4.0",
  "crypto",
  "openssl",
  "platform",
@@ -340,7 +347,7 @@ version = "0.10.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd2523381e46256e40930512c7fd25562b9eae4812cb52078f155e87217c9d1e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",

--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -11,6 +11,7 @@ dpe_profile_p256_sha256 = []
 dpe_profile_p384_sha384 = []
 
 [dependencies]
+bitflags = "2.4.0"
 crypto = {path = "../crypto"}
 platform = {path = "../platform"}
 zerocopy = "0.6.1"

--- a/dpe/fuzz/src/fuzz_target_1.rs
+++ b/dpe/fuzz/src/fuzz_target_1.rs
@@ -17,23 +17,11 @@ use std::fs::OpenOptions;
 
 use crypto::OpensslCrypto;
 use dpe::dpe_instance::{DpeEnv, DpeTypes};
-use dpe::{commands::Command, response::Response, DpeInstance, Support};
+use dpe::{commands::Command, response::Response, DpeInstance, support::Support};
 use platform::{DefaultPlatform, AUTO_INIT_LOCALITY};
 
 // https://github.com/chipsalliance/caliptra-sw/issues/624 will consider matrix fuzzing.
-const SUPPORT: Support = Support {
-    simulation: true,
-    extend_tci: true,
-    auto_init: true,
-    tagging: true,
-    rotate_context: true,
-    x509: true,
-    csr: true,
-    is_ca: true,
-    is_symmetric: true,
-    internal_info: true,
-    internal_dice: true,
-};
+const SUPPORT: Support = Support::all();
 
 struct SimTypes {}
 

--- a/dpe/src/commands/extend_tci.rs
+++ b/dpe/src/commands/extend_tci.rs
@@ -47,7 +47,6 @@ mod tests {
         commands::{tests::TEST_DIGEST, Command, CommandHdr, InitCtxCmd},
         dpe_instance::tests::{TestTypes, SIMULATION_HANDLE, TEST_LOCALITIES},
         support::Support,
-        U8Bool,
     };
     use crypto::OpensslCrypto;
     use platform::{DefaultPlatform, AUTO_INIT_LOCALITY};
@@ -88,7 +87,7 @@ mod tests {
         );
 
         // Turn on support.
-        dpe.support.extend_tci = U8Bool::new(true);
+        dpe.support = dpe.support | Support::EXTEND_TCI;
         InitCtxCmd::new_use_default()
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
             .unwrap();
@@ -127,7 +126,7 @@ mod tests {
         // Make sure cached private key is invalidated
 
         let sim_local = TEST_LOCALITIES[1];
-        dpe.support.simulation = U8Bool::new(true);
+        dpe.support = dpe.support | Support::SIMULATION;
         InitCtxCmd::new_simulation()
             .execute(&mut dpe, &mut env, sim_local)
             .unwrap();

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -4,12 +4,12 @@ Licensed under the Apache-2.0 license.
 Abstract:
     DPE Commands and deserialization.
 --*/
-pub use self::derive_child::DeriveChildCmd;
+pub use self::derive_child::{DeriveChildCmd, DeriveChildFlags};
 pub(crate) use self::destroy_context::DestroyCtxCmd;
 pub(crate) use self::get_certificate_chain::GetCertificateChainCmd;
 pub use self::initialize_context::InitCtxCmd;
 
-pub use self::certify_key::CertifyKeyCmd;
+pub use self::certify_key::{CertifyKeyCmd, CertifyKeyFlags};
 
 use self::extend_tci::ExtendTciCmd;
 use self::get_tagged_tci::GetTaggedTciCmd;

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -6,22 +6,31 @@ use crate::{
     response::{DpeErrorCode, Response, ResponseHdr, SignResp},
     DPE_PROFILE,
 };
+use bitflags::bitflags;
 use crypto::{Crypto, CryptoBuf, Digest, EcdsaSig, HmacSig};
+
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq, zerocopy::AsBytes, zerocopy::FromBytes)]
+pub struct SignFlags(u32);
+
+bitflags! {
+    impl SignFlags: u32 {
+        const IS_SYMMETRIC = 1u32 << 31;
+    }
+}
 
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, zerocopy::AsBytes, zerocopy::FromBytes)]
 pub struct SignCmd {
     pub handle: ContextHandle,
     pub label: [u8; DPE_PROFILE.get_hash_size()],
-    pub flags: u32,
+    pub flags: SignFlags,
     pub digest: [u8; DPE_PROFILE.get_hash_size()],
 }
 
 impl SignCmd {
-    const IS_SYMMETRIC: u32 = 1 << 31;
-
     const fn uses_symmetric(&self) -> bool {
-        self.flags & Self::IS_SYMMETRIC != 0
+        self.flags.contains(SignFlags::IS_SYMMETRIC)
     }
 
     fn ecdsa_sign(
@@ -121,12 +130,12 @@ mod tests {
     use super::*;
     use crate::{
         commands::{
-            certify_key::CertifyKeyCmd, tests::TEST_DIGEST, Command, CommandHdr, DeriveChildCmd,
-            InitCtxCmd,
+            certify_key::CertifyKeyCmd, certify_key::CertifyKeyFlags,
+            derive_child::DeriveChildFlags, tests::TEST_DIGEST, Command, CommandHdr,
+            DeriveChildCmd, InitCtxCmd,
         },
         dpe_instance::tests::{TestTypes, SIMULATION_HANDLE, TEST_LOCALITIES},
         support::{test::SUPPORT, Support},
-        U8Bool,
     };
     use crypto::OpensslCrypto;
     use openssl::x509::X509;
@@ -148,7 +157,7 @@ mod tests {
     const TEST_SIGN_CMD: SignCmd = SignCmd {
         handle: SIMULATION_HANDLE,
         label: TEST_LABEL,
-        flags: 0x1234_5678,
+        flags: SignFlags(0x1234_5678),
         digest: TEST_DIGEST,
     };
 
@@ -168,14 +177,14 @@ mod tests {
     fn test_uses_symmetric() {
         // No flags set.
         assert!(!SignCmd {
-            flags: 0,
+            flags: SignFlags::empty(),
             ..TEST_SIGN_CMD
         }
         .uses_symmetric());
 
         // Just is-symmetric flag set.
         assert!(SignCmd {
-            flags: SignCmd::IS_SYMMETRIC,
+            flags: SignFlags::IS_SYMMETRIC,
             ..TEST_SIGN_CMD
         }
         .uses_symmetric());
@@ -195,7 +204,7 @@ mod tests {
             SignCmd {
                 handle: ContextHandle([0xff; ContextHandle::SIZE]),
                 label: TEST_LABEL,
-                flags: SignCmd::IS_SYMMETRIC,
+                flags: SignFlags::IS_SYMMETRIC,
                 digest: TEST_DIGEST
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -207,7 +216,7 @@ mod tests {
             SignCmd {
                 handle: ContextHandle([0xff; ContextHandle::SIZE]),
                 label: TEST_LABEL,
-                flags: 0,
+                flags: SignFlags::empty(),
                 digest: TEST_DIGEST
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -222,7 +231,7 @@ mod tests {
             SignCmd {
                 handle: ContextHandle::default(),
                 label: TEST_LABEL,
-                flags: 0,
+                flags: SignFlags::empty(),
                 digest: TEST_DIGEST
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])
@@ -240,7 +249,7 @@ mod tests {
             SignCmd {
                 handle: SIMULATION_HANDLE,
                 label: TEST_LABEL,
-                flags: 0,
+                flags: SignFlags::empty(),
                 digest: TEST_DIGEST
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -259,7 +268,7 @@ mod tests {
             DeriveChildCmd {
                 handle: ContextHandle::default(),
                 data: [i; DPE_PROFILE.get_hash_size()],
-                flags: DeriveChildCmd::MAKE_DEFAULT | DeriveChildCmd::INPUT_ALLOW_X509,
+                flags: DeriveChildFlags::MAKE_DEFAULT | DeriveChildFlags::INPUT_ALLOW_X509,
                 tci_type: i as u32,
                 target_locality: 0,
             }
@@ -271,7 +280,7 @@ mod tests {
             let cmd = SignCmd {
                 handle: ContextHandle::default(),
                 label: TEST_LABEL,
-                flags: 0,
+                flags: SignFlags::empty(),
                 digest: TEST_DIGEST,
             };
             let resp = match cmd.execute(&mut dpe, &mut env, TEST_LOCALITIES[0]).unwrap() {
@@ -289,7 +298,7 @@ mod tests {
         let ec_pub_key = {
             let cmd = CertifyKeyCmd {
                 handle: ContextHandle::default(),
-                flags: 0,
+                flags: CertifyKeyFlags::empty(),
                 label: TEST_LABEL,
                 format: CertifyKeyCmd::FORMAT_X509,
             };
@@ -312,20 +321,13 @@ mod tests {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
-        let mut dpe = DpeInstance::new(
-            &mut env,
-            Support {
-                auto_init: U8Bool::new(true),
-                is_symmetric: U8Bool::new(true),
-                ..Support::default()
-            },
-        )
-        .unwrap();
+        let mut dpe =
+            DpeInstance::new(&mut env, Support::AUTO_INIT | Support::IS_SYMMETRIC).unwrap();
 
         let cmd = SignCmd {
             handle: ContextHandle::default(),
             label: TEST_LABEL,
-            flags: SignCmd::IS_SYMMETRIC,
+            flags: SignFlags::IS_SYMMETRIC,
             digest: TEST_DIGEST,
         };
         let resp = match cmd.execute(&mut dpe, &mut env, TEST_LOCALITIES[0]).unwrap() {

--- a/dpe/src/commands/tag_tci.rs
+++ b/dpe/src/commands/tag_tci.rs
@@ -60,7 +60,6 @@ mod tests {
         commands::{Command, CommandHdr, InitCtxCmd},
         dpe_instance::tests::{TestTypes, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES},
         support::Support,
-        U8Bool,
     };
     use crypto::OpensslCrypto;
     use platform::DefaultPlatform;
@@ -101,15 +100,7 @@ mod tests {
         );
 
         // Make a new instance that supports tagging.
-        let mut dpe = DpeInstance::new(
-            &mut env,
-            Support {
-                tagging: U8Bool::new(true),
-                simulation: U8Bool::new(true),
-                ..Support::default()
-            },
-        )
-        .unwrap();
+        let mut dpe = DpeInstance::new(&mut env, Support::TAGGING | Support::SIMULATION).unwrap();
         InitCtxCmd::new_use_default()
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
             .unwrap();

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -37,6 +37,9 @@ pub struct DpeInstance {
     /// Can only successfully execute the initialize context command for non-simulation (i.e.
     /// `InitializeContext(simulation=false)`) once per reset cycle.
     pub(crate) has_initialized: U8Bool,
+
+    // unused buffer added to make DpeInstance word aligned and remove padding
+    reserved: [u8; 3],
 }
 
 impl DpeInstance {
@@ -57,6 +60,7 @@ impl DpeInstance {
             contexts: [CONTEXT_INITIALIZER; MAX_HANDLES],
             support,
             has_initialized: false.into(),
+            reserved: [0u8; 3],
         };
 
         if dpe.support.auto_init() {
@@ -84,7 +88,7 @@ impl DpeInstance {
             .get_vendor_sku()
             .map_err(|_| DpeErrorCode::PlatformError)?;
         Ok(GetProfileResp::new(
-            self.support.get_flags(),
+            self.support.bits(),
             vendor_id,
             vendor_sku,
         ))
@@ -419,10 +423,10 @@ impl Iterator for FlagsIter {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::commands::DeriveChildCmd;
+    use crate::commands::{DeriveChildCmd, DeriveChildFlags};
     use crate::response::NewHandleResp;
     use crate::support::test::SUPPORT;
-    use crate::{commands::CommandHdr, U8Bool, CURRENT_PROFILE_MAJOR_VERSION};
+    use crate::{commands::CommandHdr, CURRENT_PROFILE_MAJOR_VERSION};
     use crypto::OpensslCrypto;
     use platform::{DefaultPlatform, AUTO_INIT_LOCALITY, MAX_CHUNK_SIZE, TEST_CERT_CHAIN};
     use zerocopy::AsBytes;
@@ -450,7 +454,7 @@ pub mod tests {
 
         assert_eq!(
             Response::GetProfile(GetProfileResp::new(
-                SUPPORT.get_flags(),
+                SUPPORT.bits(),
                 env.platform.get_vendor_id().unwrap(),
                 env.platform.get_vendor_sku().unwrap()
             )),
@@ -487,7 +491,7 @@ pub mod tests {
         let dpe = DpeInstance::new(&mut env, SUPPORT).unwrap();
         let profile = dpe.get_profile(&mut env.platform).unwrap();
         assert_eq!(profile.major_version, CURRENT_PROFILE_MAJOR_VERSION);
-        assert_eq!(profile.flags, SUPPORT.get_flags());
+        assert_eq!(profile.flags, SUPPORT.bits());
     }
 
     #[test]
@@ -534,14 +538,7 @@ pub mod tests {
             platform: DefaultPlatform,
         };
 
-        let mut dpe = DpeInstance::new(
-            &mut env,
-            Support {
-                auto_init: U8Bool::new(true),
-                ..Default::default()
-            },
-        )
-        .unwrap();
+        let mut dpe = DpeInstance::new(&mut env, Support::AUTO_INIT).unwrap();
 
         // Verify bounds checking.
         assert_eq!(
@@ -654,7 +651,7 @@ pub mod tests {
             DeriveChildCmd {
                 handle: ContextHandle::default(),
                 data: [i; DPE_PROFILE.get_hash_size()],
-                flags: DeriveChildCmd::MAKE_DEFAULT,
+                flags: DeriveChildFlags::MAKE_DEFAULT,
                 tci_type: i as u32,
                 target_locality: 0,
             }
@@ -701,14 +698,7 @@ pub mod tests {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
-        let mut dpe = DpeInstance::new(
-            &mut env,
-            Support {
-                internal_info: U8Bool::new(true),
-                ..SUPPORT
-            },
-        )
-        .unwrap();
+        let mut dpe = DpeInstance::new(&mut env, SUPPORT | Support::INTERNAL_INFO).unwrap();
 
         let parent_context_idx = dpe
             .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[0])
@@ -716,7 +706,7 @@ pub mod tests {
         DeriveChildCmd {
             handle: ContextHandle::default(),
             data: [0; DPE_PROFILE.get_hash_size()],
-            flags: DeriveChildCmd::MAKE_DEFAULT | DeriveChildCmd::INTERNAL_INPUT_INFO,
+            flags: DeriveChildFlags::MAKE_DEFAULT | DeriveChildFlags::INTERNAL_INPUT_INFO,
             tci_type: 0u32,
             target_locality: 0,
         }
@@ -758,14 +748,7 @@ pub mod tests {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
-        let mut dpe = DpeInstance::new(
-            &mut env,
-            Support {
-                internal_dice: U8Bool::new(true),
-                ..SUPPORT
-            },
-        )
-        .unwrap();
+        let mut dpe = DpeInstance::new(&mut env, SUPPORT | Support::INTERNAL_DICE).unwrap();
 
         let parent_context_idx = dpe
             .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[0])
@@ -773,7 +756,7 @@ pub mod tests {
         DeriveChildCmd {
             handle: ContextHandle::default(),
             data: [0; DPE_PROFILE.get_hash_size()],
-            flags: DeriveChildCmd::MAKE_DEFAULT | DeriveChildCmd::INTERNAL_INPUT_DICE,
+            flags: DeriveChildFlags::MAKE_DEFAULT | DeriveChildFlags::INTERNAL_INPUT_DICE,
             tci_type: 0u32,
             target_locality: 0,
         }

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -7,7 +7,6 @@ Abstract:
 #![cfg_attr(not(test), no_std)]
 
 pub use dpe_instance::DpeInstance;
-pub use support::Support;
 
 pub mod commands;
 pub mod context;

--- a/dpe/src/support.rs
+++ b/dpe/src/support.rs
@@ -1,105 +1,60 @@
 // Licensed under the Apache-2.0 license.
-use crate::U8Bool;
+use bitflags::bitflags;
 use zerocopy::{AsBytes, FromBytes};
 
 #[derive(Default, AsBytes, FromBytes)]
 #[repr(C)]
-pub struct Support {
-    pub simulation: U8Bool,
-    pub extend_tci: U8Bool,
-    pub auto_init: U8Bool,
-    pub tagging: U8Bool,
-    pub rotate_context: U8Bool,
-    pub x509: U8Bool,
-    pub csr: U8Bool,
-    pub is_symmetric: U8Bool,
-    pub internal_info: U8Bool,
-    pub internal_dice: U8Bool,
-    pub is_ca: U8Bool,
+pub struct Support(u32);
+
+bitflags! {
+    impl Support: u32 {
+        const SIMULATION = 1u32 << 31;
+        const EXTEND_TCI = 1u32 << 30;
+        const AUTO_INIT = 1u32 << 29;
+        const TAGGING = 1u32 << 28;
+        const ROTATE_CONTEXT = 1u32 << 27;
+        const X509 = 1u32 << 26;
+        const CSR = 1u32 << 25;
+        const IS_SYMMETRIC = 1u32 << 24;
+        const INTERNAL_INFO = 1u32 << 23;
+        const INTERNAL_DICE = 1u32 << 22;
+        const IS_CA = 1u32 << 21;
+    }
 }
 
 impl Support {
     pub fn simulation(&self) -> bool {
-        self.simulation.get()
+        self.contains(Support::SIMULATION)
     }
     pub fn extend_tci(&self) -> bool {
-        self.extend_tci.get()
+        self.contains(Support::EXTEND_TCI)
     }
     pub fn auto_init(&self) -> bool {
-        self.auto_init.get()
+        self.contains(Support::AUTO_INIT)
     }
     pub fn tagging(&self) -> bool {
-        self.tagging.get()
+        self.contains(Support::TAGGING)
     }
     pub fn rotate_context(&self) -> bool {
-        self.rotate_context.get()
+        self.contains(Support::ROTATE_CONTEXT)
     }
     pub fn x509(&self) -> bool {
-        self.x509.get()
+        self.contains(Support::X509)
     }
     pub fn csr(&self) -> bool {
-        self.csr.get()
+        self.contains(Support::CSR)
     }
     pub fn is_symmetric(&self) -> bool {
-        self.is_symmetric.get()
+        self.contains(Support::IS_SYMMETRIC)
     }
     pub fn internal_info(&self) -> bool {
-        self.internal_info.get()
+        self.contains(Support::INTERNAL_INFO)
     }
     pub fn internal_dice(&self) -> bool {
-        self.internal_dice.get()
+        self.contains(Support::INTERNAL_DICE)
     }
     pub fn is_ca(&self) -> bool {
-        self.is_ca.get()
-    }
-
-    /// Returns all the flags bit-wise OR'ed together in the same configuration as the `GetProfile`
-    /// command.
-    pub fn get_flags(&self) -> u32 {
-        self.get_simulation_flag()
-            | self.get_extend_tci_flag()
-            | self.get_auto_init_flag()
-            | self.get_tagging_flag()
-            | self.get_rotate_context_flag()
-            | self.get_x509_flag()
-            | self.get_csr_flag()
-            | self.get_is_symmetric_flag()
-            | self.get_internal_info_flag()
-            | self.get_internal_dice_flag()
-            | self.get_is_ca_flag()
-    }
-    fn get_simulation_flag(&self) -> u32 {
-        u32::from(self.simulation.get()) << 31
-    }
-    fn get_extend_tci_flag(&self) -> u32 {
-        u32::from(self.extend_tci.get()) << 30
-    }
-    fn get_auto_init_flag(&self) -> u32 {
-        u32::from(self.auto_init.get()) << 29
-    }
-    fn get_tagging_flag(&self) -> u32 {
-        u32::from(self.tagging.get()) << 28
-    }
-    fn get_rotate_context_flag(&self) -> u32 {
-        u32::from(self.rotate_context.get()) << 27
-    }
-    fn get_x509_flag(&self) -> u32 {
-        u32::from(self.x509.get()) << 26
-    }
-    fn get_csr_flag(&self) -> u32 {
-        u32::from(self.csr.get()) << 25
-    }
-    fn get_is_symmetric_flag(&self) -> u32 {
-        u32::from(self.is_symmetric.get()) << 24
-    }
-    fn get_internal_info_flag(&self) -> u32 {
-        u32::from(self.internal_info.get()) << 23
-    }
-    fn get_internal_dice_flag(&self) -> u32 {
-        u32::from(self.internal_dice.get()) << 22
-    }
-    fn get_is_ca_flag(&self) -> u32 {
-        u32::from(self.is_ca.get()) << 21
+        self.contains(Support::IS_CA)
     }
 }
 
@@ -107,134 +62,75 @@ impl Support {
 pub mod test {
     use super::*;
 
-    pub const SUPPORT: Support = Support {
-        simulation: U8Bool::new(true),
-        extend_tci: U8Bool::new(false),
-        auto_init: U8Bool::new(true),
-        tagging: U8Bool::new(true),
-        rotate_context: U8Bool::new(true),
-        x509: U8Bool::new(true),
-        csr: U8Bool::new(false),
-        is_symmetric: U8Bool::new(false),
-        internal_info: U8Bool::new(false),
-        internal_dice: U8Bool::new(false),
-        is_ca: U8Bool::new(false),
-    };
+    pub const SUPPORT: Support = Support::union(
+        Support::union(
+            Support::union(
+                Support::union(Support::SIMULATION, Support::AUTO_INIT),
+                Support::TAGGING,
+            ),
+            Support::ROTATE_CONTEXT,
+        ),
+        Support::X509,
+    );
 
     #[test]
     fn test_get_support_flags() {
         // Supports simulation flag.
-        let flags = Support {
-            simulation: U8Bool::new(true),
-            ..Support::default()
-        }
-        .get_flags();
+        let flags = Support::SIMULATION.bits();
         assert_eq!(flags, 1 << 31);
         // Supports extended TCI flag.
-        let flags = Support {
-            extend_tci: U8Bool::new(true),
-            ..Support::default()
-        }
-        .get_flags();
+        let flags = Support::EXTEND_TCI.bits();
         assert_eq!(flags, 1 << 30);
         // Supports auto-init.
-        let flags = Support {
-            auto_init: U8Bool::new(true),
-            ..Support::default()
-        }
-        .get_flags();
+        let flags = Support::AUTO_INIT.bits();
         assert_eq!(flags, 1 << 29);
         // Supports tagging.
-        let flags = Support {
-            tagging: U8Bool::new(true),
-            ..Support::default()
-        }
-        .get_flags();
+        let flags = Support::TAGGING.bits();
         assert_eq!(flags, 1 << 28);
         // Supports rotate context.
-        let flags = Support {
-            rotate_context: U8Bool::new(true),
-            ..Support::default()
-        }
-        .get_flags();
+        let flags = Support::ROTATE_CONTEXT.bits();
         assert_eq!(flags, 1 << 27);
         // Supports certify key.
-        let flags = Support {
-            x509: U8Bool::new(true),
-            ..Support::default()
-        }
-        .get_flags();
+        let flags = Support::X509.bits();
         assert_eq!(flags, 1 << 26);
         // Supports certify csr.
-        let flags = Support {
-            csr: U8Bool::new(true),
-            ..Support::default()
-        }
-        .get_flags();
+        let flags = Support::CSR.bits();
         assert_eq!(flags, 1 << 25);
         // Supports is symmetric.
-        let flags = Support {
-            is_symmetric: U8Bool::new(true),
-            ..Support::default()
-        }
-        .get_flags();
+        let flags = Support::IS_SYMMETRIC.bits();
         assert_eq!(flags, 1 << 24);
         // Supports internal info.
-        let flags = Support {
-            internal_info: U8Bool::new(true),
-            ..Support::default()
-        }
-        .get_flags();
+        let flags = Support::INTERNAL_INFO.bits();
         assert_eq!(flags, 1 << 23);
         // Supports internal DICE.
-        let flags = Support {
-            internal_dice: U8Bool::new(true),
-            ..Support::default()
-        }
-        .get_flags();
+        let flags = Support::INTERNAL_DICE.bits();
         assert_eq!(flags, 1 << 22);
+        // Supports is ca.
+        let flags = Support::IS_CA.bits();
+        assert_eq!(flags, 1 << 21);
         // Supports a couple combos.
-        let flags = Support {
-            simulation: U8Bool::new(true),
-            auto_init: U8Bool::new(true),
-            rotate_context: U8Bool::new(true),
-            csr: U8Bool::new(true),
-            internal_dice: U8Bool::new(true),
-            ..Support::default()
-        }
-        .get_flags();
+        let flags = (Support::SIMULATION
+            | Support::AUTO_INIT
+            | Support::ROTATE_CONTEXT
+            | Support::CSR
+            | Support::INTERNAL_DICE)
+            .bits();
         assert_eq!(
             flags,
             (1 << 31) | (1 << 29) | (1 << 27) | (1 << 25) | (1 << 22)
         );
-        let flags = Support {
-            extend_tci: U8Bool::new(true),
-            tagging: U8Bool::new(true),
-            x509: U8Bool::new(true),
-            is_symmetric: U8Bool::new(true),
-            internal_info: U8Bool::new(true),
-            ..Support::default()
-        }
-        .get_flags();
+        let flags = (Support::EXTEND_TCI
+            | Support::TAGGING
+            | Support::X509
+            | Support::IS_SYMMETRIC
+            | Support::INTERNAL_INFO)
+            .bits();
         assert_eq!(
             flags,
             (1 << 30) | (1 << 28) | (1 << 26) | (1 << 24) | (1 << 23)
         );
         // Supports everything.
-        let flags = Support {
-            simulation: U8Bool::new(true),
-            extend_tci: U8Bool::new(true),
-            auto_init: U8Bool::new(true),
-            tagging: U8Bool::new(true),
-            rotate_context: U8Bool::new(true),
-            x509: U8Bool::new(true),
-            csr: U8Bool::new(true),
-            is_symmetric: U8Bool::new(true),
-            internal_info: U8Bool::new(true),
-            internal_dice: U8Bool::new(true),
-            is_ca: U8Bool::new(true),
-        }
-        .get_flags();
+        let flags = Support::all().bits();
         assert_eq!(
             flags,
             (1 << 31)

--- a/simulator/Cargo.lock
+++ b/simulator/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,7 +68,7 @@ version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
  "is-terminal",
@@ -147,6 +153,7 @@ dependencies = [
 name = "dpe"
 version = "0.1.0"
 dependencies = [
+ "bitflags 2.4.0",
  "crypto",
  "platform",
  "zerocopy",
@@ -302,7 +309,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "static_assertions",
@@ -320,7 +327,7 @@ version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -434,7 +441,7 @@ version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -14,7 +14,8 @@ use dpe::{
     commands::Command,
     dpe_instance::{DpeEnv, DpeTypes},
     response::Response,
-    DpeInstance, Support,
+    support::Support,
+    DpeInstance,
 };
 
 const SOCKET_PATH: &str = "/tmp/dpe-sim.socket";
@@ -140,19 +141,18 @@ fn main() -> std::io::Result<()> {
     })
     .unwrap();
 
-    let support = Support {
-        simulation: args.supports_simulation.into(),
-        extend_tci: args.supports_extend_tci.into(),
-        auto_init: args.supports_auto_init.into(),
-        tagging: args.supports_tagging.into(),
-        rotate_context: args.supports_rotate_context.into(),
-        x509: args.supports_x509.into(),
-        csr: args.supports_csr.into(),
-        is_ca: args.supports_is_ca.into(),
-        is_symmetric: args.supports_is_symmetric.into(),
-        internal_info: args.supports_internal_info.into(),
-        internal_dice: args.supports_internal_dice.into(),
-    };
+    let mut support = Support::default();
+    support.set(Support::SIMULATION, args.supports_simulation);
+    support.set(Support::AUTO_INIT, args.supports_auto_init);
+    support.set(Support::X509, args.supports_x509);
+    support.set(Support::CSR, args.supports_csr);
+    support.set(Support::EXTEND_TCI, args.supports_extend_tci);
+    support.set(Support::ROTATE_CONTEXT, args.supports_rotate_context);
+    support.set(Support::INTERNAL_DICE, args.supports_internal_dice);
+    support.set(Support::INTERNAL_INFO, args.supports_internal_info);
+    support.set(Support::IS_CA, args.supports_is_ca);
+    support.set(Support::IS_SYMMETRIC, args.supports_is_symmetric);
+    support.set(Support::TAGGING, args.supports_tagging);
 
     let mut env = DpeEnv::<SimTypes> {
         crypto: OpensslCrypto::new(),

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "base64"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +19,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block-buffer"
@@ -54,6 +66,7 @@ dependencies = [
 name = "crypto"
 version = "0.1.0"
 dependencies = [
+ "arrayvec",
  "hkdf",
  "openssl",
  "sha2",
@@ -84,6 +97,7 @@ dependencies = [
 name = "dpe"
 version = "0.1.0"
 dependencies = [
+ "bitflags 2.4.0",
  "crypto",
  "platform",
  "zerocopy",
@@ -150,7 +164,7 @@ version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",

--- a/tools/src/sample_dpe_cert.rs
+++ b/tools/src/sample_dpe_cert.rs
@@ -2,11 +2,11 @@
 
 use {
     crypto::OpensslCrypto,
-    dpe::commands::{self, CertifyKeyCmd, CommandHdr},
+    dpe::commands::{self, CertifyKeyCmd, CertifyKeyFlags, CommandHdr},
     dpe::context::ContextHandle,
     dpe::dpe_instance::{DpeEnv, DpeTypes},
     dpe::response::Response,
-    dpe::{DpeInstance, Support, DPE_PROFILE},
+    dpe::{support::Support, DpeInstance, DPE_PROFILE},
     pem::{encode_config, EncodeConfig, LineEnding, Pem},
     platform::DefaultPlatform,
     zerocopy::AsBytes,
@@ -20,11 +20,7 @@ impl DpeTypes for TestTypes {
 }
 
 fn main() {
-    let support = Support {
-        auto_init: true.into(),
-        x509: true.into(),
-        ..Support::default()
-    };
+    let support = Support::AUTO_INIT | Support::X509;
 
     let mut env = DpeEnv::<TestTypes> {
         crypto: OpensslCrypto::new(),
@@ -35,7 +31,7 @@ fn main() {
 
     let certify_key_cmd: CertifyKeyCmd = commands::CertifyKeyCmd {
         handle: ContextHandle::default(),
-        flags: 0,
+        flags: CertifyKeyFlags::empty(),
         label: [0; DPE_PROFILE.get_hash_size()],
         format: commands::CertifyKeyCmd::FORMAT_X509,
     };


### PR DESCRIPTION
Also refactor flags passed to each DPE command to use bitflags instead of u32.