### PR TITLE
Add sccache to CI for faster testing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,60 @@ on:
 jobs:
   ubuntu:
     runs-on: ubuntu-latest
+
+    env:
+      CARGO_INCREMENTAL: 0
+      SCCACHE_VERSION: 0.3.3
+      SCCACHE_GHA_CACHE_TO: sccache-caliptra-sw
+      SCCACHE_GHA_CACHE_FROM: sccache-caliptra-sw
+
+      # Change this to a new random value if you suspect the cache is corrupted
+      SCCACHE_C_CUSTOM_CACHE_BUSTER: db7245ea5da5
+
+
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Test commit name
+        run: |
+          echo "Build-Test: release_ref=$(git rev-parse HEAD)"
+
       # The runner image has rustup with stable (with clippy and rustfmt). So we
       # just need to update to use the most recent stable.
-      - run: rustup update
-      - run: ./ci.sh
+      - name: Update rustup
+        run: |
+          rustup update
+
+      - name: Restore sccache binary
+        uses: actions/cache/restore@v3
+        id: sccache_bin_restore
+        with:
+          path: ~/.cargo/bin/sccache
+          key: sccache-bin-${{ env.SCCACHE_VERSION }}-${{ env.SCCACHE_C_CUSTOM_CACHE_BUSTER }}
+
+      - name: Install sccache
+        if: steps.sccache_bin_restore.outputs.cache-hit != 'true'
+        run: |
+          cargo install sccache --version ${SCCACHE_VERSION} --no-default-features --features=gha
+
+      # Save the sccache binary immediately so we can reuse it in future runs
+      # even if the rest of the current run fails.
+      - name: Save sccache binary
+        uses: actions/cache/save@v3
+        if: steps.sccache_bin_restore.outputs.cache-hit != 'true'
+        with:
+          path: ~/.cargo/bin/sccache
+          key: ${{ steps.sccache_bin_restore.outputs.cache-primary-key }}
+
+      - name: Configure sccache
+        uses: actions/github-script@v6
+        with:
+          script: |
+            core.exportVariable('RUSTC_WRAPPER', process.env.HOME + '/.cargo/bin/sccache');
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - name: Run CI tests
+        run: |
+          ./ci.sh


### PR DESCRIPTION
This cuts the time CI tests take to run by 50%. Bringing the time down to ~5 minutes.