### PR TITLE
Add functionality to Platform trait to print from DPE

### DIFF
--- a/dpe/Cargo.lock
+++ b/dpe/Cargo.lock
@@ -217,6 +217,7 @@ dependencies = [
  "crypto",
  "openssl",
  "platform",
+ "ufmt",
  "x509-parser",
  "zerocopy",
 ]
@@ -410,6 +411,7 @@ name = "platform"
 version = "0.1.0"
 dependencies = [
  "openssl",
+ "ufmt",
 ]
 
 [[package]]
@@ -573,6 +575,30 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ufmt"
+version = "0.2.0"
+source = "git+https://github.com/korran/ufmt.git?rev=1d0743c1ffffc68bc05ca8eeb81c166192863f33#1d0743c1ffffc68bc05ca8eeb81c166192863f33"
+dependencies = [
+ "ufmt-macros",
+ "ufmt-write",
+]
+
+[[package]]
+name = "ufmt-macros"
+version = "0.3.0"
+source = "git+https://github.com/korran/ufmt.git?rev=1d0743c1ffffc68bc05ca8eeb81c166192863f33#1d0743c1ffffc68bc05ca8eeb81c166192863f33"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ufmt-write"
+version = "0.1.0"
+source = "git+https://github.com/korran/ufmt.git?rev=1d0743c1ffffc68bc05ca8eeb81c166192863f33#1d0743c1ffffc68bc05ca8eeb81c166192863f33"
 
 [[package]]
 name = "unicode-ident"

--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -15,6 +15,7 @@ bitflags = "2.4.0"
 constant_time_eq = "0.3.0"
 crypto = {path = "../crypto", default-features = false}
 platform = {path = "../platform", default-features = false}
+ufmt = { git = "https://github.com/korran/ufmt.git", rev = "1d0743c1ffffc68bc05ca8eeb81c166192863f33", features = ["inline"] }
 zerocopy = "0.6.1"
 
 [dev-dependencies]

--- a/dpe/fuzz/Cargo.lock
+++ b/dpe/fuzz/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "constant_time_eq",
  "crypto",
  "platform",
+ "ufmt",
  "zerocopy",
 ]
 
@@ -396,7 +397,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -422,6 +423,7 @@ name = "platform"
 version = "0.1.0"
 dependencies = [
  "openssl",
+ "ufmt",
 ]
 
 [[package]]
@@ -496,7 +498,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -532,6 +534,17 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -601,6 +614,30 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ufmt"
+version = "0.2.0"
+source = "git+https://github.com/korran/ufmt.git?rev=1d0743c1ffffc68bc05ca8eeb81c166192863f33#1d0743c1ffffc68bc05ca8eeb81c166192863f33"
+dependencies = [
+ "ufmt-macros",
+ "ufmt-write",
+]
+
+[[package]]
+name = "ufmt-macros"
+version = "0.3.0"
+source = "git+https://github.com/korran/ufmt.git?rev=1d0743c1ffffc68bc05ca8eeb81c166192863f33#1d0743c1ffffc68bc05ca8eeb81c166192863f33"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ufmt-write"
+version = "0.1.0"
+source = "git+https://github.com/korran/ufmt.git?rev=1d0743c1ffffc68bc05ca8eeb81c166192863f33#1d0743c1ffffc68bc05ca8eeb81c166192863f33"
 
 [[package]]
 name = "unicode-ident"
@@ -747,5 +784,5 @@ checksum = "56097d5b91d711293a42be9289403896b68654625021732067eac7a4ca388a1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.37",
 ]

--- a/platform/Cargo.lock
+++ b/platform/Cargo.lock
@@ -73,7 +73,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -99,6 +99,7 @@ name = "platform"
 version = "0.1.0"
 dependencies = [
  "openssl",
+ "ufmt",
 ]
 
 [[package]]
@@ -121,6 +122,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
@@ -129,6 +141,30 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "ufmt"
+version = "0.2.0"
+source = "git+https://github.com/korran/ufmt.git?rev=1d0743c1ffffc68bc05ca8eeb81c166192863f33#1d0743c1ffffc68bc05ca8eeb81c166192863f33"
+dependencies = [
+ "ufmt-macros",
+ "ufmt-write",
+]
+
+[[package]]
+name = "ufmt-macros"
+version = "0.3.0"
+source = "git+https://github.com/korran/ufmt.git?rev=1d0743c1ffffc68bc05ca8eeb81c166192863f33#1d0743c1ffffc68bc05ca8eeb81c166192863f33"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ufmt-write"
+version = "0.1.0"
+source = "git+https://github.com/korran/ufmt.git?rev=1d0743c1ffffc68bc05ca8eeb81c166192863f33#1d0743c1ffffc68bc05ca8eeb81c166192863f33"
 
 [[package]]
 name = "unicode-ident"

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -13,3 +13,4 @@ dpe_profile_p384_sha384 = []
 
 [dependencies]
 openssl = {version = "0.10", optional = true}
+ufmt = { git = "https://github.com/korran/ufmt.git", rev = "1d0743c1ffffc68bc05ca8eeb81c166192863f33", features = ["inline"] }

--- a/platform/src/default.rs
+++ b/platform/src/default.rs
@@ -64,4 +64,9 @@ impl Platform for DefaultPlatform {
     fn get_auto_init_locality(&mut self) -> Result<u32, PlatformError> {
         Ok(AUTO_INIT_LOCALITY)
     }
+
+    fn write_str(&mut self, str: &str) -> Result<(), PlatformError> {
+        print!("{str}");
+        Ok(())
+    }
 }

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -11,6 +11,8 @@ pub use openssl::x509::X509;
 #[cfg(feature = "openssl")]
 pub mod default;
 
+pub mod printer;
+
 pub const MAX_CHUNK_SIZE: usize = 2048;
 
 #[derive(Debug)]
@@ -18,6 +20,7 @@ pub enum PlatformError {
     CertificateChainError,
     NotImplemented,
     IssuerNameError,
+    PrintError,
 }
 
 pub trait Platform {
@@ -47,4 +50,6 @@ pub trait Platform {
     fn get_vendor_sku(&mut self) -> Result<u32, PlatformError>;
 
     fn get_auto_init_locality(&mut self) -> Result<u32, PlatformError>;
+
+    fn write_str(&mut self, str: &str) -> Result<(), PlatformError>;
 }

--- a/platform/src/printer.rs
+++ b/platform/src/printer.rs
@@ -1,0 +1,30 @@
+// Licensed under the Apache-2.0 license
+
+use ufmt::uWrite;
+
+use crate::{Platform, PlatformError};
+
+pub struct Printer<'a> {
+    pub platform: &'a mut dyn Platform,
+}
+
+impl<'a> uWrite for Printer<'a> {
+    type Error = PlatformError;
+
+    fn write_str(&mut self, str: &str) -> Result<(), Self::Error> {
+        self.platform.write_str(str)
+    }
+}
+
+impl<'a> Printer<'a> {
+    pub fn new(platform: &'a mut dyn Platform) -> Self {
+        Self { platform }
+    }
+}
+
+#[macro_export]
+macro_rules! plat_println {
+    ($platform:expr, $($tt:tt)*) => {{
+        let _ = ufmt::uwriteln!(&mut $crate::printer::Printer::new($platform), $($tt)*);
+    }}
+}

--- a/simulator/Cargo.lock
+++ b/simulator/Cargo.lock
@@ -163,6 +163,7 @@ dependencies = [
  "constant_time_eq",
  "crypto",
  "platform",
+ "ufmt",
  "zerocopy",
 ]
 
@@ -384,6 +385,7 @@ name = "platform"
 version = "0.1.0"
 dependencies = [
  "openssl",
+ "ufmt",
 ]
 
 [[package]]
@@ -527,6 +529,30 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "ufmt"
+version = "0.2.0"
+source = "git+https://github.com/korran/ufmt.git?rev=1d0743c1ffffc68bc05ca8eeb81c166192863f33#1d0743c1ffffc68bc05ca8eeb81c166192863f33"
+dependencies = [
+ "ufmt-macros",
+ "ufmt-write",
+]
+
+[[package]]
+name = "ufmt-macros"
+version = "0.3.0"
+source = "git+https://github.com/korran/ufmt.git?rev=1d0743c1ffffc68bc05ca8eeb81c166192863f33#1d0743c1ffffc68bc05ca8eeb81c166192863f33"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ufmt-write"
+version = "0.1.0"
+source = "git+https://github.com/korran/ufmt.git?rev=1d0743c1ffffc68bc05ca8eeb81c166192863f33#1d0743c1ffffc68bc05ca8eeb81c166192863f33"
 
 [[package]]
 name = "unicode-ident"

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -108,6 +108,7 @@ dependencies = [
  "constant_time_eq",
  "crypto",
  "platform",
+ "ufmt",
  "zerocopy",
 ]
 
@@ -236,6 +237,7 @@ name = "platform"
 version = "0.1.0"
 dependencies = [
  "openssl",
+ "ufmt",
 ]
 
 [[package]]
@@ -353,6 +355,30 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ufmt"
+version = "0.2.0"
+source = "git+https://github.com/korran/ufmt.git?rev=1d0743c1ffffc68bc05ca8eeb81c166192863f33#1d0743c1ffffc68bc05ca8eeb81c166192863f33"
+dependencies = [
+ "ufmt-macros",
+ "ufmt-write",
+]
+
+[[package]]
+name = "ufmt-macros"
+version = "0.3.0"
+source = "git+https://github.com/korran/ufmt.git?rev=1d0743c1ffffc68bc05ca8eeb81c166192863f33#1d0743c1ffffc68bc05ca8eeb81c166192863f33"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ufmt-write"
+version = "0.1.0"
+source = "git+https://github.com/korran/ufmt.git?rev=1d0743c1ffffc68bc05ca8eeb81c166192863f33#1d0743c1ffffc68bc05ca8eeb81c166192863f33"
 
 [[package]]
 name = "unicode-ident"


### PR DESCRIPTION
Make use of the ufmt crate to create a macro plat_println which prints things from the platform. This will be useful for debugging and allows the implementation to define the printing functionality. In the default implementation, we simply use print!.

Fixes #205 