### PR TITLE
Refactor count_active_contexts into a higher-order function

### DIFF
--- a/dpe/src/commands/derive_child.rs
+++ b/dpe/src/commands/derive_child.rs
@@ -74,7 +74,7 @@ impl DeriveChildCmd {
     ///
     /// * `parent_idx` - Index of the soon-to-be parent.
     /// * `default_context_idx` - Index of the target locality's default context, if there is one.
-    /// * `num_contexts_in_locality` - Number of contexts already in the locality.
+    /// * `num_contexts_in_locality` - Number of active contexts already in the locality.
     fn safe_to_make_default(
         &self,
         parent_idx: usize,
@@ -142,7 +142,11 @@ impl DeriveChildCmd {
         let default_context_idx = dpe
             .get_active_context_pos(&ContextHandle::default(), target_locality)
             .ok();
-        let num_contexts_in_locality = dpe.count_active_contexts_in_locality(target_locality)?;
+
+        // count active contexts in target_locality
+        let num_contexts_in_locality = dpe.count_contexts(|c: &Context| {
+            c.state == ContextState::Active && c.locality == target_locality
+        })?;
 
         Ok(if self.makes_default() {
             self.safe_to_make_default(parent_idx, default_context_idx, num_contexts_in_locality)

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -437,20 +437,13 @@ impl DpeInstance {
         false
     }
 
-    pub fn count_active_contexts(&self) -> Result<usize, DpeErrorCode> {
-        Ok(self
-            .contexts
-            .iter()
-            .filter(|context| context.state == ContextState::Active)
-            .count())
-    }
-
-    pub fn count_active_contexts_in_locality(&self, locality: u32) -> Result<usize, DpeErrorCode> {
-        Ok(self
-            .contexts
-            .iter()
-            .filter(|context| context.state == ContextState::Active && context.locality == locality)
-            .count())
+    /// Count number of contexts satisfying some predicate
+    ///
+    /// # Arguments
+    ///
+    /// * `context_pred` - A predicate on a context used to determine contexts to count
+    pub fn count_contexts(&self, f: impl Fn(&Context) -> bool) -> Result<usize, DpeErrorCode> {
+        Ok(self.contexts.iter().filter(|context| f(context)).count())
     }
 }
 


### PR DESCRIPTION
This way we can use the hof count_contexts to count non inactive
contexts, count active contexts, count non inactive contexts in
a locality, and many other things.