### PR TITLE
Allow calling get_error_detail on each error type

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -55,6 +55,16 @@ impl CryptoError {
         // field, so we can read the discriminant without offsetting the pointer.
         unsafe { *<*const _>::from(self).cast::<u16>() }
     }
+
+    pub fn get_error_detail(&self) -> Option<u32> {
+        match self {
+            CryptoError::AbstractionLayer(code) => Some(*code),
+            CryptoError::CryptoLibError(code) => Some(*code),
+            CryptoError::Size => None,
+            CryptoError::NotImplemented => None,
+            CryptoError::HashError(code) => Some(*code),
+        }
+    }
 }
 
 pub trait Hasher: Sized {

--- a/dpe/src/response.rs
+++ b/dpe/src/response.rs
@@ -206,19 +206,8 @@ impl DpeErrorCode {
     /// Reporting of detailed error information is platform-defined.
     pub fn get_error_detail(&self) -> Option<u32> {
         match self {
-            DpeErrorCode::Platform(e) => match e {
-                PlatformError::CertificateChainError => None,
-                PlatformError::NotImplemented => None,
-                PlatformError::IssuerNameError(code) => Some(*code),
-                PlatformError::PrintError(code) => Some(*code),
-            },
-            DpeErrorCode::Crypto(e) => match e {
-                CryptoError::AbstractionLayer(code) => Some(*code),
-                CryptoError::CryptoLibError(code) => Some(*code),
-                CryptoError::Size => None,
-                CryptoError::NotImplemented => None,
-                CryptoError::HashError(code) => Some(*code),
-            },
+            DpeErrorCode::Platform(e) => e.get_error_detail(),
+            DpeErrorCode::Crypto(e) => e.get_error_detail(),
             _ => None,
         }
     }

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -31,6 +31,15 @@ impl PlatformError {
         // field, so we can read the discriminant without offsetting the pointer.
         unsafe { *<*const _>::from(self).cast::<u16>() }
     }
+
+    pub fn get_error_detail(&self) -> Option<u32> {
+        match self {
+            PlatformError::CertificateChainError => None,
+            PlatformError::NotImplemented => None,
+            PlatformError::IssuerNameError(code) => Some(*code),
+            PlatformError::PrintError(code) => Some(*code),
+        }
+    }
 }
 
 pub trait Platform {


### PR DESCRIPTION
This is helpful if all you have is a CryptoError or PlatformError and want to get the detailed code. You don't have to first convert to a DpeErrorCode.