### PR TITLE
Implement CertifyKey with CSRs and add encodings of CMS/CSRs

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -7,19 +7,19 @@ set -ex
 function build_rust_targets() {
   profile=$1
 
-  cargo build --release --manifest-path crypto/Cargo.toml --features=$profile --no-default-features
+  cargo build --release --manifest-path crypto/Cargo.toml --no-default-features
   cargo build --release --manifest-path platform/Cargo.toml --features=$profile --no-default-features
   cargo build --release --manifest-path dpe/Cargo.toml --features=$profile --no-default-features
   cargo build --release --manifest-path simulator/Cargo.toml #--features=$profile --no-default-features
   cargo build --release --manifest-path tools/Cargo.toml --features=$profile --no-default-features
 
-  cargo build --manifest-path crypto/Cargo.toml --features=$profile --no-default-features
+  cargo build --manifest-path crypto/Cargo.toml --no-default-features
   cargo build --manifest-path platform/Cargo.toml --features=$profile --no-default-features
   cargo build --manifest-path dpe/Cargo.toml --features=$profile --no-default-features
   cargo build --manifest-path simulator/Cargo.toml #--features=$profile
   cargo build --manifest-path tools/Cargo.toml --features=$profile --no-default-features
 
-  cargo clippy --manifest-path crypto/Cargo.toml --features=$profile --no-default-features -- --deny=warnings
+  cargo clippy --manifest-path crypto/Cargo.toml --no-default-features -- --deny=warnings
   cargo clippy --manifest-path platform/Cargo.toml --features=$profile --no-default-features -- --deny=warnings
   cargo clippy --manifest-path dpe/Cargo.toml --features=$profile --no-default-features -- --deny=warnings
   cargo clippy --manifest-path simulator/Cargo.toml -- --deny=warnings #--features=$profile --no-default-features
@@ -45,7 +45,7 @@ function test_rust_targets() {
   profile=$1
 
   cargo test --manifest-path platform/Cargo.toml --features=$profile --no-default-features
-  cargo test --manifest-path crypto/Cargo.toml --features=$profile --no-default-features
+  cargo test --manifest-path crypto/Cargo.toml --no-default-features
   cargo test --manifest-path dpe/Cargo.toml --features=$profile --no-default-features
   cargo test --manifest-path simulator/Cargo.toml #--features=$profile --no-default-features
 }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -8,9 +8,6 @@ edition = "2021"
 [features]
 openssl = ["dep:openssl", "dep:hkdf", "dep:sha2"]
 deterministic_rand = ["dep:rand"]
-default = ["dpe_profile_p256_sha256"]
-dpe_profile_p256_sha256 = []
-dpe_profile_p384_sha384 = []
 
 [dependencies]
 arrayvec = { version = "0.7.4", default-features = false }

--- a/crypto/build.rs
+++ b/crypto/build.rs
@@ -12,35 +12,49 @@ fn main() {
             std::path::Path,
         };
 
-        #[cfg(feature = "dpe_profile_p256_sha256")]
-        const ALIAS_PRIV: &str = "../platform/src/test_data/key_256.pem";
+        const ALIAS_PRIV_256: &str = "../platform/src/test_data/key_256.pem";
+        const ALIAS_PRIV_384: &str = "../platform/src/test_data/key_384.pem";
 
-        #[cfg(feature = "dpe_profile_p384_sha384")]
-        const ALIAS_PRIV: &str = "../platform/src/test_data/key_384.pem";
+        const CURVE_ID_256: nid::Nid = nid::Nid::X9_62_PRIME256V1;
+        const CURVE_ID_384: nid::Nid = nid::Nid::SECP384R1;
 
-        #[cfg(feature = "dpe_profile_p256_sha256")]
-        const CURVE_ID: nid::Nid = nid::Nid::X9_62_PRIME256V1;
-
-        #[cfg(feature = "dpe_profile_p384_sha384")]
-        const CURVE_ID: nid::Nid = nid::Nid::SECP384R1;
-
-        println!("cargo:rerun-if-changed={ALIAS_PRIV}");
+        println!("cargo:rerun-if-changed={ALIAS_PRIV_256}");
+        println!("cargo:rerun-if-changed={ALIAS_PRIV_384}");
 
         let out_dir = env::var_os("OUT_DIR").unwrap();
 
-        let pem = if Path::new(ALIAS_PRIV).exists() {
-            let input_pem = fs::read(ALIAS_PRIV).unwrap();
+        // generate 256 bit private key in PEM format
+        let pem_256 = if Path::new(ALIAS_PRIV_256).exists() {
+            let input_pem = fs::read(ALIAS_PRIV_256).unwrap();
             let ec_priv: ec::EcKey<pkey::Private> =
                 ec::EcKey::private_key_from_pem(&input_pem).unwrap();
             ec_priv.private_key_to_pem().unwrap()
         } else {
-            let group = ec::EcGroup::from_curve_name(CURVE_ID).unwrap();
+            let group = ec::EcGroup::from_curve_name(CURVE_ID_256).unwrap();
             let ec_key = ec::EcKey::generate(&group).unwrap();
             ec_key.private_key_to_pem().unwrap()
         };
 
-        let path = Path::new(&out_dir).join("alias_priv.pem");
-        let mut sample_alias_key_file = File::create(path).unwrap();
-        sample_alias_key_file.write_all(&pem).unwrap();
+        // generate 384 bit private key in PEM format
+        let pem_384 = if Path::new(ALIAS_PRIV_384).exists() {
+            let input_pem = fs::read(ALIAS_PRIV_384).unwrap();
+            let ec_priv: ec::EcKey<pkey::Private> =
+                ec::EcKey::private_key_from_pem(&input_pem).unwrap();
+            ec_priv.private_key_to_pem().unwrap()
+        } else {
+            let group = ec::EcGroup::from_curve_name(CURVE_ID_384).unwrap();
+            let ec_key = ec::EcKey::generate(&group).unwrap();
+            ec_key.private_key_to_pem().unwrap()
+        };
+
+        // write 256 bit private key to file
+        let path_256 = Path::new(&out_dir).join("alias_priv_256.pem");
+        let mut sample_alias_key_file_256 = File::create(path_256).unwrap();
+        sample_alias_key_file_256.write_all(&pem_256).unwrap();
+
+        // write 384 bit private key to file
+        let path_384 = Path::new(&out_dir).join("alias_priv_384.pem");
+        let mut sample_alias_key_file_384 = File::create(path_384).unwrap();
+        sample_alias_key_file_384.write_all(&pem_384).unwrap();
     }
 }

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -183,7 +183,7 @@ pub trait Crypto {
         algs: AlgLen,
         digest: &Digest,
         priv_key: &Self::PrivKey,
-        pub_key: EcdsaPub,
+        pub_key: &EcdsaPub,
     ) -> Result<EcdsaSig, CryptoError>;
 
     /// Sign `digest` with a derived HMAC key from the CDI.

--- a/crypto/src/openssl.rs
+++ b/crypto/src/openssl.rs
@@ -186,8 +186,18 @@ impl Crypto for OpensslCrypto {
         algs: AlgLen,
         digest: &Digest,
     ) -> Result<super::EcdsaSig, CryptoError> {
-        let pem = include_bytes!(concat!(env!("OUT_DIR"), "/alias_priv.pem"));
-        let ec_priv: EcKey<Private> = EcKey::private_key_from_pem(pem).unwrap();
+        let ec_priv: EcKey<Private> = match algs {
+            AlgLen::Bit256 => EcKey::private_key_from_pem(include_bytes!(concat!(
+                env!("OUT_DIR"),
+                "/alias_priv_256.pem"
+            )))
+            .unwrap(),
+            AlgLen::Bit384 => EcKey::private_key_from_pem(include_bytes!(concat!(
+                env!("OUT_DIR"),
+                "/alias_priv_384.pem"
+            )))
+            .unwrap(),
+        };
 
         let sig = EcdsaSig::sign::<Private>(digest.bytes(), &ec_priv)
             .map_err(|_| CryptoError::CryptoLibError)?;
@@ -203,7 +213,7 @@ impl Crypto for OpensslCrypto {
         algs: AlgLen,
         digest: &Digest,
         priv_key: &Self::PrivKey,
-        _pub_key: EcdsaPub,
+        _pub_key: &EcdsaPub,
     ) -> Result<super::EcdsaSig, CryptoError> {
         let ec_priv_key = OpensslCrypto::ec_key_from_priv_key(algs, priv_key)
             .map_err(|_| CryptoError::CryptoLibError)?;

--- a/dpe/Cargo.lock
+++ b/dpe/Cargo.lock
@@ -75,10 +75,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "base64"
-version = "0.13.1"
+name = "base64ct"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bitflags"
@@ -124,6 +124,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cms"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b1b34bce0eaafd63b374fa6b58178d72c0b6670e92db786bdd3cde9e37a1f1"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "x509-cert",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +184,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
+name = "der"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+dependencies = [
+ "const-oid",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "der-parser"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +208,17 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rusticata-macros",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -207,15 +249,24 @@ version = "0.1.0"
 dependencies = [
  "asn1",
  "bitflags",
+ "cms",
  "constant_time_eq",
  "crypto",
+ "der",
  "openssl",
  "platform",
+ "spki",
  "ufmt",
  "x509-parser",
  "zerocopy",
  "zeroize",
 ]
+
+[[package]]
+name = "flagset"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a7e408202050813e6f1d9addadcaafef3dca7530c7ddfb005d4081cce6779"
 
 [[package]]
 name = "foreign-types"
@@ -395,6 +446,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +546,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -636,13 +706,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "x509-parser"
-version = "0.14.0"
+name = "x509-cert"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
+checksum = "25eefca1d99701da3a57feb07e5079fc62abba059fc139e98c13bbb250f3ef29"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7069fba5b66b9193bd2c5d3d4ff12b839118f6bcbef5328efafafb5395cf63da"
 dependencies = [
  "asn1-rs",
- "base64",
  "data-encoding",
  "der-parser",
  "lazy_static",

--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -22,6 +22,9 @@ zeroize = { version = "1.6.0", default-features = false, features = ["zeroize_de
 [dev-dependencies]
 asn1 = "0.13.0"
 openssl = "0.10.57"
-x509-parser = "0.14.0"
+x509-parser = "0.15.1"
 crypto = {path = "../crypto", features = ["deterministic_rand", "openssl"]}
 platform = {path = "../platform", features = ["openssl"]}
+cms = "0.2.2"
+der = "0.7.8"
+spki = "0.7.2"

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -53,7 +53,7 @@ impl SignCmd {
 
         let sig = env
             .crypto
-            .ecdsa_sign_with_derived(algs, digest, &priv_key, pub_key)
+            .ecdsa_sign_with_derived(algs, digest, &priv_key, &pub_key)
             .map_err(|_| DpeErrorCode::CryptoError)?;
 
         Ok(sig)

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 
 [features]
 default = ["dpe_profile_p256_sha256"]
-dpe_profile_p256_sha256 = ["dpe/dpe_profile_p256_sha256", "crypto/dpe_profile_p256_sha256", "platform/dpe_profile_p256_sha256"]
-dpe_profile_p384_sha384 = ["dpe/dpe_profile_p384_sha384", "crypto/dpe_profile_p384_sha384", "platform/dpe_profile_p384_sha384"]
+dpe_profile_p256_sha256 = ["dpe/dpe_profile_p256_sha256", "platform/dpe_profile_p256_sha256"]
+dpe_profile_p384_sha384 = ["dpe/dpe_profile_p384_sha384", "platform/dpe_profile_p384_sha384"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -9,12 +9,10 @@ edition = "2021"
 default = ["dpe_profile_p256_sha256"]
 dpe_profile_p256_sha256 = [
   "dpe/dpe_profile_p256_sha256",
-  "crypto/dpe_profile_p256_sha256",
   "platform/dpe_profile_p256_sha256"
 ]
 dpe_profile_p384_sha384 = [
   "dpe/dpe_profile_p384_sha384",
-  "crypto/dpe_profile_p384_sha384",
   "platform/dpe_profile_p384_sha384"
 ]
 


### PR DESCRIPTION
Also, rework build.rs to write both the 256 bit and 384 bit private keys. This is necessary because feature compilation doesn't work in build.rs. Then when we read the alias key in OpensslCrypto::ecdsa_sign_with_alias, we can read from the proper file based on the value of the algorithm size. 

fixes #237 
fixes #83 