### PR TITLE
Rearrange ci.sh to group profile builds

### DIFF
--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -7,14 +7,22 @@ edition = "2021"
 
 [features]
 default = ["dpe_profile_p256_sha256"]
-dpe_profile_p256_sha256 = ["dpe/dpe_profile_p256_sha256"]
-dpe_profile_p384_sha384 = ["dpe/dpe_profile_p384_sha384"]
+dpe_profile_p256_sha256 = [
+  "dpe/dpe_profile_p256_sha256",
+  "crypto/dpe_profile_p256_sha256",
+  "platform/dpe_profile_p256_sha256"
+]
+dpe_profile_p384_sha384 = [
+  "dpe/dpe_profile_p384_sha384",
+  "crypto/dpe_profile_p384_sha384",
+  "platform/dpe_profile_p384_sha384"
+]
 
 [dependencies]
-dpe = {path = "../dpe"}
-crypto = {path = "../crypto", features = ["deterministic_rand", "openssl"]}
+dpe = {path = "../dpe", default-features = false}
+crypto = {path = "../crypto", default-features = false, features = ["deterministic_rand", "openssl"]}
 pem = "2"
-platform = {path = "../platform", features = ["openssl"]}
+platform = {path = "../platform", default-features = false, features = ["openssl"]}
 zerocopy = "0.6.1"
 
 [[bin]]


### PR DESCRIPTION
Rebuilding targets with different profiles invalidates a lot of cargo caching. Instead, group the builds/tests so that all the steps are grouped by profile. This should improve the speed of running CI both locally and in GH Actions.