### PR TITLE
Exclude root node from certs if it doesn't contain any measurements

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -246,7 +246,7 @@ impl CommandExecution for CertifyKeyCmd {
 mod tests {
     use super::*;
     use crate::{
-        commands::{Command, CommandHdr, InitCtxCmd},
+        commands::{extend_tci::ExtendTciCmd, tests::TEST_DIGEST, Command, CommandHdr, InitCtxCmd},
         dpe_instance::tests::{TestTypes, SIMULATION_HANDLE, TEST_LOCALITIES},
         support::Support,
     };
@@ -298,7 +298,7 @@ mod tests {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
-        let mut dpe = DpeInstance::new(&mut env, Support::X509).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, Support::X509 | Support::EXTEND_TCI).unwrap();
 
         let init_resp = match InitCtxCmd::new_use_default()
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -307,8 +307,22 @@ mod tests {
             Response::InitCtx(resp) => resp,
             _ => panic!("Incorrect return type."),
         };
-        let certify_cmd = CertifyKeyCmd {
+
+        // extend tci for root node so it has measurements to be included in cert
+        let extend_tci = ExtendTciCmd {
             handle: init_resp.handle,
+            data: TEST_DIGEST,
+        };
+        let extend_tci_resp = match extend_tci
+            .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
+            .unwrap()
+        {
+            Response::ExtendTci(extend_tci_resp) => extend_tci_resp,
+            _ => panic!("Incorrect return type."),
+        };
+
+        let certify_cmd = CertifyKeyCmd {
+            handle: extend_tci_resp.handle,
             flags: CertifyKeyFlags::empty(),
             label: [0; DPE_PROFILE.get_hash_size()],
             format: CertifyKeyCmd::FORMAT_X509,
@@ -338,7 +352,11 @@ mod tests {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
-        let mut dpe = DpeInstance::new(&mut env, Support::X509 | Support::IS_CA).unwrap();
+        let mut dpe = DpeInstance::new(
+            &mut env,
+            Support::X509 | Support::IS_CA | Support::EXTEND_TCI,
+        )
+        .unwrap();
 
         let init_resp = match InitCtxCmd::new_use_default()
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -347,8 +365,22 @@ mod tests {
             Response::InitCtx(resp) => resp,
             _ => panic!("Incorrect return type."),
         };
-        let certify_cmd_ca = CertifyKeyCmd {
+
+        // extend tci for root node so it has measurements to be included in cert
+        let extend_tci = ExtendTciCmd {
             handle: init_resp.handle,
+            data: TEST_DIGEST,
+        };
+        let extend_tci_resp = match extend_tci
+            .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
+            .unwrap()
+        {
+            Response::ExtendTci(extend_tci_resp) => extend_tci_resp,
+            _ => panic!("Incorrect return type."),
+        };
+
+        let certify_cmd_ca = CertifyKeyCmd {
+            handle: extend_tci_resp.handle,
             flags: CertifyKeyFlags::IS_CA,
             label: [0; DPE_PROFILE.get_hash_size()],
             format: CertifyKeyCmd::FORMAT_X509,
@@ -375,7 +407,7 @@ mod tests {
         };
 
         let certify_cmd_non_ca = CertifyKeyCmd {
-            handle: init_resp.handle,
+            handle: extend_tci_resp.handle,
             flags: CertifyKeyFlags::empty(),
             label: [0; DPE_PROFILE.get_hash_size()],
             format: CertifyKeyCmd::FORMAT_X509,
@@ -409,7 +441,7 @@ mod tests {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
-        let mut dpe = DpeInstance::new(&mut env, Support::CSR).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, Support::CSR | Support::EXTEND_TCI).unwrap();
 
         let init_resp = match InitCtxCmd::new_use_default()
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -418,8 +450,22 @@ mod tests {
             Response::InitCtx(resp) => resp,
             _ => panic!("Incorrect return type."),
         };
-        let certify_cmd = CertifyKeyCmd {
+
+        // extend tci for root node so it has measurements to be included in cert
+        let extend_tci = ExtendTciCmd {
             handle: init_resp.handle,
+            data: TEST_DIGEST,
+        };
+        let extend_tci_resp = match extend_tci
+            .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
+            .unwrap()
+        {
+            Response::ExtendTci(extend_tci_resp) => extend_tci_resp,
+            _ => panic!("Incorrect return type."),
+        };
+
+        let certify_cmd = CertifyKeyCmd {
+            handle: extend_tci_resp.handle,
             flags: CertifyKeyFlags::empty(),
             label: [0; DPE_PROFILE.get_hash_size()],
             format: CertifyKeyCmd::FORMAT_CSR,

--- a/dpe/src/commands/extend_tci.rs
+++ b/dpe/src/commands/extend_tci.rs
@@ -12,8 +12,8 @@ use crate::{
 #[derive(Debug, PartialEq, Eq, zerocopy::FromBytes)]
 #[cfg_attr(test, derive(zerocopy::AsBytes))]
 pub struct ExtendTciCmd {
-    handle: ContextHandle,
-    data: [u8; DPE_PROFILE.get_hash_size()],
+    pub handle: ContextHandle,
+    pub data: [u8; DPE_PROFILE.get_hash_size()],
 }
 
 impl CommandExecution for ExtendTciCmd {
@@ -40,6 +40,10 @@ impl CommandExecution for ExtendTciCmd {
             handle: dpe.contexts[idx].handle,
             ..tmp_context
         };
+
+        if dpe.contexts[idx].parent_idx == Context::ROOT_INDEX {
+            dpe.root_has_measurement = true.into();
+        }
 
         Ok(Response::ExtendTci(NewHandleResp {
             handle: dpe.contexts[idx].handle,

--- a/verification/certifyKey.go
+++ b/verification/certifyKey.go
@@ -444,7 +444,7 @@ func testCertifyKey(d TestDPEInstance, client DPEClient, t *testing.T, use_simul
 				t.Fatal("Incorrect simulation context handle.")
 			}
 
-			defer client.DestroyContext(handle, 0)
+			defer client.DestroyContext(handle)
 		} else {
 			t.Errorf("[ERROR]:  DPE instance doesn't support simulation contexts.")
 		}
@@ -465,8 +465,16 @@ func testCertifyKey(d TestDPEInstance, client DPEClient, t *testing.T, use_simul
 	digestLen := profile.GetDigestSize()
 
 	seqLabel := make([]byte, digestLen)
+	seqData := make([]byte, digestLen)
 	for i, _ := range seqLabel {
 		seqLabel[i] = byte(i)
+		seqData[i] = byte(i)
+	}
+
+	// Extend tci to add measurement to root node
+	extendTciHandle, err := client.ExtendTci(&ctx, seqData)
+	if err != nil {
+		t.Fatalf("[FATAL]: Could not extend tci: %v", err)
 	}
 
 	certifyKeyParams := []Params{
@@ -476,7 +484,7 @@ func testCertifyKey(d TestDPEInstance, client DPEClient, t *testing.T, use_simul
 
 	for _, params := range certifyKeyParams {
 		// Get DPE leaf certificate from CertifyKey
-		certifyKeyResp, err := client.CertifyKey(&ctx, params.Label, CertifyKeyX509, params.Flags)
+		certifyKeyResp, err := client.CertifyKey(extendTciHandle, params.Label, CertifyKeyX509, params.Flags)
 		if err != nil {
 			t.Fatalf("[FATAL]: Could not certify key: %v", err)
 		}

--- a/verification/client.go
+++ b/verification/client.go
@@ -37,10 +37,11 @@ type DPEClient interface {
 	InitializeContext(flags InitCtxFlags) (*ContextHandle, error)
 	GetProfile() (*GetProfileResp, error)
 	CertifyKey(handle *ContextHandle, label []byte, format CertifyKeyFormat, flags CertifyKeyFlags) (*CertifiedKey, error)
+	ExtendTci(handle *ContextHandle, data []byte) (*ContextHandle, error)
 	GetCertificateChain() ([]byte, error)
 	TagTCI(handle *ContextHandle, tag TCITag) (*ContextHandle, error)
 	GetTaggedTCI(tag TCITag) (*DPETCI, error)
-	DestroyContext(handle *ContextHandle, flags DestroyCtxFlags) error
+	DestroyContext(handle *ContextHandle) error
 }
 
 func NewClient(t Transport, p Profile) (DPEClient, error) {

--- a/verification/initializeContext.go
+++ b/verification/initializeContext.go
@@ -59,7 +59,7 @@ func testInitContext(d TestDPEInstance, client DPEClient, t *testing.T, simulati
 		if err != nil {
 			t.Fatal("Failed to create a simulation context.")
 		}
-		defer client.DestroyContext(handle, DestroyDescendants)
+		defer client.DestroyContext(handle)
 
 		// Could prove difficult to prove it is a cryptographically secure random.
 		if *handle == ContextHandle([16]byte{0}) {

--- a/verification/tagTCI.go
+++ b/verification/tagTCI.go
@@ -17,7 +17,7 @@ func TestTagTCI(d TestDPEInstance, client DPEClient, t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to initialize default context: %v", err)
 		}
-		defer client.DestroyContext(handle, DestroyDescendants)
+		defer client.DestroyContext(handle)
 	}
 
 	tag := TCITag(12345)

--- a/verification/verification.go
+++ b/verification/verification.go
@@ -25,10 +25,10 @@ var InitializeContextSimulationTestCase = TestCase{
 	"InitializeContextSimulation", TestInitializeSimulation, []string{"Simulation"},
 }
 var CertifyKeyTestCase = TestCase{
-	"CertifyKey", TestCertifyKey, []string{"AutoInit", "X509", "IsCA"},
+	"CertifyKey", TestCertifyKey, []string{"AutoInit", "X509", "IsCA", "ExtendTci"},
 }
 var CertifyKeySimulationTestCase = TestCase{
-	"CertifyKeySimulation", TestCertifyKey_SimulationMode, []string{"AutoInit", "Simulation", "X509", "IsCA"},
+	"CertifyKeySimulation", TestCertifyKey_SimulationMode, []string{"AutoInit", "Simulation", "X509", "IsCA", "ExtendTci"},
 }
 var GetCertificateChainTestCase = TestCase{
 	"GetCertificateChain", TestGetCertificateChain, []string{"AutoInit", "X509"},


### PR DESCRIPTION
There are two ways a context can get measurements - if it got created in derive child as a child context or if it's tci was extended. Thus, the root node can only have measurements if it's tci was extended. Otherwise, we should exclude adding it's measurements to the certs since they are default buffers of 0s.

This PR also adds support for extend_tci in the go verification tests so that we can call it before certifying key. This is necessary since we do not have derive_child implemented yet in the verification tests, so we can only ever have the root node to certify. If we skip adding the root node to the certs, then certify key would fail as there are no measurements to add to the certs, so we call extend_tci to create measurements in the root node.

fixes #244 