### PR TITLE
Add lifetime parameter to Platform

### DIFF
--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -20,12 +20,14 @@ pub trait DpeTypes {
     type Crypto<'a>: Crypto
     where
         Self: 'a;
-    type Platform: Platform;
+    type Platform<'a>: Platform
+    where
+        Self: 'a;
 }
 
 pub struct DpeEnv<'a, T: DpeTypes + 'a> {
     pub crypto: T::Crypto<'a>,
-    pub platform: T::Platform,
+    pub platform: T::Platform<'a>,
 }
 
 #[repr(C, align(4))]
@@ -434,7 +436,7 @@ pub mod tests {
     pub struct TestTypes;
     impl DpeTypes for TestTypes {
         type Crypto<'a> = OpensslCrypto;
-        type Platform = DefaultPlatform;
+        type Platform<'a> = DefaultPlatform;
     }
 
     pub const TEST_HANDLE: ContextHandle =

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -527,7 +527,7 @@ impl X509CertWriter<'_> {
     ///     printableString   PrintableString (SIZE (1..ub-common-name)),
     ///     ...
     ///     }
-    fn encode_rdn(&mut self, name: &Name) -> Result<usize, DpeErrorCode> {
+    pub fn encode_rdn(&mut self, name: &Name) -> Result<usize, DpeErrorCode> {
         let cn_size =
             Self::get_structure_size(Self::RDN_COMMON_NAME_OID.len(), /*tagged=*/ true)?
                 + Self::get_structure_size(name.cn.len(), /*tagged=*/ true)?;

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -120,7 +120,7 @@ struct SimTypes {}
 
 impl DpeTypes for SimTypes {
     type Crypto<'a> = OpensslCrypto;
-    type Platform = DefaultPlatform;
+    type Platform<'a> = DefaultPlatform;
 }
 
 fn main() -> std::io::Result<()> {

--- a/tools/src/sample_dpe_cert.rs
+++ b/tools/src/sample_dpe_cert.rs
@@ -16,7 +16,7 @@ pub struct TestTypes {}
 
 impl DpeTypes for TestTypes {
     type Crypto<'a> = OpensslCrypto;
-    type Platform = DefaultPlatform;
+    type Platform<'a> = DefaultPlatform;
 }
 
 fn main() {


### PR DESCRIPTION
We will be adding a &[u8] to DpePlatform in
Caliptra which requires a lifetime parameter, so this change adds one to the Platform trait, similar to how we did for the Crypto trait.