### PR TITLE
Add functions to count number of active contexts

### DIFF
--- a/dpe/src/commands/derive_child.rs
+++ b/dpe/src/commands/derive_child.rs
@@ -46,7 +46,7 @@ impl DeriveChildCmd {
         self.flags.contains(DeriveChildFlags::INTERNAL_INPUT_DICE)
     }
 
-    const fn retains_parent(&self) -> bool {
+    pub const fn retains_parent(&self) -> bool {
         self.flags.contains(DeriveChildFlags::RETAIN_PARENT)
     }
 

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -24,7 +24,7 @@ impl InitCtxCmd {
         Self::DEFAULT_FLAG_MASK
     }
 
-    const fn flag_is_simulation(&self) -> bool {
+    pub const fn flag_is_simulation(&self) -> bool {
         self.contains(Self::SIMULATION_FLAG_MASK)
     }
 

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -435,6 +435,22 @@ impl DpeInstance {
         }
         false
     }
+
+    pub fn count_active_contexts(&self) -> Result<usize, DpeErrorCode> {
+        Ok(self
+            .contexts
+            .iter()
+            .filter(|context| context.state == ContextState::Active)
+            .count())
+    }
+
+    pub fn count_active_contexts_in_locality(&self, locality: u32) -> Result<usize, DpeErrorCode> {
+        Ok(self
+            .contexts
+            .iter()
+            .filter(|context| context.state == ContextState::Active && context.locality == locality)
+            .count())
+    }
 }
 
 /// Iterate over all of the bits set to 1 in a u32. Each iteration returns the bit index 0 being the


### PR DESCRIPTION
Add a function to count total number of active contexts and a function to count number of active contexts in a certain locality. These functions will be used to determine the number of active contexts per pauser privilege level in Caliptra.