### PR TITLE
Draft PR requesting review for GetCertificateChain_test

### DIFF
--- a/verification/abi.go
+++ b/verification/abi.go
@@ -13,12 +13,13 @@ const (
 type CommandCode uint32
 
 const (
-	CommandGetProfile        CommandCode = 0x1
-	CommandInitializeContext CommandCode = 0x7
-	CommandCertifyKey        CommandCode = 0x9
-	CommandDestroyContext    CommandCode = 0xf
-	CommandTagTCI            CommandCode = 0x82
-	CommandGetTaggedTCI      CommandCode = 0x83
+	CommandGetProfile          CommandCode = 0x1
+	CommandInitializeContext   CommandCode = 0x7
+	CommandCertifyKey          CommandCode = 0x9
+	CommandDestroyContext      CommandCode = 0xf
+	CommandGetCertificateChain CommandCode = 0x80
+	CommandTagTCI              CommandCode = 0x82
+	CommandGetTaggedTCI        CommandCode = 0x83
 )
 
 type CommandHdr struct {
@@ -95,6 +96,15 @@ type CertifyKeyResp[CurveParameter Curve, Digest DigestAlgorithm] struct {
 	DerivedPublicKeyX CurveParameter
 	DerivedPublicKeyY CurveParameter
 	Certificate       []byte
+}
+
+type GetCertificateChainReq struct {
+	Offset uint32
+	Size   uint32
+}
+type GetCertificateChainResp struct {
+	CertificateSize  uint32
+	CertificateChain []byte
 }
 
 type TCITag uint32

--- a/verification/client.go
+++ b/verification/client.go
@@ -192,6 +192,24 @@ func (c *Client[CurveParameter, Digest]) CertifyKey(cmd *CertifyKeyReq[Digest]) 
 	}, nil
 }
 
+// GetCertificateChain calls the DPE GetCertificateChain command.
+func (c *Client[_, _]) GetCertificateChain(cmd *GetCertificateChainReq) (*GetCertificateChainResp, error) {
+	respStruct := struct {
+		CertificateSize  uint32
+		CertificateChain [2048]byte
+	}{}
+
+	_, err := execCommand(c.transport, CommandGetCertificateChain, c.Profile, cmd, &respStruct)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GetCertificateChainResp{
+		CertificateSize:  respStruct.CertificateSize,
+		CertificateChain: respStruct.CertificateChain[:],
+	}, nil
+}
+
 // TagTCI calls the DPE TagTCI command.
 func (c *Client[_, _]) TagTCI(cmd *TagTCIReq) (*TagTCIResp, error) {
 	var respStruct TagTCIResp

--- a/verification/getCertificateChain_test.go
+++ b/verification/getCertificateChain_test.go
@@ -1,0 +1,67 @@
+// Licensed under the Apache-2.0 license
+
+package verification
+
+import (
+	"fmt"
+	"log"
+	"testing"
+)
+
+// This file is used to test the Get Certificate Chain command by using a simulator/emulator
+
+func TestGetCertificateChain(t *testing.T) {
+	support_needed := []string{"AutoInit", "X509"}
+	instance, err := GetTestTarget(support_needed)
+	if err != nil {
+		if err.Error() == "Requested support is not supported in the emulator" {
+			t.Skipf("Warning: Failed executing TestCertifyKey command due to unsupported request. Hence, skipping the command execution")
+		} else {
+			log.Fatal(err)
+		}
+	}
+	testGetCertificateChain(instance, t)
+}
+
+func TestGetCertificateChain_SimulationMode(t *testing.T) {
+
+	support_needed := []string{"AutoInit", "Simulation", "X509"}
+	instance, err := GetTestTarget(support_needed)
+	if err != nil {
+		if err.Error() == "Requested support is not supported in the emulator" {
+			t.Skipf("Warning: Failed executing TestCertifyKey_SimulationMode command due to unsupported request. Hence, skipping the command execution")
+		} else {
+			log.Fatal(err)
+		}
+	}
+	testGetCertificateChain(instance, t)
+}
+
+func testGetCertificateChain(d TestDPEInstance, t *testing.T) {
+	if d.HasPowerControl() {
+		err := d.PowerOn()
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer d.PowerOff()
+	}
+	client, err := NewClient256(d)
+	if err != nil {
+		t.Fatalf("Could not initialize client: %v", err)
+	}
+
+	getCertificateChainReq := GetCertificateChainReq{
+		Offset: 0,
+		Size:   2048,
+	}
+
+	getCertificateChainResp, err := client.GetCertificateChain(&getCertificateChainReq)
+	if err != nil {
+		t.Fatalf("Could not get Certificate Chain: %v", err)
+	}
+
+	fmt.Println(getCertificateChainResp)
+	//checkCertificateStructure(t, getCertificateChainResp.CertificateChain[0])
+
+	// TODO: When DeriveChild is implemented, call it here to add more TCIs and call CertifyKey again. ?????
+}

--- a/verification/getCertificateChain_test.go
+++ b/verification/getCertificateChain_test.go
@@ -3,8 +3,10 @@
 package verification
 
 import (
-	"fmt"
+	"crypto/x509"
+	"encoding/pem"
 	"log"
+	"strings"
 	"testing"
 )
 
@@ -15,7 +17,7 @@ func TestGetCertificateChain(t *testing.T) {
 	instance, err := GetTestTarget(support_needed)
 	if err != nil {
 		if err.Error() == "Requested support is not supported in the emulator" {
-			t.Skipf("Warning: Failed executing TestCertifyKey command due to unsupported request. Hence, skipping the command execution")
+			t.Skipf("Warning: Failed executing TestGetCertificateChain command due to unsupported request. Hence, skipping the command execution")
 		} else {
 			log.Fatal(err)
 		}
@@ -29,7 +31,7 @@ func TestGetCertificateChain_SimulationMode(t *testing.T) {
 	instance, err := GetTestTarget(support_needed)
 	if err != nil {
 		if err.Error() == "Requested support is not supported in the emulator" {
-			t.Skipf("Warning: Failed executing TestCertifyKey_SimulationMode command due to unsupported request. Hence, skipping the command execution")
+			t.Skipf("Warning: Failed executing TestGetCertificateChain_SimulationMode command due to unsupported request. Hence, skipping the command execution")
 		} else {
 			log.Fatal(err)
 		}
@@ -50,9 +52,10 @@ func testGetCertificateChain(d TestDPEInstance, t *testing.T) {
 		t.Fatalf("Could not initialize client: %v", err)
 	}
 
+	// Initialize request input parameters
 	getCertificateChainReq := GetCertificateChainReq{
 		Offset: 0,
-		Size:   2048,
+		Size:   MAX_CERT_CHUNK_SIZE,
 	}
 
 	getCertificateChainResp, err := client.GetCertificateChain(&getCertificateChainReq)
@@ -60,8 +63,89 @@ func testGetCertificateChain(d TestDPEInstance, t *testing.T) {
 		t.Fatalf("Could not get Certificate Chain: %v", err)
 	}
 
-	fmt.Println(getCertificateChainResp)
-	//checkCertificateStructure(t, getCertificateChainResp.CertificateChain[0])
+	//fmt.Println(getCertificateChainResp)
+	checkCertificateChain(t, getCertificateChainResp.CertificateChain)
 
-	// TODO: When DeriveChild is implemented, call it here to add more TCIs and call CertifyKey again. ?????
+	// TODO: When DeriveChild is implemented, call it here to add more TCIs and call GetCertificateChain again.
+}
+
+func checkCertificateChain(t *testing.T, certData []byte) {
+	t.Helper()
+	failed := false
+
+	// QUERY
+	// The certiifcate chain data is returned as Base64 encoded PEM string instead of DER.
+	// This is understandable as opposed to CertifyKey command, a chain of certs will be returned.
+	// So, the x509 parsing employed for CertifyKey will not work.
+	// We had to prefix and suffix the "BEGIN CERTIFICATE", "END CERTIFICATE"
+	// This is possible currently as the GetCertificateChain command returns just single certificate.
+	// This will become a trouble if multiple certs are returned as there would
+	//    not be a way to demarcate one cert from another in certificate chain
+
+	certstr := "-----BEGIN CERTIFICATE-----\n" + strings.ReplaceAll(string(certData), "\x00", "") + "\n-----END CERTIFICATE-----"
+	certData = []byte(certstr)
+	block, _ := pem.Decode(certData)
+	//fmt.Println(block.Bytes)
+	if _, err := x509.ParseCertificate(block.Bytes); err != nil {
+		t.Fatalf("Could not parse certificate using crypto/x509: %v", err)
+		failed = true
+	}
+
+	// TODO: Need to add these validations on PEM cert received.
+	// zcrypto desnt work with PEM block,
+	// such as converting each cert into DER format and then validating te same.
+
+	// // Parse the cert with zcrypto so we can lint it.
+	// cert, err := zx509.ParseCertificate(certData)
+	// if err != nil {
+	// 	t.Errorf("Could not parse certificate using zcrypto/x509: %v", err)
+	// 	failed = true
+	// }
+
+	// // zlint provides a lot of linter sources. Limit results to just the relevant RFCs.
+	// // For a full listing of supported linter sources, see https://github.com/zmap/zlint/blob/master/v3/lint/source.go
+	// registry, err := lint.GlobalRegistry().Filter(lint.FilterOptions{
+	// 	IncludeSources: lint.SourceList{
+	// 		lint.RFC3279,
+	// 		lint.RFC5280,
+	// 		lint.RFC5480,
+	// 		lint.RFC5891,
+	// 		lint.RFC8813,
+	// 	}})
+	// if err != nil {
+	// 	t.Fatalf("Could not set up zlint registry: %v", err)
+	// }
+
+	// results := zlint.LintCertificateEx(cert, registry)
+
+	// for id, result := range results.Results {
+	// 	var level string
+	// 	switch result.Status {
+	// 	case lint.Error:
+	// 		level = "ERROR"
+	// 	case lint.Warn:
+	// 		level = "WARN"
+	// 	default:
+	// 		continue
+	// 	}
+	// 	details := result.Details
+	// 	if details != "" {
+	// 		details = fmt.Sprintf("%s. ", details)
+	// 	}
+	// 	l := registry.ByName(id)
+	// 	// TODO(https://github.com/chipsalliance/caliptra-dpe/issues/74):
+	// 	// Fail the test with Errorf here once we expect it to pass.
+	// 	t.Logf("[%s] %s: %s%s (%s)", level, l.Source, details, l.Description, l.Citation)
+	// 	failed = true
+	// }
+
+	// TODO: Need to modify according to cert data format
+	if failed {
+		// Dump the cert in PEM and hex for use with various tools
+		t.Logf("Offending certificate (PEM):\n%s", (string)(pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: certData,
+		})))
+		t.Logf("Offending certificate (DER):\n%x", certData)
+	}
 }

--- a/verification/verification_test.go
+++ b/verification/verification_test.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"golang.org/x/exp/slices"
@@ -22,9 +23,8 @@ var testTargetType string
 
 // This will be called before running tests, and it assigns the socket path based on command line flag.
 func TestMain(m *testing.M) {
-	testTarget := flag.String("target", "simulator", "socket type - emulator")
-	flag.Parse()
-	testTargetType = *testTarget
+	flag.StringVar(&testTargetType, "target", "simulator", "allowed target types - emulator, simulator, by default target is simulator")
+	testTargetType = strings.ToLower(testTargetType)
 	if testTargetType == SIMULATOR {
 		target_exe = flag.String("sim", "../simulator/target/debug/simulator", "path to simulator executable")
 	} else if testTargetType == EMULATOR {
@@ -93,7 +93,7 @@ func GetTestTarget(support_needed []string) (TestDPEInstance, error) {
 		instance.SetLocality(DPE_SIMULATOR_AUTO_INIT_LOCALITY)
 		return instance, nil
 	}
-	return nil, errors.New("Error in creating dpe instances - supported feature is not enabled")
+	return nil, errors.New("Error in creating dpe instances - invalid test target type.")
 }
 
 // Get the emulator target


### PR DESCRIPTION
Hi @jhand2,

- Added a new test file for GetCertificateChain command validation  (getCertificateChain_test.go)
- Added a new function to execute GetCertificateChain command  (client.go) 
- Could resolve the EOF issue that we discussed in last day's call
- Could get the certificate in command response and parse it.

**Queries:**
1. The GetCertificateChain command does not return _CertificateSize_ as returned by CertifyKey command.   
It is always 2048, I couldn't exclude the junk data at the end. I have tried to TrimRight("\x00") on cert chain, 
but I feel it is not correct do so. **Can you please let me know the current working of command is correct i.e always returning CertificateSize=2048?**

2. I observed that certificate chain returned by GetCertificateChain is in PEM format, but it's header, footer for PEM block type are missing i.e starts like "MIiJYqwdf...." without "----BEGIN CERTIFICATE----\nMIijYqw....At==\n-----END CERTIFICATE-----". Will it not cause trouble to demarcate the certificates in certificate chain?  **Can the command response send the cert chain with BEGIN CERTIFICATE and END CERTIFICATE?**

3. The certificate chain returned by command response has just one certificate and seems be a dummy certificate. There is no link between the DPE leaf cert returned by CertifyKey and  Issuer certificate returned by GetCertificateChain. **Is it possible to have a realistic cert chain and DPE leaf cert to properly validate the positive usecases like Issue validation, chain validation etc?**

4. I have added test for AutoInit support and Simulation support for GetCertificateCommand test. **Adding tests for aforementioned "support{}" is sufficient. Let me know if there are any other "support" to be added.**

6. Kindly share your feedback on the implementation so far..