### PR TITLE
Set internal input flags on child contexts instead of parent

### DIFF
--- a/crypto/Cargo.lock
+++ b/crypto/Cargo.lock
@@ -57,6 +57,7 @@ dependencies = [
  "arrayvec",
  "hkdf",
  "openssl",
+ "rand",
  "sha2",
  "strum",
  "strum_macros",
@@ -109,6 +110,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "once_cell"
@@ -190,6 +202,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +223,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -283,3 +331,9 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [features]
 openssl = ["dep:openssl", "dep:hkdf", "dep:sha2"]
-deterministic_rand = ["openssl"]
+deterministic_rand = ["dep:rand"]
 default = ["dpe_profile_p256_sha256"]
 dpe_profile_p256_sha256 = []
 dpe_profile_p384_sha384 = []
@@ -16,6 +16,7 @@ dpe_profile_p384_sha384 = []
 arrayvec = { version = "0.7.4", default-features = false }
 hkdf = {version = "0.12.3", optional = true}
 openssl = {version = "0.10", optional = true}
+rand = {version = "0.8.5", optional = true}
 sha2 = {version = "0.10.6", optional = true}
 
 [dev-dependencies]
@@ -24,3 +25,4 @@ strum_macros = "0.24"
 
 [build-dependencies]
 openssl = {version = "0.10", optional = true}
+rand = {version = "0.8.5", optional = true}

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -12,6 +12,9 @@ pub use signer::*;
 #[cfg(feature = "openssl")]
 pub mod openssl;
 
+#[cfg(feature = "deterministic_rand")]
+pub use rand::*;
+
 mod signer;
 
 #[derive(Debug, Clone, Copy)]

--- a/dpe/Cargo.lock
+++ b/dpe/Cargo.lock
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -145,6 +145,7 @@ dependencies = [
  "arrayvec",
  "hkdf",
  "openssl",
+ "rand",
  "sha2",
 ]
 
@@ -239,6 +240,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,9 +282,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "memchr"
@@ -394,6 +406,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +427,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -428,9 +476,9 @@ checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -515,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
@@ -542,6 +590,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "x509-parser"

--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -20,5 +20,5 @@ zerocopy = "0.6.1"
 asn1 = "0.13.0"
 openssl = "0.10"
 x509-parser = "0.14.0"
-crypto = {path = "../crypto", features = ["deterministic_rand"]}
+crypto = {path = "../crypto", features = ["deterministic_rand", "openssl"]}
 platform = {path = "../platform", features = ["openssl"]}

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -184,6 +184,17 @@ pub mod tests {
         26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
     ];
 
+    #[cfg(feature = "dpe_profile_p256_sha256")]
+    pub const TEST_LABEL: [u8; DPE_PROFILE.get_hash_size()] = [
+        32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10,
+        9, 8, 7, 6, 5, 4, 3, 2, 1,
+    ];
+    #[cfg(feature = "dpe_profile_p384_sha384")]
+    pub const TEST_LABEL: [u8; DPE_PROFILE.get_hash_size()] = [
+        48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26,
+        25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
+    ];
+
     const DEFAULT_COMMAND: CommandHdr = CommandHdr {
         magic: CommandHdr::DPE_COMMAND_MAGIC,
         cmd_id: Command::GET_PROFILE,

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -74,7 +74,7 @@ mod tests {
     use super::*;
     use crate::{
         commands::{Command, CommandHdr, InitCtxCmd},
-        dpe_instance::tests::{TestTypes, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES},
+        dpe_instance::tests::{TestTypes, RANDOM_HANDLE, TEST_HANDLE, TEST_LOCALITIES},
         support::Support,
     };
     use crypto::OpensslCrypto;
@@ -159,7 +159,7 @@ mod tests {
         // Rotate default handle.
         assert_eq!(
             Ok(Response::RotateCtx(NewHandleResp {
-                handle: SIMULATION_HANDLE,
+                handle: RANDOM_HANDLE,
                 resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
             })),
             RotateCtxCmd {
@@ -177,7 +177,7 @@ mod tests {
                 resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
             })),
             RotateCtxCmd {
-                handle: SIMULATION_HANDLE,
+                handle: RANDOM_HANDLE,
                 flags: RotateCtxFlags::TARGET_IS_DEFAULT,
                 target_locality: 0
             }

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -130,11 +130,13 @@ mod tests {
     use super::*;
     use crate::{
         commands::{
-            certify_key::CertifyKeyCmd, certify_key::CertifyKeyFlags,
-            derive_child::DeriveChildFlags, tests::TEST_DIGEST, Command, CommandHdr,
-            DeriveChildCmd, InitCtxCmd,
+            certify_key::CertifyKeyCmd,
+            certify_key::CertifyKeyFlags,
+            derive_child::DeriveChildFlags,
+            tests::{TEST_DIGEST, TEST_LABEL},
+            Command, CommandHdr, DeriveChildCmd, InitCtxCmd,
         },
-        dpe_instance::tests::{TestTypes, SIMULATION_HANDLE, TEST_LOCALITIES},
+        dpe_instance::tests::{TestTypes, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_LOCALITIES},
         support::{test::SUPPORT, Support},
     };
     use crypto::OpensslCrypto;
@@ -142,17 +144,6 @@ mod tests {
     use openssl::{bn::BigNum, ecdsa::EcdsaSig};
     use platform::default::DefaultPlatform;
     use zerocopy::AsBytes;
-
-    #[cfg(feature = "dpe_profile_p256_sha256")]
-    const TEST_LABEL: [u8; DPE_PROFILE.get_hash_size()] = [
-        32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10,
-        9, 8, 7, 6, 5, 4, 3, 2, 1,
-    ];
-    #[cfg(feature = "dpe_profile_p384_sha384")]
-    const TEST_LABEL: [u8; DPE_PROFILE.get_hash_size()] = [
-        48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26,
-        25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
-    ];
 
     const TEST_SIGN_CMD: SignCmd = SignCmd {
         handle: SIMULATION_HANDLE,
@@ -240,12 +231,12 @@ mod tests {
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
             .unwrap();
         assert!(dpe
-            .get_active_context_pos(&SIMULATION_HANDLE, TEST_LOCALITIES[0])
+            .get_active_context_pos(&RANDOM_HANDLE, TEST_LOCALITIES[0])
             .is_ok());
         assert_eq!(
             Err(DpeErrorCode::InvalidArgument),
             SignCmd {
-                handle: SIMULATION_HANDLE,
+                handle: RANDOM_HANDLE,
                 label: TEST_LABEL,
                 flags: SignFlags::empty(),
                 digest: TEST_DIGEST

--- a/dpe/src/commands/tag_tci.rs
+++ b/dpe/src/commands/tag_tci.rs
@@ -58,7 +58,9 @@ mod tests {
     use super::*;
     use crate::{
         commands::{Command, CommandHdr, InitCtxCmd},
-        dpe_instance::tests::{TestTypes, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES},
+        dpe_instance::tests::{
+            TestTypes, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES,
+        },
         support::Support,
     };
     use crypto::OpensslCrypto;
@@ -166,32 +168,29 @@ mod tests {
         // Give the simulation context another handle so we can prove the handle rotates when it
         // gets tagged.
         let simulation_ctx = &mut dpe.contexts[dpe
-            .get_active_context_pos(&SIMULATION_HANDLE, sim_local)
+            .get_active_context_pos(&RANDOM_HANDLE, sim_local)
             .unwrap()];
         let sim_tmp_handle = ContextHandle([0xff; ContextHandle::SIZE]);
         simulation_ctx.handle = sim_tmp_handle;
         assert!(dpe
-            .get_active_context_pos(&SIMULATION_HANDLE, sim_local)
+            .get_active_context_pos(&RANDOM_HANDLE, sim_local)
             .is_err());
 
         // Tag simulation.
-        assert_eq!(
-            Ok(Response::TagTci(NewHandleResp {
-                handle: SIMULATION_HANDLE,
-                resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
-            })),
-            TagTciCmd {
-                handle: sim_tmp_handle,
-                tag: 1,
+        match (TagTciCmd {
+            handle: sim_tmp_handle,
+            tag: 1,
+        }
+        .execute(&mut dpe, &mut env, TEST_LOCALITIES[1]))
+        {
+            Ok(Response::TagTci(NewHandleResp { handle, .. })) => {
+                // Make sure it rotated back to the deterministic simulation handle.
+                assert!(dpe
+                    .get_active_context_pos(&sim_tmp_handle, sim_local)
+                    .is_err());
+                assert!(dpe.get_active_context_pos(&handle, sim_local).is_ok());
             }
-            .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])
-        );
-        // Make sure it rotated back to the deterministic simulation handle.
-        assert!(dpe
-            .get_active_context_pos(&sim_tmp_handle, sim_local)
-            .is_err());
-        assert!(dpe
-            .get_active_context_pos(&SIMULATION_HANDLE, sim_local)
-            .is_ok());
+            _ => panic!("Tag simulation failed"),
+        }
     }
 }

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -55,9 +55,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -69,6 +69,7 @@ dependencies = [
  "arrayvec",
  "hkdf",
  "openssl",
+ "rand",
  "sha2",
 ]
 
@@ -126,6 +127,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -220,6 +232,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +253,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -295,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
@@ -316,6 +364,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "zerocopy"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -12,7 +12,7 @@ dpe_profile_p384_sha384 = ["dpe/dpe_profile_p384_sha384"]
 
 [dependencies]
 dpe = {path = "../dpe"}
-crypto = {path = "../crypto", features = ["deterministic_rand"]}
+crypto = {path = "../crypto", features = ["deterministic_rand", "openssl"]}
 pem = "2"
 platform = {path = "../platform", features = ["openssl"]}
 zerocopy = "0.6.1"


### PR DESCRIPTION
Previously we were setting the internal_dice and internal_info flags on the parent context in derive child. This is a bug since attestation could fail under the following scenario:

1. Assume context[0] is auto-initialized to the default context
2. Call DeriveChild with retain parent
3. Call Sign on the default context (context[0])
4. Call DeriveChild with retain parent and internal_input_info.
5. Call CertifyKey on the default context (context[0])

Attestation fails here (we cannot verify the signature with the public key given to us by CertifyKey) since step 2 does not set the internal_input_flag so in step 3, when computing CDIs we do not mix in internal input info. However, in step 4, we would then incorrectly set context[0]'s internal_input_flag so when we certify key in step 5 and derive CDIs, the internal input info is mixed in, leading to a signature verification failure.

Now we make derive child set the internal_input flags on the child context in order to avoid this problem. I have also added a test for this scenario.

We also make deterministic rand_bytes use a seed so that successive calls return different results. This helps for testing.

Fixes #187 