### PR TITLE
Exclude linter error about time encoding formats

### DIFF
--- a/verification/certifyKey.go
+++ b/verification/certifyKey.go
@@ -386,7 +386,14 @@ func checkCertificateStructure(t *testing.T, certBytes []byte) *x509.Certificate
 			lint.RFC5480,
 			lint.RFC5891,
 			lint.RFC8813,
-		}})
+		},
+		ExcludeNames: []string{
+			// It is fine for cert chains to always use GeneralizedTime, UTCTime is
+			// strictly worse and mixing the two formats does not lend itself well
+			// to fixed-sized X.509 templating.
+			"e_wrong_time_format_pre2050",
+		},
+	})
 	if err != nil {
 		t.Fatalf("[FATAL]: Could not set up zlint registry: %v", err)
 	}

--- a/verification/getCertificateChain.go
+++ b/verification/getCertificateChain.go
@@ -68,7 +68,14 @@ func checkCertificateChain(t *testing.T, certData []byte) []*x509.Certificate {
 			lint.RFC5480,
 			lint.RFC5891,
 			lint.RFC8813,
-		}})
+		},
+		ExcludeNames: []string{
+			// It is fine for cert chains to always use GeneralizedTime, UTCTime is
+			// strictly worse and mixing the two formats does not lend itself well
+			// to fixed-sized X.509 templating.
+			"e_wrong_time_format_pre2050",
+		},
+	})
 	if err != nil {
 		t.Fatalf("[FATAL]: Could not set up zlint registry: %v", err)
 	}


### PR DESCRIPTION
RFC 5280 requires dates <= 2049 to use UTCTime and dates >= 2050 to use GeneralizedTime.

The reason this is a problem for Caliptra:
1. By default notBefore is before 2049
2. By default notAfter is after 2049
3. We allow these values to be configured by the fw header
4. The two encodings have different sizes. So they aren't interchangeable for cert templating.

The good news is that OpenSSL, Go x509 libraries, and mbedTLS don’t care when verifying certs.

Ignore this error in the linter.