### PR TITLE
Remove usage of unsafe Rust in CryptoBuf

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -33,7 +33,7 @@ impl AlgLen {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum CryptoError {
     AbstractionLayer,
     CryptoLibError,

--- a/crypto/src/signer.rs
+++ b/crypto/src/signer.rs
@@ -28,16 +28,16 @@ impl EcdsaPub {
 pub type HmacSig = CryptoBuf;
 
 /// A common base struct that can be used for all digests, signatures, and keys.
+#[derive(Debug, PartialEq, Eq)]
 pub struct CryptoBuf(ArrayVec<u8, { Self::MAX_SIZE }>);
 
 impl CryptoBuf {
     pub const MAX_SIZE: usize = AlgLen::MAX_ALG_LEN_BYTES;
 
-    pub fn new(bytes: &[u8], algs: AlgLen) -> Result<CryptoBuf, CryptoError> {
+    pub fn new(bytes: &[u8]) -> Result<CryptoBuf, CryptoError> {
         let mut vec = ArrayVec::new();
         vec.try_extend_from_slice(bytes)
             .map_err(|_| CryptoError::Size)?;
-        unsafe { vec.set_len(algs.size()) };
         Ok(CryptoBuf(vec))
     }
 
@@ -46,7 +46,6 @@ impl CryptoBuf {
         for _ in 0..algs.size() {
             vec.push(0);
         }
-        unsafe { vec.set_len(algs.size()) };
         CryptoBuf(vec)
     }
 
@@ -82,5 +81,32 @@ impl CryptoBuf {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_crypto_buf_init() {
+        let arr = &[1u8; CryptoBuf::MAX_SIZE + 1];
+
+        // array length must not exceed MAX_SIZE
+        assert_eq!(CryptoBuf::new(arr), Err(CryptoError::Size));
+
+        let arr = &[1u8; AlgLen::Bit256.size()];
+        // test new
+        match CryptoBuf::new(arr) {
+            Ok(buf) => {
+                assert_eq!(arr, buf.bytes());
+                assert_eq!(buf.len(), AlgLen::Bit256.size());
+            }
+            Err(_) => panic!("CryptoBuf::new failed"),
+        };
+
+        // test default
+        let default_buf = CryptoBuf::default(AlgLen::Bit384);
+        assert_eq!(default_buf.bytes(), [0; AlgLen::Bit384.size()]);
     }
 }

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -98,7 +98,7 @@ impl CommandExecution for SignCmd {
         }
 
         let algs = DPE_PROFILE.alg_len();
-        let digest = Digest::new(&self.digest, algs).map_err(|_| DpeErrorCode::InternalError)?;
+        let digest = Digest::new(&self.digest).map_err(|_| DpeErrorCode::InternalError)?;
 
         let EcdsaSig { r, s } = if !self.uses_symmetric() {
             self.ecdsa_sign(dpe, env, idx, &digest)?
@@ -339,14 +339,9 @@ mod tests {
         // Check that r is equal to the HMAC over the digest
         assert_eq!(
             resp.sig_r_or_hmac,
-            cmd.hmac_sign(
-                &mut dpe,
-                &mut env,
-                idx,
-                &Digest::new(&TEST_DIGEST, DPE_PROFILE.alg_len()).unwrap(),
-            )
-            .unwrap()
-            .bytes()
+            cmd.hmac_sign(&mut dpe, &mut env, idx, &Digest::new(&TEST_DIGEST).unwrap(),)
+                .unwrap()
+                .bytes()
         );
         // Check that s is a buffer of all 0s
         assert!(&resp.sig_s.iter().all(|&b| b == 0x0));

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -1142,7 +1142,7 @@ mod tests {
     use crate::tci::{TciMeasurement, TciNodeData};
     use crate::x509::{MeasurementData, Name, X509CertWriter};
     use crate::DPE_PROFILE;
-    use crypto::{AlgLen, CryptoBuf, EcdsaPub, EcdsaSig};
+    use crypto::{CryptoBuf, EcdsaPub, EcdsaSig};
     use std::str;
     use x509_parser::certificate::X509CertificateParser;
     use x509_parser::nom::Parser;
@@ -1358,10 +1358,9 @@ mod tests {
         };
 
         const ECC_INT_SIZE: usize = DPE_PROFILE.get_ecc_int_size();
-        const ALG_LEN: AlgLen = DPE_PROFILE.alg_len();
         let test_pub = EcdsaPub {
-            x: CryptoBuf::new(&[0xAA; ECC_INT_SIZE], ALG_LEN).unwrap(),
-            y: CryptoBuf::new(&[0xBB; ECC_INT_SIZE], ALG_LEN).unwrap(),
+            x: CryptoBuf::new(&[0xAA; ECC_INT_SIZE]).unwrap(),
+            y: CryptoBuf::new(&[0xBB; ECC_INT_SIZE]).unwrap(),
         };
 
         let node = TciNodeData::new();
@@ -1412,7 +1411,6 @@ mod tests {
     };
 
     const ECC_INT_SIZE: usize = DPE_PROFILE.get_ecc_int_size();
-    const ALG_LEN: AlgLen = DPE_PROFILE.alg_len();
 
     fn build_test_tbs<'a>(is_ca: bool, cert_buf: &'a mut [u8]) -> (usize, TbsCertificate<'a>) {
         let mut issuer_der = [0u8; 1024];
@@ -1420,8 +1418,8 @@ mod tests {
         let issuer_len = issuer_writer.encode_rdn(&TEST_ISSUER_NAME).unwrap();
 
         let test_pub = EcdsaPub {
-            x: CryptoBuf::new(&[0xAA; ECC_INT_SIZE], ALG_LEN).unwrap(),
-            y: CryptoBuf::new(&[0xBB; ECC_INT_SIZE], ALG_LEN).unwrap(),
+            x: CryptoBuf::new(&[0xAA; ECC_INT_SIZE]).unwrap(),
+            y: CryptoBuf::new(&[0xBB; ECC_INT_SIZE]).unwrap(),
         };
 
         let node = TciNodeData::new();
@@ -1455,8 +1453,8 @@ mod tests {
         let (tbs_written, _) = build_test_tbs(is_ca, &mut tbs_buf);
 
         let test_sig = EcdsaSig {
-            r: CryptoBuf::new(&[0xCC; ECC_INT_SIZE], ALG_LEN).unwrap(),
-            s: CryptoBuf::new(&[0xDD; ECC_INT_SIZE], ALG_LEN).unwrap(),
+            r: CryptoBuf::new(&[0xCC; ECC_INT_SIZE]).unwrap(),
+            s: CryptoBuf::new(&[0xDD; ECC_INT_SIZE]).unwrap(),
         };
 
         let mut w = X509CertWriter::new(cert_buf, true);


### PR DESCRIPTION
Previously, we were unsafely using ArrayVec::set_len in the CryptoBuf implementation. We were also not checking that the size of the input slice bytes == algs.size() which resulted in partially initialized CryptoBufs. This change fixes both of these issues.

Now, there are no more usages of unsafe Rust in DPE.

Fixes #196 