### PR TITLE
Minor fixes to make DPE tests easier to run against Caliptra

### DIFF
--- a/verification/getProfile.go
+++ b/verification/getProfile.go
@@ -18,6 +18,7 @@ func TestGetProfile(d TestDPEInstance, t *testing.T) {
 	}
 
 	const MIN_TCI_NODES uint32 = 8
+
 	profile, err := GetTransportProfile(d)
 	if err != nil {
 		t.Fatalf("Could not get profile: %v", err)
@@ -44,7 +45,7 @@ func TestGetProfile(d TestDPEInstance, t *testing.T) {
 			t.Fatalf("Incorrect version. 0x%08x != 0x%08x", d.GetProfileVendorId(), rsp.VendorId)
 		}
 		if rsp.VendorSku != d.GetProfileVendorSku() {
-			t.Fatalf("Incorrect version. 0x%08x != 0x%08x", d.GetProfileVendorSku(), rsp.VendorSku)
+			t.Fatalf("Unexpected SKU. 0x%08x != 0x%08x", d.GetProfileVendorSku(), rsp.VendorSku)
 		}
 		if rsp.MaxTciNodes != d.GetMaxTciNodes() {
 			t.Fatalf("Incorrect max TCI nodes. 0x%08x != 0x%08x", d.GetMaxTciNodes(), rsp.MaxTciNodes)

--- a/verification/initializeContext.go
+++ b/verification/initializeContext.go
@@ -13,11 +13,18 @@ import (
 func TestInitializeContext(d TestDPEInstance, t *testing.T) {
 	for _, locality := range d.GetSupportedLocalities() {
 		d.SetLocality(locality)
-		testInitContext(d, t)
+		testInitContext(d, t, false)
 	}
 }
 
-func testInitContext(d TestDPEInstance, t *testing.T) {
+func TestInitializeSimulation(d TestDPEInstance, t *testing.T) {
+	for _, locality := range d.GetSupportedLocalities() {
+		d.SetLocality(locality)
+		testInitContext(d, t, true)
+	}
+}
+
+func testInitContext(d TestDPEInstance, t *testing.T, simulation bool) {
 	if d.HasPowerControl() {
 		err := d.PowerOn()
 		if err != nil {
@@ -64,40 +71,18 @@ func testInitContext(d TestDPEInstance, t *testing.T) {
 		t.Fatalf("Incorrect error type. Should return %q, but returned %q", StatusInvalidArgument, err)
 	}
 
-	if !d.GetSupport().Simulation {
-		// Try to initialize a simulation context when they aren't supported.
-		_, err = client.InitializeContext(InitIsSimulation)
-		if err == nil {
-			t.Fatal("The instance should return an error when trying to initialize another default context.")
-		} else if !errors.Is(err, StatusArgumentNotSupported) {
-			t.Fatalf("Incorrect error type. Should return %q, but returned %q", StatusArgumentNotSupported, err)
-		}
-	} else {
-		getProfileRsp, err := client.GetProfile()
+	// TODO: test exhausting handles. This requires the ability to query how
+	// many handles are currently in use.
+	if simulation {
+		handle, err := client.InitializeContext(InitIsSimulation)
 		if err != nil {
-			t.Fatalf("Failed to get profile: %v", err)
+			t.Fatal("Failed to create a simulation context.")
 		}
+		defer client.DestroyContext(handle, DestroyDescendants)
 
-		// Try to get the correct error for overflowing the contexts. Fill up the
-		// rest of the contexts (-1 for default).
-		for i := uint32(0); i < getProfileRsp.MaxTciNodes-1; i++ {
-			handle, err := client.InitializeContext(InitIsSimulation)
-			if err != nil {
-				t.Fatal("The instance should be able to create a simulation context.")
-			}
-			// Could prove difficult to prove it is a cryptographically secure random.
-			if *handle == ContextHandle([16]byte{0}) {
-				t.Fatal("Incorrect simulation context handle.")
-			}
-			defer client.DestroyContext(handle, DestroyDescendants)
-		}
-
-		// Now try to make one more than the max.
-		_, err = client.InitializeContext(InitIsSimulation)
-		if err == nil {
-			t.Fatal("Failed to report an error for too many contexts.")
-		} else if !errors.Is(err, StatusMaxTCIs) {
-			t.Fatalf("Incorrect error type. Should return %q, but returned %q", StatusMaxTCIs, err)
+		// Could prove difficult to prove it is a cryptographically secure random.
+		if *handle == ContextHandle([16]byte{0}) {
+			t.Fatal("Incorrect simulation context handle.")
 		}
 	}
 }

--- a/verification/tagTCI.go
+++ b/verification/tagTCI.go
@@ -4,7 +4,7 @@ package verification
 
 import (
 	"errors"
-	"reflect"
+	//"reflect"
 	"testing"
 )
 
@@ -56,20 +56,25 @@ func TestTagTCI(d TestDPEInstance, t *testing.T) {
 		t.Errorf("New context handle from TagTCI was %x, expected %x", handle, ctx)
 	}
 
-	taggedTCI, err := client.GetTaggedTCI(tag)
+	_, err = client.GetTaggedTCI(tag)
 	if err != nil {
 		t.Fatalf("Could not get tagged TCI: %v", err)
 	}
 
-	wantCumulativeTCI := make([]byte, profile.GetDigestSize())
-	if !reflect.DeepEqual(taggedTCI.CumulativeTCI, wantCumulativeTCI) {
-		t.Errorf("GetTaggedTCI returned cumulative TCI %x, expected %x", taggedTCI.CumulativeTCI, wantCumulativeTCI)
-	}
+	// TODO: For profiles which use auto-initialization, we don't know the expected
+	// TCIs. Uncomment this once the DeriveChild API is implemented so the test
+	// can control the TCI inputs.
+	/*
+		wantCumulativeTCI := make([]byte, profile.GetDigestSize())
+		if !reflect.DeepEqual(taggedTCI.CumulativeTCI, wantCumulativeTCI) {
+			t.Errorf("GetTaggedTCI returned cumulative TCI %x, expected %x", taggedTCI.CumulativeTCI, wantCumulativeTCI)
+		}
 
-	wantCurrentTCI := make([]byte, profile.GetDigestSize())
-	if !reflect.DeepEqual(taggedTCI.CurrentTCI, wantCurrentTCI) {
-		t.Errorf("GetTaggedTCI returned current TCI %x, expected %x", taggedTCI.CurrentTCI, wantCurrentTCI)
-	}
+		wantCurrentTCI := make([]byte, profile.GetDigestSize())
+		if !reflect.DeepEqual(taggedTCI.CurrentTCI, wantCurrentTCI) {
+			t.Errorf("GetTaggedTCI returned current TCI %x, expected %x", taggedTCI.CurrentTCI, wantCurrentTCI)
+		}
+	*/
 
 	// Make sure some other tag is still not found.
 	if _, err := client.GetTaggedTCI(TCITag(98765)); !errors.Is(err, StatusBadTag) {

--- a/verification/verification.go
+++ b/verification/verification.go
@@ -19,6 +19,9 @@ var TestCases = []TestCase{
 	TestCase{
 		"InitializeContext", TestInitializeContext, []string{},
 	},
+	TestCase{
+		"InitializeContextSimulation", TestInitializeSimulation, []string{"Simulation"},
+	},
 	// CertifyKey
 	TestCase{
 		"CertifyKey", TestCertifyKey, []string{"AutoInit", "X509", "IsCA"},
@@ -37,47 +40,5 @@ var TestCases = []TestCase{
 	// GetProfile
 	TestCase{
 		"GetProfile", TestGetProfile, []string{},
-	},
-	TestCase{
-		"GetProfile_Simulation", TestGetProfile, []string{"Simulation"},
-	},
-	TestCase{
-		"GetProfile_ExtendTCI", TestGetProfile, []string{"ExtendTci"},
-	},
-	TestCase{
-		"GetProfile_AutoInit", TestGetProfile, []string{"AutoInit"},
-	},
-	TestCase{
-		"GetProfile_Tagging", TestGetProfile, []string{"Tagging"},
-	},
-	TestCase{
-		"GetProfile_RotateContext", TestGetProfile, []string{"RotateContext"},
-	},
-	TestCase{
-		"GetProfile_X509", TestGetProfile, []string{"X509"},
-	},
-	TestCase{
-		"GetProfile_CSR", TestGetProfile, []string{"Csr"},
-	},
-	TestCase{
-		"GetProfile_Symmetric", TestGetProfile, []string{"IsSymmetric"},
-	},
-	TestCase{
-		"GetProfile_InternalInfo", TestGetProfile, []string{"InternalInfo"},
-	},
-	TestCase{
-		"GetProfile_InternalDice", TestGetProfile, []string{"InternalDice"},
-	},
-	TestCase{
-		"GetProfile_IsCA", TestGetProfile, []string{"IsCA"},
-	},
-	TestCase{
-		"GetProfile_Combo01", TestGetProfile, []string{"Simulation", "AutoInit", "RotateContext", "Csr", "InternalDice", "IsCA"},
-	},
-	TestCase{
-		"GetProfile_Combo02", TestGetProfile, []string{"ExtendTci", "Tagging", "X509", "InternalInfo"},
-	},
-	TestCase{
-		"GetProfile_All", TestGetProfile, []string{"Simulation", "ExtendTci", "AutoInit", "Tagging", "RotateContext", "X509", "Csr", "IsSymmetric", "InternalInfo", "InternalDice", "IsCA"},
 	},
 }


### PR DESCRIPTION
1. Make InitializeContext tests use simulation when the test asks for it instead of when the target supports it.
2. TagTCI assumes the default context TCI is all zeros, but this only works if the target does not support auto initialization. Disable this assertion until the test can use DeriveChild to specify the input TCI.
3. For tagets whose support vector isn't configurable, the GetProfile tests were just running the same test repeatedly. Update this to just run the test once. For simulator configuration, this testing belongs in simulator unit tests.