### PR TITLE
Convince compiler that hex string encoding can't panic

### DIFF
--- a/crypto/src/signer.rs
+++ b/crypto/src/signer.rs
@@ -72,7 +72,7 @@ impl CryptoBuf {
         for &b in src {
             let h1 = (b >> 4) as usize;
             let h2 = (b & 0xF) as usize;
-            if h1 >= HEX_CHARS.len() || h2 >= HEX_CHARS.len() || curr_idx + 1 >= dest.len() {
+            if h1 >= HEX_CHARS.len() || h2 >= HEX_CHARS.len() || curr_idx >= dest.len() || curr_idx + 1 >= dest.len() {
                 return Err(CryptoError::CryptoLibError);
             }
             dest[curr_idx] = HEX_CHARS[h1];


### PR DESCRIPTION
Add an additional check to ensure the hex_str encoding function is panic-free.