### PR TITLE
Reboot the verification tests less often.

### DIFF
--- a/verification/getCertificateChain.go
+++ b/verification/getCertificateChain.go
@@ -13,25 +13,7 @@ import (
 	"github.com/zmap/zlint/v3/lint"
 )
 
-func TestGetCertificateChain(d TestDPEInstance, t *testing.T) {
-	if d.HasPowerControl() {
-		err := d.PowerOn()
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer d.PowerOff()
-	}
-
-	profile, err := GetTransportProfile(d)
-	if err != nil {
-		t.Fatalf("Could not get profile: %v", err)
-	}
-
-	client, err := NewClient(d, profile)
-	if err != nil {
-		t.Fatalf("[FATAL]: Could not initialize client: %v", err)
-	}
-
+func TestGetCertificateChain(d TestDPEInstance, client DPEClient, t *testing.T) {
 	certChain, err := client.GetCertificateChain()
 	if err != nil {
 		t.Fatalf("[FATAL]: Could not get Certificate Chain: %v", err)

--- a/verification/getProfile.go
+++ b/verification/getProfile.go
@@ -8,26 +8,8 @@ import (
 
 // This file is used to test the get profile command.
 
-func TestGetProfile(d TestDPEInstance, t *testing.T) {
-	if d.HasPowerControl() {
-		err := d.PowerOn()
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer d.PowerOff()
-	}
-
+func TestGetProfile(d TestDPEInstance, client DPEClient, t *testing.T) {
 	const MIN_TCI_NODES uint32 = 8
-
-	profile, err := GetTransportProfile(d)
-	if err != nil {
-		t.Fatalf("Could not get profile: %v", err)
-	}
-
-	client, err := NewClient(d, profile)
-	if err != nil {
-		t.Fatalf("Could not initialize client: %v", err)
-	}
 
 	for _, locality := range d.GetSupportedLocalities() {
 		d.SetLocality(locality)

--- a/verification/tagTCI.go
+++ b/verification/tagTCI.go
@@ -10,25 +10,7 @@ import (
 
 // This file is used to test the tagTCI command.
 
-func TestTagTCI(d TestDPEInstance, t *testing.T) {
-	if d.HasPowerControl() {
-		err := d.PowerOn()
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer d.PowerOff()
-	}
-
-	profile, err := GetTransportProfile(d)
-	if err != nil {
-		t.Fatalf("Could not get profile: %v", err)
-	}
-
-	client, err := NewClient(d, profile)
-	if err != nil {
-		t.Fatalf("Could not initialize client: %v", err)
-	}
-
+func TestTagTCI(d TestDPEInstance, client DPEClient, t *testing.T) {
 	// Try to create the default context if isn't done automatically.
 	if !d.GetSupport().AutoInit {
 		handle, err := client.InitializeContext(InitIsDefault)

--- a/verification/transport.go
+++ b/verification/transport.go
@@ -35,6 +35,10 @@ type TestDPEInstance interface {
 	// it supports, but this function is used by tests to know how to test the DPE
 	// instance.
 	GetSupport() *Support
+	// Whether the default context has been initialized.
+	GetIsInitialized() bool
+	// Set whether the default context has been initialized.
+	SetIsInitialized(bool)
 	// Returns a slice of all the localities the instance supports.
 	GetSupportedLocalities() []uint32
 	// Sets the current locality.

--- a/verification/verification.go
+++ b/verification/verification.go
@@ -2,11 +2,9 @@
 
 package verification
 
-import (
-	"testing"
-)
+import "testing"
 
-type DpeTestFunc func(d TestDPEInstance, t *testing.T)
+type DpeTestFunc func(d TestDPEInstance, c DPEClient, t *testing.T)
 
 type TestCase struct {
 	Name          string
@@ -14,31 +12,73 @@ type TestCase struct {
 	SupportNeeded []string
 }
 
-var TestCases = []TestCase{
-	// InitializeContext
-	TestCase{
-		"InitializeContext", TestInitializeContext, []string{},
-	},
-	TestCase{
-		"InitializeContextSimulation", TestInitializeSimulation, []string{"Simulation"},
-	},
-	// CertifyKey
-	TestCase{
-		"CertifyKey", TestCertifyKey, []string{"AutoInit", "X509", "IsCA"},
-	},
-	TestCase{
-		"CertifyKeySimulation", TestCertifyKey_SimulationMode, []string{"AutoInit", "Simulation", "X509", "IsCA"},
-	},
-	// GetCertificateChain
-	TestCase{
-		"GetCertificateChain", TestGetCertificateChain, []string{"AutoInit", "X509"},
-	},
-	// TagTCI
-	TestCase{
-		"TagTCI", TestTagTCI, []string{"AutoInit", "Tagging"},
-	},
-	// GetProfile
-	TestCase{
-		"GetProfile", TestGetProfile, []string{},
-	},
+type TestTarget struct {
+	Name      string
+	D         TestDPEInstance
+	TestCases []TestCase
+}
+
+var InitializeContextTestCase = TestCase{
+	"InitializeContext", TestInitializeContext, []string{},
+}
+var InitializeContextSimulationTestCase = TestCase{
+	"InitializeContextSimulation", TestInitializeSimulation, []string{"Simulation"},
+}
+var CertifyKeyTestCase = TestCase{
+	"CertifyKey", TestCertifyKey, []string{"AutoInit", "X509", "IsCA"},
+}
+var CertifyKeySimulationTestCase = TestCase{
+	"CertifyKeySimulation", TestCertifyKey_SimulationMode, []string{"AutoInit", "Simulation", "X509", "IsCA"},
+}
+var GetCertificateChainTestCase = TestCase{
+	"GetCertificateChain", TestGetCertificateChain, []string{"AutoInit", "X509"},
+}
+var TagTCITestCase = TestCase{
+	"TagTCI", TestTagTCI, []string{"AutoInit", "Tagging"},
+}
+var GetProfileTestCase = TestCase{
+	"GetProfile", TestGetProfile, []string{},
+}
+
+var AllTestCases = []TestCase{
+	CertifyKeyTestCase,
+	CertifyKeySimulationTestCase,
+	GetCertificateChainTestCase,
+	TagTCITestCase,
+	GetProfileTestCase,
+	InitializeContextTestCase,
+	InitializeContextSimulationTestCase,
+}
+
+func RunTargetTestCases(target TestTarget, t *testing.T) {
+	// This needs to be in a separate function to make sure it is powered off before running the
+	// next target. This is particularly important for the simulator because it can attach to an
+	// old instance if the was not closed yet.
+	if target.D.HasPowerControl() {
+		err := target.D.PowerOn()
+		if err != nil {
+			t.Fatalf("Could not power on the target: %v", err)
+		}
+		defer target.D.PowerOff()
+	}
+
+	profile, err := GetTransportProfile(target.D)
+	if err != nil {
+		t.Fatalf("Could not get profile: %v", err)
+	}
+
+	c, err := NewClient(target.D, profile)
+	if err != nil {
+		t.Fatalf("Could not initialize client: %v", err)
+	}
+
+	for _, test := range target.TestCases {
+		t.Run(target.Name+"-"+test.Name, func(t *testing.T) {
+			if !HasSupportNeeded(target.D, test.SupportNeeded) {
+				t.Skipf("Warning: Target does not have required support, skipping test.")
+			}
+
+			test.Run(target.D, c, t)
+		})
+	}
 }

--- a/verification/verification_test.go
+++ b/verification/verification_test.go
@@ -8,40 +8,20 @@ import (
 	"testing"
 )
 
-var target_exe *string
 var testTargetType string
 
 // This will be called before running tests, and it assigns the socket path based on command line flag.
 func TestMain(m *testing.M) {
-	target_exe = flag.String("sim", "../simulator/target/debug/simulator", "path to simulator executable")
+	TargetExe = flag.String("sim", "../simulator/target/debug/simulator", "path to simulator executable")
 
 	exitVal := m.Run()
 	os.Exit(exitVal)
 }
 
 func TestRunAll(t *testing.T) {
-	for _, test := range TestCases {
-		t.Run(test.Name, func(t *testing.T) {
-			d, err := GetTestTarget(test.SupportNeeded)
-			if err != nil {
-				t.Errorf("Unable to get test target: %v", err)
-			}
+	targets := GetSimulatorTargets()
 
-			if !HasSupportNeeded(d, test.SupportNeeded) {
-				t.Skipf("Warning: Target does not have required support, skipping test.")
-			}
-
-			test.Run(d, t)
-		})
+	for _, target := range targets {
+		RunTargetTestCases(target, t)
 	}
-}
-
-// Get the test target for simulator/emulator
-func GetTestTarget(supportNeeded []string) (TestDPEInstance, error) {
-	instance, err := GetSimulatorTarget(supportNeeded, *target_exe)
-	if err != nil {
-		return nil, err
-	}
-	instance.SetLocality(DPE_SIMULATOR_AUTO_INIT_LOCALITY)
-	return instance, nil
 }


### PR DESCRIPTION
With a simulator it is very easy to reboot to reset the state and try different configurations, this is not true for real platforms. This refactors the golang verification test suite to reboot less often, if at all.

#226 