### PR TITLE
Use constant_time_eq to compare ContextHandles

### DIFF
--- a/dpe/Cargo.lock
+++ b/dpe/Cargo.lock
@@ -130,6 +130,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +213,7 @@ version = "0.1.0"
 dependencies = [
  "asn1",
  "bitflags 2.4.0",
+ "constant_time_eq",
  "crypto",
  "openssl",
  "platform",

--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -12,6 +12,7 @@ dpe_profile_p384_sha384 = []
 
 [dependencies]
 bitflags = "2.4.0"
+constant_time_eq = "0.3.0"
 crypto = {path = "../crypto", default-features = false}
 platform = {path = "../platform", default-features = false}
 zerocopy = "0.6.1"

--- a/dpe/src/commands/tag_tci.rs
+++ b/dpe/src/commands/tag_tci.rs
@@ -106,6 +106,17 @@ mod tests {
         InitCtxCmd::new_use_default()
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
             .unwrap();
+
+        // Wrong locality.
+        assert_eq!(
+            Err(DpeErrorCode::InvalidLocality),
+            TagTciCmd {
+                handle: ContextHandle::default(),
+                tag: 0,
+            }
+            .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])
+        );
+
         let sim_local = TEST_LOCALITIES[1];
         // Make a simulation context to test against.
         InitCtxCmd::new_simulation()
@@ -120,16 +131,6 @@ mod tests {
                 tag: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
-        );
-
-        // Wrong locality.
-        assert_eq!(
-            Err(DpeErrorCode::InvalidLocality),
-            TagTciCmd {
-                handle: ContextHandle::default(),
-                tag: 0,
-            }
-            .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])
         );
 
         // Tag default handle.

--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -1,5 +1,6 @@
 // Licensed under the Apache-2.0 license.
 use crate::{response::DpeErrorCode, tci::TciNodeData, U8Bool, MAX_HANDLES};
+use constant_time_eq::constant_time_eq;
 use zerocopy::{AsBytes, FromBytes};
 
 #[repr(C, align(4))]
@@ -140,7 +141,7 @@ impl ContextHandle {
 
     /// Whether the handle is the default context handle.
     pub fn is_default(&self) -> bool {
-        self.0 == Self::DEFAULT
+        constant_time_eq(&self.0, &Self::DEFAULT)
     }
 }
 

--- a/simulator/Cargo.lock
+++ b/simulator/Cargo.lock
@@ -100,6 +100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +160,7 @@ name = "dpe"
 version = "0.1.0"
 dependencies = [
  "bitflags 2.4.0",
+ "constant_time_eq",
  "crypto",
  "platform",
  "zerocopy",

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -54,6 +54,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +105,7 @@ name = "dpe"
 version = "0.1.0"
 dependencies = [
  "bitflags 2.4.0",
+ "constant_time_eq",
  "crypto",
  "platform",
  "zerocopy",


### PR DESCRIPTION
Currently, we are using a non-constant time comparator for ContextHandles which is a security issue since attackers can determine the correct content handle in a byte-by-byte manner by repeatedly observing the execution time of get_active_context_pos with varying inputs.

Fixes #188 