### PR TITLE
Preserve platform error codes in DpeErrorCode

### DIFF
--- a/crypto/src/signer.rs
+++ b/crypto/src/signer.rs
@@ -77,7 +77,7 @@ impl CryptoBuf {
                 || curr_idx >= dest.len()
                 || curr_idx + 1 >= dest.len()
             {
-                return Err(CryptoError::CryptoLibError);
+                return Err(CryptoError::CryptoLibError(0));
             }
             dest[curr_idx] = HEX_CHARS[h1];
             dest[curr_idx + 1] = HEX_CHARS[h2];

--- a/dpe/fuzz/src/fuzz_target_1.rs
+++ b/dpe/fuzz/src/fuzz_target_1.rs
@@ -92,7 +92,7 @@ fn harness(data: &[u8]) {
     if dpe.contexts != prev_contexts && response_code != 0 {
         panic!("Error: DPE state changes upon a failed DPE command.");
     }
-    if response_code == DpeErrorCode::InternalError as u32 {
+    if response_code == DpeErrorCode::InternalError.discriminant() {
         panic!("Error: DPE reached a state that should be unreachable.");
     }
     trace!("----------------------------------");

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -4,7 +4,7 @@ use crate::{
     dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
     response::{DpeErrorCode, GetCertificateChainResp, Response, ResponseHdr},
 };
-use platform::{Platform, PlatformError, MAX_CHUNK_SIZE};
+use platform::{Platform, MAX_CHUNK_SIZE};
 
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, zerocopy::FromBytes, zerocopy::AsBytes)]
@@ -28,11 +28,7 @@ impl CommandExecution for GetCertificateChainCmd {
         let mut cert_chunk = [0u8; MAX_CHUNK_SIZE];
         let len = env
             .platform
-            .get_certificate_chain(self.offset, self.size, &mut cert_chunk)
-            .map_err(|platform_error| match platform_error {
-                PlatformError::CertificateChainError => DpeErrorCode::InvalidArgument,
-                _ => DpeErrorCode::PlatformError,
-            })?;
+            .get_certificate_chain(self.offset, self.size, &mut cert_chunk)?;
         Ok(Response::GetCertificateChain(GetCertificateChainResp {
             certificate_chain: cert_chunk,
             certificate_size: len,

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -44,17 +44,14 @@ impl SignCmd {
         let cdi_digest = dpe.compute_measurement_hash(env, idx)?;
         let cdi = env
             .crypto
-            .derive_cdi(DPE_PROFILE.alg_len(), &cdi_digest, b"DPE")
-            .map_err(|_| DpeErrorCode::CryptoError)?;
+            .derive_cdi(DPE_PROFILE.alg_len(), &cdi_digest, b"DPE")?;
         let (priv_key, pub_key) = env
             .crypto
-            .derive_key_pair(algs, &cdi, &self.label, b"ECC")
-            .map_err(|_| DpeErrorCode::CryptoError)?;
+            .derive_key_pair(algs, &cdi, &self.label, b"ECC")?;
 
         let sig = env
             .crypto
-            .ecdsa_sign_with_derived(algs, digest, &priv_key, &pub_key)
-            .map_err(|_| DpeErrorCode::CryptoError)?;
+            .ecdsa_sign_with_derived(algs, digest, &priv_key, &pub_key)?;
 
         Ok(sig)
     }
@@ -70,11 +67,10 @@ impl SignCmd {
         let cdi_digest = dpe.compute_measurement_hash(env, idx)?;
         let cdi = env
             .crypto
-            .derive_cdi(DPE_PROFILE.alg_len(), &cdi_digest, b"DPE")
-            .map_err(|_| DpeErrorCode::CryptoError)?;
-        env.crypto
-            .hmac_sign_with_derived(algs, &cdi, &self.label, b"HMAC", digest)
-            .map_err(|_| DpeErrorCode::CryptoError)
+            .derive_cdi(DPE_PROFILE.alg_len(), &cdi_digest, b"DPE")?;
+        Ok(env
+            .crypto
+            .hmac_sign_with_derived(algs, &cdi, &self.label, b"HMAC", digest)?)
     }
 }
 
@@ -98,7 +94,7 @@ impl CommandExecution for SignCmd {
         }
 
         let algs = DPE_PROFILE.alg_len();
-        let digest = Digest::new(&self.digest).map_err(|_| DpeErrorCode::InternalError)?;
+        let digest = Digest::new(&self.digest)?;
 
         let EcdsaSig { r, s } = if !self.uses_symmetric() {
             self.ecdsa_sign(dpe, env, idx, &digest)?

--- a/platform/src/default.rs
+++ b/platform/src/default.rs
@@ -47,7 +47,7 @@ impl Platform for DefaultPlatform {
             .to_der()
             .unwrap();
         if issuer_name.len() > out.len() {
-            return Err(PlatformError::IssuerNameError);
+            return Err(PlatformError::IssuerNameError(0));
         }
         out[..issuer_name.len()].copy_from_slice(&issuer_name);
         Ok(issuer_name.len())

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -15,12 +15,22 @@ pub mod printer;
 
 pub const MAX_CHUNK_SIZE: usize = 2048;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u16)]
 pub enum PlatformError {
-    CertificateChainError,
-    NotImplemented,
-    IssuerNameError,
-    PrintError,
+    CertificateChainError = 0x1,
+    NotImplemented = 0x2,
+    IssuerNameError(u32) = 0x3,
+    PrintError(u32) = 0x4,
+}
+
+impl PlatformError {
+    pub fn discriminant(&self) -> u16 {
+        // SAFETY: Because `Self` is marked `repr(u16)`, its layout is a `repr(C)` `union`
+        // between `repr(C)` structs, each of which has the `u16` discriminant as its first
+        // field, so we can read the discriminant without offsetting the pointer.
+        unsafe { *<*const _>::from(self).cast::<u16>() }
+    }
 }
 
 pub trait Platform {


### PR DESCRIPTION
The DPE Platform and Crypto APIs both implement error enums, but they may mask more detailed platform-specific error codes. Make the DPE error enums more expressive so they can suface these details errors.

Ultimately, it is up to the platform to decide how to surface this extended error information.