### PR TITLE
Make verification tests runnable on either profile

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -51,6 +51,9 @@ set -ex
 )
 ( cd verification
   test -z "$(gofmt -l .)"
+  cargo build --no-default-features --features=dpe_profile_p256_sha256 --manifest-path ../simulator/Cargo.toml
+  go test
+  cargo build --no-default-features --features=dpe_profile_p384_sha384 --manifest-path ../simulator/Cargo.toml
   go test
 )
 (

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -5,6 +5,11 @@ name = "simulator"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["dpe_profile_p256_sha256"]
+dpe_profile_p256_sha256 = ["dpe/dpe_profile_p256_sha256", "crypto/dpe_profile_p256_sha256", "platform/dpe_profile_p256_sha256"]
+dpe_profile_p384_sha384 = ["dpe/dpe_profile_p384_sha384", "crypto/dpe_profile_p384_sha384", "platform/dpe_profile_p384_sha384"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -13,6 +18,6 @@ openssl = "0.10"
 clap = { version = "4.1.8", features = ["derive"] }
 log = "0.4.17"
 env_logger = "0.10.0"
-dpe = { path = "../dpe" }
-crypto = { path = "../crypto", features = ["openssl"] }
-platform = { path = "../platform", features = ["openssl"] }
+dpe = { path = "../dpe", default-features = false }
+crypto = { path = "../crypto", default-features = false, features = ["openssl"] }
+platform = { path = "../platform", default-features = false, features = ["openssl"] }

--- a/verification/abi.go
+++ b/verification/abi.go
@@ -2,6 +2,13 @@
 
 package verification
 
+/* Structures for DPE commands and responses
+ *
+ * These structures do not not use generics for parameters which are
+ * fixed-size based on the profile (e.g. hashes, ecc ints). This is to support
+ * a Client interface that does not use generics.
+ */
+
 const (
 	CmdMagic  uint32 = 0x44504543
 	RespMagic uint32 = 0x44504552
@@ -84,17 +91,17 @@ const (
 	CertifyKeyCsr  CertifyKeyFormat = 1
 )
 
-type CertifyKeyReq[Digest DigestAlgorithm] struct {
+type CertifyKeyReq struct {
 	ContextHandle ContextHandle
 	Flags         CertifyKeyFlags
-	Label         Digest
+	Label         []byte
 	Format        CertifyKeyFormat
 }
 
-type CertifyKeyResp[CurveParameter Curve, Digest DigestAlgorithm] struct {
+type CertifyKeyResp struct {
 	NewContextHandle  ContextHandle
-	DerivedPublicKeyX CurveParameter
-	DerivedPublicKeyY CurveParameter
+	DerivedPublicKeyX []byte
+	DerivedPublicKeyY []byte
 	Certificate       []byte
 }
 
@@ -122,7 +129,7 @@ type GetTaggedTCIReq struct {
 	Tag TCITag
 }
 
-type GetTaggedTCIResp[Digest DigestAlgorithm] struct {
-	CumulativeTCI Digest
-	CurrentTCI    Digest
+type GetTaggedTCIResp struct {
+	CumulativeTCI []byte
+	CurrentTCI    []byte
 }

--- a/verification/certifyKey_test.go
+++ b/verification/certifyKey_test.go
@@ -477,9 +477,14 @@ func testCertifyKey(d TestDPEInstance, t *testing.T, use_simulation bool) {
 		}
 		defer d.PowerOff()
 	}
-	client, err := NewClient256(d)
+	client, err := NewClient(d)
 	if err != nil {
 		t.Fatalf("[FATAL]: Could not initialize client: %v", err)
+	}
+
+	profile, err := client.GetProfile()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	var ctx ContextHandle
@@ -507,17 +512,23 @@ func testCertifyKey(d TestDPEInstance, t *testing.T, use_simulation bool) {
 		ctx = initCtxResp.Handle
 	}
 
-	certifyKeyReq := []CertifyKeyReq[SHA256Digest]{
+	emptyLabel := make([]byte, profile.Profile.GetDigestSize())
+	seqLabel := make([]byte, profile.Profile.GetDigestSize())
+	for i, _ := range seqLabel {
+		seqLabel[i] = byte(i)
+	}
+
+	certifyKeyReq := []CertifyKeyReq{
 		{
 			ContextHandle: ctx,
 			Flags:         0,
-			Label:         [32]byte{},
+			Label:         emptyLabel,
 			Format:        CertifyKeyX509,
 		},
 		{
 			ContextHandle: ctx,
 			Flags:         1 << AddIsCA, // Setting the 30th bit counted from 0 returns CA cert : 01000000 00000000 00000000 00000000
-			Label:         [32]byte{143, 67, 67, 70, 100, 143, 107, 150, 223, 137, 221, 169, 1, 197, 23, 107, 16, 166, 216, 57, 97, 221, 60, 26, 200, 139, 89, 178, 220, 50, 122, 164},
+			Label:         seqLabel,
 			Format:        CertifyKeyX509,
 		},
 	}

--- a/verification/emulator.go
+++ b/verification/emulator.go
@@ -18,14 +18,13 @@ import (
 const (
 	emulatorSocketPath = "/tmp/dpe-emu.socket"
 
-	DPE_EMULATOR_AUTO_INIT_LOCALITY    uint32  = 0
-	DPE_EMULATOR_OTHER_LOCALITY        uint32  = 0
-	DPE_EMULATOR_PROFILE               Profile = 0
-	DPE_EMULATOR_MAX_TCI_NODES         uint32  = 0
-	DPE_EMULATOR_MAJOR_PROFILE_VERSION uint16  = 0
-	DPE_EMULATOR_MINOR_PROFILE_VERSION uint16  = 0
-	DPE_EMULATOR_VENDOR_ID             uint32  = 0
-	DPE_EMULATOR_VENDOR_SKU            uint32  = 0
+	DPE_EMULATOR_AUTO_INIT_LOCALITY    uint32 = 0
+	DPE_EMULATOR_OTHER_LOCALITY        uint32 = 0
+	DPE_EMULATOR_MAX_TCI_NODES         uint32 = 0
+	DPE_EMULATOR_MAJOR_PROFILE_VERSION uint16 = 0
+	DPE_EMULATOR_MINOR_PROFILE_VERSION uint16 = 0
+	DPE_EMULATOR_VENDOR_ID             uint32 = 0
+	DPE_EMULATOR_VENDOR_SKU            uint32 = 0
 )
 
 // Added dummy support for emulator .This is to verify against the support_needed list
@@ -155,10 +154,6 @@ func (s *DpeEmulator) SendCmd(buf []byte) ([]byte, error) {
 
 func (s *DpeEmulator) GetSupport() *Support {
 	return &s.supports
-}
-
-func (s *DpeEmulator) GetProfile() Profile {
-	return DPE_SIMULATOR_PROFILE
 }
 
 func (s *DpeEmulator) GetSupportedLocalities() []uint32 {

--- a/verification/getCertificateChain_test.go
+++ b/verification/getCertificateChain_test.go
@@ -37,7 +37,7 @@ func testGetCertificateChain(d TestDPEInstance, t *testing.T) {
 		}
 		defer d.PowerOff()
 	}
-	client, err := NewClient256(d)
+	client, err := NewClient(d)
 	if err != nil {
 		t.Fatalf("[FATAL]: Could not initialize client: %v", err)
 	}

--- a/verification/getProfile_test.go
+++ b/verification/getProfile_test.go
@@ -243,7 +243,7 @@ func testGetProfile(d TestDPEInstance, t *testing.T) {
 		}
 		defer d.PowerOff()
 	}
-	client, err := NewClient256(d)
+	client, err := NewClient(d)
 	if err != nil {
 		t.Fatalf("Could not initialize client: %v", err)
 	}
@@ -253,9 +253,6 @@ func testGetProfile(d TestDPEInstance, t *testing.T) {
 		rsp, err := client.GetProfile()
 		if err != nil {
 			t.Fatalf("Unable to get profile: %v", err)
-		}
-		if rsp.Profile != d.GetProfile() {
-			t.Fatalf("Incorrect profile. 0x%08x != 0x%08x", d.GetProfile(), rsp.Profile)
 		}
 		if rsp.MajorVersion != d.GetProfileMajorVersion() {
 			t.Fatalf("Incorrect version. 0x%08x != 0x%08x", d.GetProfileMajorVersion(), rsp.MajorVersion)

--- a/verification/initializeContext_test.go
+++ b/verification/initializeContext_test.go
@@ -55,7 +55,7 @@ func testInitContext(d TestDPEInstance, t *testing.T) {
 		defer d.PowerOff()
 	}
 
-	client, err := NewClient256(d)
+	client, err := NewClient(d)
 	if err != nil {
 		t.Fatalf("Could not initialize client: %v", err)
 	}

--- a/verification/profile.go
+++ b/verification/profile.go
@@ -14,6 +14,26 @@ const (
 	ProfileP384SHA384 Profile = 2
 )
 
+func (p Profile) GetDigestSize() int {
+	switch p {
+	case ProfileP256SHA256:
+		return 32
+	case ProfileP384SHA384:
+		return 48
+	}
+	return 0
+}
+
+func (p Profile) GetECCIntSize() int {
+	switch p {
+	case ProfileP256SHA256:
+		return 32
+	case ProfileP384SHA384:
+		return 48
+	}
+	return 0
+}
+
 func (p Profile) String() string {
 	switch p {
 	case ProfileP256SHA256:
@@ -27,21 +47,41 @@ func (p Profile) String() string {
 // Curve is a type constraint enumerating the supported ECC curves for DPE profiles.
 type Curve interface {
 	NISTP256Parameter | NISTP384Parameter
+
+	Slice() []byte
 }
 
 // NISTP256Parameter represents a NIST P-256 curve parameter, i.e., an x, y, r, or s value.
 type NISTP256Parameter [32]byte
 
+func (p NISTP256Parameter) Slice() []byte {
+	return p[:]
+}
+
 // NISTP384Parameter represents a NIST P-384 curve parameter, i.e., an x, y, r, or s value.
 type NISTP384Parameter [48]byte
+
+func (p NISTP384Parameter) Slice() []byte {
+	return p[:]
+}
 
 // DigestAlgorithm is a type constraint enumerating the supported hashing algorithms for DPE profiles.
 type DigestAlgorithm interface {
 	SHA256Digest | SHA384Digest
+
+	Slice() []byte
 }
 
 // SHA256Digest represents a SHA-256 digest value.
 type SHA256Digest [32]byte
 
+func (p SHA256Digest) Slice() []byte {
+	return p[:]
+}
+
 // SHA384Digest represents a SHA-384 digest value.
 type SHA384Digest [48]byte
+
+func (p SHA384Digest) Slice() []byte {
+	return p[:]
+}

--- a/verification/simulator.go
+++ b/verification/simulator.go
@@ -17,14 +17,13 @@ import (
 const (
 	simulatorSocketPath = "/tmp/dpe-sim.socket"
 
-	DPE_SIMULATOR_AUTO_INIT_LOCALITY    uint32  = 0
-	DPE_SIMULATOR_OTHER_LOCALITY        uint32  = 0x4f544852
-	DPE_SIMULATOR_PROFILE               Profile = ProfileP256SHA256
-	DPE_SIMULATOR_MAX_TCI_NODES         uint32  = 24
-	DPE_SIMULATOR_MAJOR_PROFILE_VERSION uint16  = CURRENT_PROFILE_MAJOR_VERSION
-	DPE_SIMULATOR_MINOR_PROFILE_VERSION uint16  = CURRENT_PROFILE_MINOR_VERSION
-	DPE_SIMULATOR_VENDOR_ID             uint32  = 0
-	DPE_SIMULATOR_VENDOR_SKU            uint32  = 0
+	DPE_SIMULATOR_AUTO_INIT_LOCALITY    uint32 = 0
+	DPE_SIMULATOR_OTHER_LOCALITY        uint32 = 0x4f544852
+	DPE_SIMULATOR_MAX_TCI_NODES         uint32 = 24
+	DPE_SIMULATOR_MAJOR_PROFILE_VERSION uint16 = CURRENT_PROFILE_MAJOR_VERSION
+	DPE_SIMULATOR_MINOR_PROFILE_VERSION uint16 = CURRENT_PROFILE_MINOR_VERSION
+	DPE_SIMULATOR_VENDOR_ID             uint32 = 0
+	DPE_SIMULATOR_VENDOR_SKU            uint32 = 0
 )
 
 type DpeSimulator struct {
@@ -157,10 +156,6 @@ func (s *DpeSimulator) SendCmd(buf []byte) ([]byte, error) {
 
 func (s *DpeSimulator) GetSupport() *Support {
 	return &s.supports
-}
-
-func (s *DpeSimulator) GetProfile() Profile {
-	return DPE_SIMULATOR_PROFILE
 }
 
 func (s *DpeSimulator) GetSupportedLocalities() []uint32 {

--- a/verification/tagTCI_test.go
+++ b/verification/tagTCI_test.go
@@ -5,6 +5,7 @@ package verification
 import (
 	"errors"
 	"log"
+	"reflect"
 	"testing"
 )
 
@@ -35,9 +36,14 @@ func testtagTCI(d TestDPEInstance, t *testing.T) {
 		defer d.PowerOff()
 	}
 
-	client, err := NewClient256(d)
+	client, err := NewClient(d)
 	if err != nil {
 		t.Fatalf("Could not initialize client: %v", err)
+	}
+
+	profile, err := client.GetProfile()
+	if err != nil {
+		t.Fatalf("Could not get profile: %v", err)
 	}
 
 	// Try to create the default context if isn't done automatically.
@@ -72,13 +78,13 @@ func testtagTCI(d TestDPEInstance, t *testing.T) {
 		t.Fatalf("Could not get tagged TCI: %v", err)
 	}
 
-	var wantCumulativeTCI SHA256Digest
-	if getResp.CumulativeTCI != wantCumulativeTCI {
+	wantCumulativeTCI := make([]byte, profile.Profile.GetDigestSize())
+	if !reflect.DeepEqual(getResp.CumulativeTCI, wantCumulativeTCI) {
 		t.Errorf("GetTaggedTCI returned cumulative TCI %x, expected %x", getResp.CumulativeTCI, wantCumulativeTCI)
 	}
 
-	var wantCurrentTCI SHA256Digest
-	if getResp.CurrentTCI != wantCurrentTCI {
+	wantCurrentTCI := make([]byte, profile.Profile.GetDigestSize())
+	if !reflect.DeepEqual(getResp.CurrentTCI, wantCurrentTCI) {
 		t.Errorf("GetTaggedTCI returned current TCI %x, expected %x", getResp.CurrentTCI, wantCurrentTCI)
 	}
 

--- a/verification/verification_test.go
+++ b/verification/verification_test.go
@@ -51,8 +51,6 @@ type TestDPEInstance interface {
 	// it supports, but this function is used by tests to know how to test the DPE
 	// instance.
 	GetSupport() *Support
-	// Returns the profile the transport supports.
-	GetProfile() Profile
 	// Returns a slice of all the localities the instance supports.
 	GetSupportedLocalities() []uint32
 	// Sets the current locality.


### PR DESCRIPTION
Make the go verification tests more generic so they can be run against either the 256 or 384 profile.

The tests will be run against the profile reported by the target.