### PR TITLE
Add macro for const joining bitflags.

### DIFF
--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -84,3 +84,14 @@ pub const DPE_PROFILE: DpeProfile = DpeProfile::P256Sha256;
 
 #[cfg(feature = "dpe_profile_p384_sha384")]
 pub const DPE_PROFILE: DpeProfile = DpeProfile::P384Sha384;
+
+// Recursive macro that does a union of all the flags passed to it. This is
+// const and looks about as nice as using the | operator.
+#[macro_export]
+macro_rules! bitflags_join {
+    // If input is just one element, output it
+    ($x: expr) => ($x);
+    // In input is 1 or more comma separated things, take the first one, and call
+    // .union(bitflags_join!(remaining))
+    ($x: expr, $($z: expr),+) => ($x.union(bitflags_join!($($z),*)));
+}

--- a/dpe/src/support.rs
+++ b/dpe/src/support.rs
@@ -61,16 +61,14 @@ impl Support {
 #[cfg(test)]
 pub mod test {
     use super::*;
+    use crate::bitflags_join;
 
-    pub const SUPPORT: Support = Support::union(
-        Support::union(
-            Support::union(
-                Support::union(Support::SIMULATION, Support::AUTO_INIT),
-                Support::TAGGING,
-            ),
-            Support::ROTATE_CONTEXT,
-        ),
-        Support::X509,
+    pub const SUPPORT: Support = bitflags_join!(
+        Support::SIMULATION,
+        Support::AUTO_INIT,
+        Support::TAGGING,
+        Support::ROTATE_CONTEXT,
+        Support::X509
     );
 
     #[test]


### PR DESCRIPTION
bitflags only supports a union function for combining flags for a const variable. This adds a macro made by @jhand2 to make it much cleaner to combine multiple.