### PR TITLE
Add a wrapper around the generics-based DPE clients

### DIFF
--- a/verification/abi.go
+++ b/verification/abi.go
@@ -2,6 +2,12 @@
 
 package verification
 
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
 const (
 	CmdMagic  uint32 = 0x44504543
 	RespMagic uint32 = 0x44504552
@@ -11,6 +17,20 @@ const (
 )
 
 type CommandCode uint32
+
+type Support struct {
+	Simulation    bool
+	ExtendTci     bool
+	AutoInit      bool
+	Tagging       bool
+	RotateContext bool
+	X509          bool
+	Csr           bool
+	IsSymmetric   bool
+	InternalInfo  bool
+	InternalDice  bool
+	IsCA          bool
+}
 
 const (
 	CommandGetProfile          CommandCode = 0x1
@@ -35,28 +55,33 @@ type RespHdr struct {
 }
 
 type InitCtxCmd struct {
-	flags uint32
+	flags InitCtxFlags
 }
 
-func NewInitCtxIsDefault() *InitCtxCmd {
-	return &InitCtxCmd{flags: 1 << 30}
-}
+type InitCtxFlags uint32
 
-func NewInitCtxIsSimulation() *InitCtxCmd {
-	return &InitCtxCmd{flags: 1 << 31}
-}
+const (
+	InitIsSimulation InitCtxFlags = 1 << 31
+	InitIsDefault    InitCtxFlags = 1 << 30
+)
 
 type ContextHandle [16]byte
 
+type DestroyCtxFlags uint32
+
+const (
+	DestroyDescendants DestroyCtxFlags = 1 << 31
+)
+
 type DestroyCtxCmd struct {
 	handle ContextHandle
-	flags  uint32
+	flags  DestroyCtxFlags
 }
 
 func NewDestroyCtx(handle ContextHandle, destroy_descendants bool) *DestroyCtxCmd {
-	flags := uint32(0)
+	flags := DestroyCtxFlags(0)
 	if destroy_descendants {
-		flags |= 1 << 31
+		flags |= DestroyDescendants
 	}
 	return &DestroyCtxCmd{handle: handle, flags: flags}
 }
@@ -76,6 +101,10 @@ type GetProfileResp struct {
 }
 
 type CertifyKeyFlags uint32
+
+const (
+	CertifyAddIsCA CertifyKeyFlags = 1 << 30
+)
 
 type CertifyKeyFormat uint32
 
@@ -125,4 +154,371 @@ type GetTaggedTCIReq struct {
 type GetTaggedTCIResp[Digest DigestAlgorithm] struct {
 	CumulativeTCI Digest
 	CurrentTCI    Digest
+}
+
+// dpeABI is a connection to a DPE instance, parameterized by hash algorithm and ECC curve.
+type dpeABI[CurveParameter Curve, Digest DigestAlgorithm] struct {
+	transport    Transport
+	Profile      Profile
+	MajorVersion uint16
+	MinorVersion uint16
+	VendorId     uint32
+	VendorSku    uint32
+	MaxTciNodes  uint32
+	Flags        uint32
+}
+
+// DPEABI256 is a client that implements DPE_PROFILE_IROT_P256_SHA256
+type DPEABI256 = dpeABI[NISTP256Parameter, SHA256Digest]
+
+// DPEABI384 is a client that implements DPE_PROFILE_IROT_P384_SHA384
+type DPEABI384 = dpeABI[NISTP384Parameter, SHA384Digest]
+
+// dpeProfileImplementsTypeConstraints checks that the requested dpeABI type constraints are compatible with the DPE profile.
+func dpeProfileImplementsTypeConstraints[C Curve, D DigestAlgorithm](profile Profile) error {
+	// Test that the expected value types produced by each DPE profile can be assigned to variables of type C and D
+	var c C
+	var d D
+
+	var targetProfile Profile
+	_, isP256 := any(c).(NISTP256Parameter)
+	_, isSHA256 := any(d).(SHA256Digest)
+	_, isP384 := any(c).(NISTP384Parameter)
+	_, isSHA384 := any(d).(SHA384Digest)
+
+	if isP256 && isSHA256 {
+		targetProfile = ProfileP256SHA256
+	} else if isP384 && isSHA384 {
+		targetProfile = ProfileP384SHA384
+	} else {
+		return fmt.Errorf("Client requested (Curve = %v, Digest = %v), this is an invalid DPE profile",
+			reflect.TypeOf(c), reflect.TypeOf(d))
+	}
+
+	if profile != targetProfile {
+		fmt.Errorf("Expected profile %v, got profile %v", targetProfile, profile)
+	}
+
+	return nil
+}
+
+// newDPEABI initializes a new DPE client.
+func newDPEABI[C Curve, D DigestAlgorithm](t Transport) (*dpeABI[C, D], error) {
+	rsp, err := getProfile(t)
+	if err != nil {
+		return nil, fmt.Errorf("could not query DPE for profile: %w", err)
+	}
+
+	if err := dpeProfileImplementsTypeConstraints[C, D](rsp.Profile); err != nil {
+		return nil, err
+	}
+
+	return &dpeABI[C, D]{
+		transport:    t,
+		Profile:      rsp.Profile,
+		MajorVersion: rsp.MajorVersion,
+		MinorVersion: rsp.MinorVersion,
+		VendorId:     rsp.VendorId,
+		VendorSku:    rsp.VendorSku,
+		Flags:        rsp.Flags,
+	}, nil
+}
+
+// NewDPEABI256 is a convenience wrapper for NewDPEABI[NISTP256Parameter, SHA256Digest].
+func NewDPEABI256(t Transport) (*dpeABI[NISTP256Parameter, SHA256Digest], error) {
+	return newDPEABI[NISTP256Parameter, SHA256Digest](t)
+}
+
+// NewDPEABI256 is a convenience wrapper for NewDPEABI[NISTP384Parameter, SHA384Digest].
+func NewDPEABI384(t Transport) (*dpeABI[NISTP384Parameter, SHA384Digest], error) {
+	return newDPEABI[NISTP384Parameter, SHA384Digest](t)
+}
+
+func (c *dpeABI[_, _]) InitializeContextABI(cmd *InitCtxCmd) (*InitCtxResp, error) {
+	var respStruct InitCtxResp
+
+	if _, err := execCommand(c.transport, CommandInitializeContext, c.Profile, cmd, &respStruct); err != nil {
+		return nil, err
+	}
+
+	return &respStruct, nil
+}
+
+func GetTransportProfile(t Transport) (Profile, error) {
+	resp, err := getProfile(t)
+	if err != nil {
+		return 0, err
+	}
+
+	return resp.Profile, nil
+}
+
+// getProfile is an internal helper for handling GetProfile as part of either the client API or initialization.
+func getProfile(t Transport) (*GetProfileResp, error) {
+	// GetProfile does not take any parameters.
+	cmd := struct{}{}
+
+	// Define an anonymous struct for the actual wire-format members of GetProfile,
+	// since GetProfileResp includes the actual profile copied from the response header.
+	respStruct := struct {
+		MajorVersion uint16
+		MinorVersion uint16
+		VendorId     uint32
+		VendorSku    uint32
+		MaxTciNodes  uint32
+		Flags        uint32
+	}{}
+
+	respHdr, err := execCommand(t, CommandGetProfile, 0, cmd, &respStruct)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GetProfileResp{
+		// Special case for GetProfile: copy the profile from the inner packet header into the response structure.
+		Profile:      respHdr.Profile,
+		MajorVersion: respStruct.MajorVersion,
+		MinorVersion: respStruct.MinorVersion,
+		VendorId:     respStruct.VendorId,
+		VendorSku:    respStruct.VendorSku,
+		MaxTciNodes:  respStruct.MaxTciNodes,
+		Flags:        respStruct.Flags,
+	}, nil
+}
+
+func (c *dpeABI[_, _]) GetProfileABI() (*GetProfileResp, error) {
+	return getProfile(c.transport)
+}
+
+// Send the command to destroy a context.
+func (c *dpeABI[_, _]) DestroyContextABI(cmd *DestroyCtxCmd) error {
+	// DestroyContext does not return any parameters.
+	respStruct := struct{}{}
+
+	if _, err := execCommand(c.transport, CommandDestroyContext, c.Profile, cmd, &respStruct); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CertifyKey calls the DPE CertifyKey command.
+func (c *dpeABI[CurveParameter, Digest]) CertifyKeyABI(cmd *CertifyKeyReq[Digest]) (*CertifyKeyResp[CurveParameter, Digest], error) {
+	// Define an anonymous struct for the response, because we have to accept the variable-sized certificate.
+	respStruct := struct {
+		NewContextHandle  [16]byte
+		DerivedPublicKeyX CurveParameter
+		DerivedPublicKeyY CurveParameter
+		CertificateSize   uint32
+		Certificate       [2048]byte
+	}{}
+
+	_, err := execCommand(c.transport, CommandCertifyKey, c.Profile, cmd, &respStruct)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check that the reported cert size makes sense.
+	if respStruct.CertificateSize > 2048 {
+		return nil, fmt.Errorf("DPE reported a %d-byte cert, which was larger than 2048", respStruct.CertificateSize)
+	}
+
+	return &CertifyKeyResp[CurveParameter, Digest]{
+		NewContextHandle:  respStruct.NewContextHandle,
+		DerivedPublicKeyX: respStruct.DerivedPublicKeyX,
+		DerivedPublicKeyY: respStruct.DerivedPublicKeyY,
+		Certificate:       respStruct.Certificate[:respStruct.CertificateSize],
+	}, nil
+}
+
+// GetCertificateChain calls the DPE GetCertificateChain command.
+func (c *dpeABI[_, _]) GetCertificateChainABI() (*GetCertificateChainResp, error) {
+	var certs GetCertificateChainResp
+
+	// Initialize request input parameters
+	cmd := GetCertificateChainReq{
+		Offset: 0,
+		Size:   MaxChunkSize,
+	}
+
+	for {
+		respStruct := struct {
+			CertificateSize  uint32
+			CertificateChain [2048]byte
+		}{}
+
+		_, err := execCommand(c.transport, CommandGetCertificateChain, c.Profile, cmd, &respStruct)
+		if err == StatusInvalidArgument {
+			// This indicates that there are no more bytes to be read in certificate chain
+			break
+		} else if err != nil {
+			// This indicates error in processing GetCertificateChain command
+			return nil, err
+		}
+
+		certs.CertificateChain = append(certs.CertificateChain, respStruct.CertificateChain[:respStruct.CertificateSize]...)
+		if MaxChunkSize > respStruct.CertificateSize {
+			break
+		}
+		// Increment offset in steps of 2048 bytes till end of cert chain
+		cmd.Offset += MaxChunkSize
+	}
+
+	if len(certs.CertificateChain) == 0 {
+		return nil, errors.New("empty certificate chain")
+	}
+	return &certs, nil
+}
+
+// TagTCI calls the DPE TagTCI command.
+func (c *dpeABI[_, _]) TagTCIABI(cmd *TagTCIReq) (*TagTCIResp, error) {
+	var respStruct TagTCIResp
+
+	_, err := execCommand(c.transport, CommandTagTCI, c.Profile, cmd, &respStruct)
+	if err != nil {
+		return nil, err
+	}
+
+	return &respStruct, nil
+}
+
+// GetTaggedTCI calls the DPE GetTaggedTCI command.
+func (c *dpeABI[_, Digest]) GetTaggedTCIABI(cmd *GetTaggedTCIReq) (*GetTaggedTCIResp[Digest], error) {
+	var respStruct GetTaggedTCIResp[Digest]
+
+	_, err := execCommand(c.transport, CommandGetTaggedTCI, c.Profile, cmd, &respStruct)
+	if err != nil {
+		return nil, err
+	}
+
+	return &respStruct, nil
+}
+
+func (c *dpeABI[_, _]) InitializeContext(flags InitCtxFlags) (*ContextHandle, error) {
+	cmd := InitCtxCmd{flags: flags}
+	resp, err := c.InitializeContextABI(&cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp.Handle, nil
+}
+
+func (c *dpeABI[_, _]) GetProfile() (*GetProfileResp, error) {
+	return c.GetProfileABI()
+}
+
+func (c *dpeABI[_, Digest]) CertifyKey(handle *ContextHandle, label []byte, format CertifyKeyFormat, flags CertifyKeyFlags) (*CertifiedKey, error) {
+	cmd := CertifyKeyReq[Digest]{
+		ContextHandle: *handle,
+		Flags:         flags,
+		Label:         Digest(label),
+		Format:        format,
+	}
+
+	if len(label) != len(cmd.Label) {
+		return nil, fmt.Errorf("Invalid digest length")
+	}
+
+	resp, err := c.CertifyKeyABI(&cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	key := &CertifiedKey{
+		Handle: resp.NewContextHandle,
+		Pub: DPEPubKey{
+			X: resp.DerivedPublicKeyX.Bytes(),
+			Y: resp.DerivedPublicKeyY.Bytes(),
+		},
+		Certificate: resp.Certificate,
+	}
+
+	return key, nil
+}
+
+func (c *dpeABI[_, _]) TagTCI(handle *ContextHandle, tag TCITag) (*ContextHandle, error) {
+	cmd := TagTCIReq{
+		ContextHandle: *handle,
+		Tag:           tag,
+	}
+
+	resp, err := c.TagTCIABI(&cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp.NewContextHandle, nil
+}
+
+func (c *dpeABI[_, _]) GetTaggedTCI(tag TCITag) (*DPETCI, error) {
+	cmd := GetTaggedTCIReq{
+		Tag: tag,
+	}
+
+	resp, err := c.GetTaggedTCIABI(&cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DPETCI{
+		CumulativeTCI: resp.CumulativeTCI.Bytes(),
+		CurrentTCI:    resp.CurrentTCI.Bytes(),
+	}, nil
+}
+
+func (c *dpeABI[_, _]) DestroyContext(handle *ContextHandle, flags DestroyCtxFlags) error {
+	cmd := DestroyCtxCmd{
+		handle: *handle,
+		flags:  flags,
+	}
+
+	return c.DestroyContextABI(&cmd)
+}
+
+func (c *dpeABI[_, _]) GetCertificateChain() ([]byte, error) {
+	resp, err := c.GetCertificateChainABI()
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.CertificateChain, nil
+}
+
+func (s *Support) ToFlags() uint32 {
+	flags := uint32(0)
+	if s.Simulation {
+		flags |= (1 << 31)
+	}
+	if s.ExtendTci {
+		flags |= (1 << 30)
+	}
+	if s.AutoInit {
+		flags |= (1 << 29)
+	}
+	if s.Tagging {
+		flags |= (1 << 28)
+	}
+	if s.RotateContext {
+		flags |= (1 << 27)
+	}
+	if s.X509 {
+		flags |= (1 << 26)
+	}
+	if s.Csr {
+		flags |= (1 << 25)
+	}
+	if s.IsSymmetric {
+		flags |= (1 << 24)
+	}
+	if s.InternalInfo {
+		flags |= (1 << 23)
+	}
+	if s.InternalDice {
+		flags |= (1 << 22)
+	}
+	if s.IsCA {
+		flags |= (1 << 21)
+	}
+	return flags
 }

--- a/verification/client.go
+++ b/verification/client.go
@@ -3,7 +3,6 @@
 package verification
 
 import (
-	"errors"
 	"fmt"
 )
 
@@ -11,289 +10,46 @@ const (
 	MaxChunkSize = 2048
 )
 
-type Support struct {
-	Simulation    bool
-	ExtendTci     bool
-	AutoInit      bool
-	Tagging       bool
-	RotateContext bool
-	X509          bool
-	Csr           bool
-	IsSymmetric   bool
-	InternalInfo  bool
-	InternalDice  bool
-	IsCA          bool
-}
-
 // Transport is an interface to define how to test and send messages to a DPE instance.
 type Transport interface {
 	// Send a command to the DPE instance.
 	SendCmd(buf []byte) ([]byte, error)
 }
 
-// Client is a connection to a DPE instance, parameterized by hash algorithm and ECC curve.
-type Client[CurveParameter Curve, Digest DigestAlgorithm] struct {
-	transport    Transport
-	Profile      Profile
-	MajorVersion uint16
-	MinorVersion uint16
-	VendorId     uint32
-	VendorSku    uint32
-	MaxTciNodes  uint32
-	Flags        uint32
+// TODO: Include curve
+type DPEPubKey struct {
+	X []byte
+	Y []byte
 }
 
-// Client256 is a client that implements DPE_PROFILE_IROT_P256_SHA256
-type Client256 = Client[NISTP256Parameter, SHA256Digest]
+type CertifiedKey struct {
+	Handle      ContextHandle
+	Pub         DPEPubKey
+	Certificate []byte
+}
 
-// Client384 is a client that implements DPE_PROFILE_IROT_P384_SHA384
-type Client384 = Client[NISTP384Parameter, SHA384Digest]
+type DPETCI struct {
+	CumulativeTCI []byte
+	CurrentTCI    []byte
+}
 
-// dpeProfileImplementsTypeConstraints checks that the requested Client type constraints are compatible with the DPE profile.
-func dpeProfileImplementsTypeConstraints[C Curve, D DigestAlgorithm](profile Profile) error {
-	// Test that the expected value types produced by each DPE profile can be assigned to variables of type C and D
-	var c C
-	var d D
-	switch profile {
+type DPEClient interface {
+	InitializeContext(flags InitCtxFlags) (*ContextHandle, error)
+	GetProfile() (*GetProfileResp, error)
+	CertifyKey(handle *ContextHandle, label []byte, format CertifyKeyFormat, flags CertifyKeyFlags) (*CertifiedKey, error)
+	GetCertificateChain() ([]byte, error)
+	TagTCI(handle *ContextHandle, tag TCITag) (*ContextHandle, error)
+	GetTaggedTCI(tag TCITag) (*DPETCI, error)
+	DestroyContext(handle *ContextHandle, flags DestroyCtxFlags) error
+}
+
+func NewClient(t Transport, p Profile) (DPEClient, error) {
+	switch p {
 	case ProfileP256SHA256:
-		// We must cast c and d to any in order to perform type assertions on them.
-		// https://go.googlesource.com/proposal/+/refs/heads/master/design/43651-type-parameters.md#why-not-permit-type-assertions-on-values-whose-type-is-a-type-parameter
-		if _, ok := any(c).(NISTP256Parameter); !ok {
-			return fmt.Errorf("an incorrect ECC parameter type was passed to a DPE implementing DPE_PROFILE_IROT_P256_SHA256")
-		}
-		if _, ok := any(d).(SHA256Digest); !ok {
-			return fmt.Errorf("an incorrect digest type was passed to a DPE implementing DPE_PROFILE_IROT_P256_SHA256")
-		}
-		return nil
+		return NewDPEABI256(t)
 	case ProfileP384SHA384:
-		if _, ok := any(c).(NISTP384Parameter); !ok {
-			return fmt.Errorf("an incorrect ECC parameter type was passed to a DPE implementing DPE_PROFILE_IROT_P384_SHA384")
-		}
-		if _, ok := any(d).(SHA384Digest); !ok {
-			return fmt.Errorf("an incorrect digest type was passed to a DPE implementing DPE_PROFILE_IROT_P384_SHA384")
-		}
-		return nil
+		return NewDPEABI384(t)
+	default:
+		return nil, fmt.Errorf("Cannot create a DPE client for profile %d", p)
 	}
-	return fmt.Errorf("unsupported DPE profile: %v", profile)
-}
-
-// NewClient initializes a new DPE client.
-func NewClient[C Curve, D DigestAlgorithm](t Transport) (*Client[C, D], error) {
-	rsp, err := getProfile(t)
-	if err != nil {
-		return nil, fmt.Errorf("could not query DPE for profile: %w", err)
-	}
-
-	if err := dpeProfileImplementsTypeConstraints[C, D](rsp.Profile); err != nil {
-		return nil, err
-	}
-
-	return &Client[C, D]{
-		transport:    t,
-		Profile:      rsp.Profile,
-		MajorVersion: rsp.MajorVersion,
-		MinorVersion: rsp.MinorVersion,
-		VendorId:     rsp.VendorId,
-		VendorSku:    rsp.VendorSku,
-		Flags:        rsp.Flags,
-	}, nil
-}
-
-// NewClient256 is a convenience wrapper for NewClient[NISTP256Parameter, SHA256Digest].
-func NewClient256(t Transport) (*Client[NISTP256Parameter, SHA256Digest], error) {
-	return NewClient[NISTP256Parameter, SHA256Digest](t)
-}
-
-// NewClient256 is a convenience wrapper for NewClient[NISTP384Parameter, SHA384Digest].
-func NewClient384(t Transport) (*Client[NISTP384Parameter, SHA384Digest], error) {
-	return NewClient[NISTP384Parameter, SHA384Digest](t)
-}
-
-func (c *Client[_, _]) InitializeContext(cmd *InitCtxCmd) (*InitCtxResp, error) {
-	var respStruct InitCtxResp
-
-	if _, err := execCommand(c.transport, CommandInitializeContext, c.Profile, cmd, &respStruct); err != nil {
-		return nil, err
-	}
-
-	return &respStruct, nil
-}
-
-// getProfile is an internal helper for handling GetProfile as part of either the client API or initialization.
-func getProfile(t Transport) (*GetProfileResp, error) {
-	// GetProfile does not take any parameters.
-	cmd := struct{}{}
-
-	// Define an anonymous struct for the actual wire-format members of GetProfile,
-	// since GetProfileResp includes the actual profile copied from the response header.
-	respStruct := struct {
-		MajorVersion uint16
-		MinorVersion uint16
-		VendorId     uint32
-		VendorSku    uint32
-		MaxTciNodes  uint32
-		Flags        uint32
-	}{}
-
-	respHdr, err := execCommand(t, CommandGetProfile, 0, cmd, &respStruct)
-	if err != nil {
-		return nil, err
-	}
-
-	return &GetProfileResp{
-		// Special case for GetProfile: copy the profile from the inner packet header into the response structure.
-		Profile:      respHdr.Profile,
-		MajorVersion: respStruct.MajorVersion,
-		MinorVersion: respStruct.MinorVersion,
-		VendorId:     respStruct.VendorId,
-		VendorSku:    respStruct.VendorSku,
-		MaxTciNodes:  respStruct.MaxTciNodes,
-		Flags:        respStruct.Flags,
-	}, nil
-}
-
-func (c *Client[_, _]) GetProfile() (*GetProfileResp, error) {
-	return getProfile(c.transport)
-}
-
-// Send the command to destroy a context.
-func (c *Client[_, _]) DestroyContext(cmd *DestroyCtxCmd) error {
-	// DestroyContext does not return any parameters.
-	respStruct := struct{}{}
-
-	if _, err := execCommand(c.transport, CommandDestroyContext, c.Profile, cmd, &respStruct); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// CertifyKey calls the DPE CertifyKey command.
-func (c *Client[CurveParameter, Digest]) CertifyKey(cmd *CertifyKeyReq[Digest]) (*CertifyKeyResp[CurveParameter, Digest], error) {
-	// Define an anonymous struct for the response, because we have to accept the variable-sized certificate.
-	respStruct := struct {
-		NewContextHandle  [16]byte
-		DerivedPublicKeyX CurveParameter
-		DerivedPublicKeyY CurveParameter
-		CertificateSize   uint32
-		Certificate       [2048]byte
-	}{}
-
-	_, err := execCommand(c.transport, CommandCertifyKey, c.Profile, cmd, &respStruct)
-	if err != nil {
-		return nil, err
-	}
-
-	// Check that the reported cert size makes sense.
-	if respStruct.CertificateSize > 2048 {
-		return nil, fmt.Errorf("DPE reported a %d-byte cert, which was larger than 2048", respStruct.CertificateSize)
-	}
-
-	return &CertifyKeyResp[CurveParameter, Digest]{
-		NewContextHandle:  respStruct.NewContextHandle,
-		DerivedPublicKeyX: respStruct.DerivedPublicKeyX,
-		DerivedPublicKeyY: respStruct.DerivedPublicKeyY,
-		Certificate:       respStruct.Certificate[:respStruct.CertificateSize],
-	}, nil
-}
-
-// GetCertificateChain calls the DPE GetCertificateChain command.
-func (c *Client[_, _]) GetCertificateChain() (*GetCertificateChainResp, error) {
-	var certs GetCertificateChainResp
-
-	// Initialize request input parameters
-	cmd := GetCertificateChainReq{
-		Offset: 0,
-		Size:   MaxChunkSize,
-	}
-
-	for {
-		respStruct := struct {
-			CertificateSize  uint32
-			CertificateChain [2048]byte
-		}{}
-
-		_, err := execCommand(c.transport, CommandGetCertificateChain, c.Profile, cmd, &respStruct)
-		if err == StatusInvalidArgument {
-			// This indicates that there are no more bytes to be read in certificate chain
-			break
-		} else if err != nil {
-			// This indicates error in processing GetCertificateChain command
-			return nil, err
-		}
-
-		certs.CertificateChain = append(certs.CertificateChain, respStruct.CertificateChain[:respStruct.CertificateSize]...)
-		if MaxChunkSize > respStruct.CertificateSize {
-			break
-		}
-		// Increment offset in steps of 2048 bytes till end of cert chain
-		cmd.Offset += MaxChunkSize
-	}
-
-	if len(certs.CertificateChain) == 0 {
-		return nil, errors.New("empty certificate chain")
-	}
-	return &certs, nil
-}
-
-// TagTCI calls the DPE TagTCI command.
-func (c *Client[_, _]) TagTCI(cmd *TagTCIReq) (*TagTCIResp, error) {
-	var respStruct TagTCIResp
-
-	_, err := execCommand(c.transport, CommandTagTCI, c.Profile, cmd, &respStruct)
-	if err != nil {
-		return nil, err
-	}
-
-	return &respStruct, nil
-}
-
-// GetTaggedTCI calls the DPE GetTaggedTCI command.
-func (c *Client[_, Digest]) GetTaggedTCI(cmd *GetTaggedTCIReq) (*GetTaggedTCIResp[Digest], error) {
-	var respStruct GetTaggedTCIResp[Digest]
-
-	_, err := execCommand(c.transport, CommandGetTaggedTCI, c.Profile, cmd, &respStruct)
-	if err != nil {
-		return nil, err
-	}
-
-	return &respStruct, nil
-}
-
-func (s *Support) ToFlags() uint32 {
-	flags := uint32(0)
-	if s.Simulation {
-		flags |= (1 << 31)
-	}
-	if s.ExtendTci {
-		flags |= (1 << 30)
-	}
-	if s.AutoInit {
-		flags |= (1 << 29)
-	}
-	if s.Tagging {
-		flags |= (1 << 28)
-	}
-	if s.RotateContext {
-		flags |= (1 << 27)
-	}
-	if s.X509 {
-		flags |= (1 << 26)
-	}
-	if s.Csr {
-		flags |= (1 << 25)
-	}
-	if s.IsSymmetric {
-		flags |= (1 << 24)
-	}
-	if s.InternalInfo {
-		flags |= (1 << 23)
-	}
-	if s.InternalDice {
-		flags |= (1 << 22)
-	}
-	if s.IsCA {
-		flags |= (1 << 21)
-	}
-	return flags
 }

--- a/verification/getCertificateChain_test.go
+++ b/verification/getCertificateChain_test.go
@@ -37,17 +37,22 @@ func testGetCertificateChain(d TestDPEInstance, t *testing.T) {
 		}
 		defer d.PowerOff()
 	}
-	client, err := NewClient256(d)
+	profile, err := GetTransportProfile(d)
+	if err != nil {
+		t.Fatalf("Could not get profile: %v", err)
+	}
+
+	client, err := NewClient(d, profile)
 	if err != nil {
 		t.Fatalf("[FATAL]: Could not initialize client: %v", err)
 	}
 
-	getCertificateChainResp, err := client.GetCertificateChain()
+	certChain, err := client.GetCertificateChain()
 	if err != nil {
 		t.Fatalf("[FATAL]: Could not get Certificate Chain: %v", err)
 	}
 
-	checkCertificateChain(t, getCertificateChainResp.CertificateChain)
+	checkCertificateChain(t, certChain)
 }
 
 func checkCertificateChain(t *testing.T, certData []byte) []*x509.Certificate {

--- a/verification/getProfile_test.go
+++ b/verification/getProfile_test.go
@@ -243,7 +243,12 @@ func testGetProfile(d TestDPEInstance, t *testing.T) {
 		}
 		defer d.PowerOff()
 	}
-	client, err := NewClient256(d)
+	profile, err := GetTransportProfile(d)
+	if err != nil {
+		t.Fatalf("Could not get profile: %v", err)
+	}
+
+	client, err := NewClient(d, profile)
 	if err != nil {
 		t.Fatalf("Could not initialize client: %v", err)
 	}
@@ -253,9 +258,6 @@ func testGetProfile(d TestDPEInstance, t *testing.T) {
 		rsp, err := client.GetProfile()
 		if err != nil {
 			t.Fatalf("Unable to get profile: %v", err)
-		}
-		if rsp.Profile != d.GetProfile() {
-			t.Fatalf("Incorrect profile. 0x%08x != 0x%08x", d.GetProfile(), rsp.Profile)
 		}
 		if rsp.MajorVersion != d.GetProfileMajorVersion() {
 			t.Fatalf("Incorrect version. 0x%08x != 0x%08x", d.GetProfileMajorVersion(), rsp.MajorVersion)

--- a/verification/profile.go
+++ b/verification/profile.go
@@ -27,21 +27,41 @@ func (p Profile) String() string {
 // Curve is a type constraint enumerating the supported ECC curves for DPE profiles.
 type Curve interface {
 	NISTP256Parameter | NISTP384Parameter
+
+	Bytes() []byte
 }
 
 // NISTP256Parameter represents a NIST P-256 curve parameter, i.e., an x, y, r, or s value.
 type NISTP256Parameter [32]byte
 
+func (p NISTP256Parameter) Bytes() []byte {
+	return p[:]
+}
+
 // NISTP384Parameter represents a NIST P-384 curve parameter, i.e., an x, y, r, or s value.
 type NISTP384Parameter [48]byte
+
+func (p NISTP384Parameter) Bytes() []byte {
+	return p[:]
+}
 
 // DigestAlgorithm is a type constraint enumerating the supported hashing algorithms for DPE profiles.
 type DigestAlgorithm interface {
 	SHA256Digest | SHA384Digest
+
+	Bytes() []byte
 }
 
 // SHA256Digest represents a SHA-256 digest value.
 type SHA256Digest [32]byte
 
+func (d SHA256Digest) Bytes() []byte {
+	return d[:]
+}
+
 // SHA384Digest represents a SHA-384 digest value.
 type SHA384Digest [48]byte
+
+func (d SHA384Digest) Bytes() []byte {
+	return d[:]
+}


### PR DESCRIPTION
To allow DPE tests to be less opinionated about which DPE profile the target uses, add a wrapper around the DPE Client (changed to DPEABIClient).

This leaves the ABI client in place for callers who do not want a more permissive interface.