### PR TITLE
RotateContext handle command tests

### DIFF
--- a/verification/rotateContextHandle.go
+++ b/verification/rotateContextHandle.go
@@ -8,71 +8,60 @@ import (
 )
 
 func TestRotateContextHandle(d TestDPEInstance, c DPEClient, t *testing.T) {
-	testRotateContextHandle(d, c, t, false)
-}
-
-func TestRotateContextHandleSimulation(d TestDPEInstance, c DPEClient, t *testing.T) {
-	testRotateContextHandle(d, c, t, true)
-}
-
-func testRotateContextHandle(d TestDPEInstance, c DPEClient, t *testing.T, simulation bool) {
+	simulation := false
 	handle := getInitialContextHandle(d, c, t, simulation)
-	defer func() {
-		if simulation {
-			c.DestroyContext(handle, DestroyDescendants)
-		}
-	}()
 
-	// Check handle rotated is non-default when no flags are set
-	handle = testWithoutTargetDefaultFlag(d, c, t, handle)
-
-	// Check handle is rotated to default handle in default context and error is reported in simulated context
-	testWithTargetDefaultFlag(d, c, t, handle, simulation)
-}
-
-// Checks whether the default context handle is rotated to a some other context handle
-func testWithoutTargetDefaultFlag(d TestDPEInstance, c DPEClient, t *testing.T, handle *ContextHandle) *ContextHandle {
-	rotatedContext, err := c.RotateContextHandle(handle, RotateContextHandleFlags(0))
+	// Check whether the rotated context handle is a random context handle
+	handle, err := c.RotateContextHandle(handle, RotateContextHandleFlags(0))
 	if err != nil {
 		t.Fatalf("[FATAL]: Could not rotate context handle: %v", err)
 	}
-
-	if *rotatedContext == DefaultContextHandle {
-		t.Errorf("[ERROR]: Expected random context handle but have got default context %v", rotatedContext)
+	if *handle == DefaultContextHandle {
+		t.Errorf("[ERROR]: Expected random context handle but have got default context %v", handle)
 	}
 
-	return rotatedContext
+	// Rotate back the handle to default handle for subsequent tests
+	// This works only when there is no default handle available
+	handle, err = c.RotateContextHandle(handle, TargetIsDefault)
+	if err != nil {
+		t.Fatalf("[FATAL]: Could not rotate context handle: %v", err)
+	}
+	if *handle != DefaultContextHandle {
+		t.Errorf("[ERROR]: TARGET_IS_DEFAULT is set, have got %v but want %v", handle, DefaultContextHandle)
+	}
+
+	// Check for error when a default context handle exists already and handle is rotated to default handle
+	// Since, there cannot be more than one default context handle
+	_, err = c.RotateContextHandle(handle, TargetIsDefault)
+	if err == nil {
+		t.Fatalf("[FATAL]: Should return %q for default context, but returned no error", StatusInvalidArgument)
+	} else if !errors.Is(err, StatusInvalidArgument) {
+		t.Fatalf("[FATAL]: Incorrect error type. Should return %q, but returned %q", StatusInvalidArgument, err)
+	}
 }
 
-// Checks whether the context handle is rotated to default context.
-// In simulated context, the rotated handle cannot be made default context handle as a mixture of default and
-// non-default context handles are not allowed.
-// In default context, the rotated handle can be made default context handle when there is no default context handle already.
-func testWithTargetDefaultFlag(d TestDPEInstance, c DPEClient, t *testing.T, handle *ContextHandle, simulation bool) {
-	if simulation {
-		_, err := c.RotateContextHandle(handle, TargetIsDefault)
-		if err == nil {
-			t.Fatalf("[FATAL]: Should return %q for simulation context, but returned no error", StatusInvalidArgument)
-		} else if !errors.Is(err, StatusInvalidArgument) {
-			t.Fatalf("[FATAL]: Incorrect error type. Should return %q, but returned %q", StatusInvalidArgument, err)
-		}
-	} else {
-		rotatedDefaultContext, err := c.RotateContextHandle(handle, TargetIsDefault)
-		if err != nil {
-			t.Fatalf("[FATAL]: Could not rotate context handle: %v", err)
-		}
+func TestRotateContextHandleSimulation(d TestDPEInstance, c DPEClient, t *testing.T) {
+	simulation := true
+	handle := getInitialContextHandle(d, c, t, simulation)
+	defer func() {
+		c.DestroyContext(handle, DestroyDescendants)
+	}()
 
-		// Check whether the rotated context handle is default context handle
-		if *rotatedDefaultContext != DefaultContextHandle {
-			t.Errorf("[ERROR]: TARGET_IS_DEFAULT is set, have got %v but want %v", rotatedDefaultContext, DefaultContextHandle)
-		}
+	// Check whether the rotated context handle is a random context handle
+	handle, err := c.RotateContextHandle(handle, RotateContextHandleFlags(0))
+	if err != nil {
+		t.Fatalf("[FATAL]: Could not rotate context handle: %v", err)
+	}
+	if *handle == DefaultContextHandle {
+		t.Errorf("[ERROR]: Expected random context handle but have got default context %v", handle)
+	}
 
-		// Check whether error is reported when TARGET_IS_DEFAULT is set when a default context handle exists already.
-		_, err = c.RotateContextHandle(rotatedDefaultContext, TargetIsDefault)
-		if err == nil {
-			t.Fatalf("[FATAL]: Should return %q for default context, but returned no error", StatusInvalidArgument)
-		} else if !errors.Is(err, StatusInvalidArgument) {
-			t.Fatalf("[FATAL]: Incorrect error type. Should return %q, but returned %q", StatusInvalidArgument, err)
-		}
+	// In simulated context, the handle cannot be rotated to default handle
+	// Since, it is not allowed to have a both of default and non-default context handles together
+	_, err = c.RotateContextHandle(handle, TargetIsDefault)
+	if err == nil {
+		t.Fatalf("[FATAL]: Should return %q for simulation context, but returned no error", StatusInvalidArgument)
+	} else if !errors.Is(err, StatusInvalidArgument) {
+		t.Fatalf("[FATAL]: Incorrect error type. Should return %q, but returned %q", StatusInvalidArgument, err)
 	}
 }

--- a/verification/rotateContextHandle.go
+++ b/verification/rotateContextHandle.go
@@ -1,0 +1,78 @@
+// Licensed under the Apache-2.0 license
+
+package verification
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestRotateContextHandle(d TestDPEInstance, c DPEClient, t *testing.T) {
+	testRotateContextHandle(d, c, t, false)
+}
+
+func TestRotateContextHandleSimulation(d TestDPEInstance, c DPEClient, t *testing.T) {
+	testRotateContextHandle(d, c, t, true)
+}
+
+func testRotateContextHandle(d TestDPEInstance, c DPEClient, t *testing.T, simulation bool) {
+	handle := getInitialContextHandle(d, c, t, simulation)
+	defer func() {
+		if simulation {
+			c.DestroyContext(handle, DestroyDescendants)
+		}
+	}()
+
+	// Check handle rotated is non-default when no flags are set
+	handle = testWithoutTargetDefaultFlag(d, c, t, handle)
+
+	// Check handle is rotated to default handle in default context and error is reported in simulated context
+	testWithTargetDefaultFlag(d, c, t, handle, simulation)
+}
+
+// Checks whether the default context handle is rotated to a some other context handle
+func testWithoutTargetDefaultFlag(d TestDPEInstance, c DPEClient, t *testing.T, handle *ContextHandle) *ContextHandle {
+	rotatedContext, err := c.RotateContextHandle(handle, RotateContextHandleFlags(0))
+	if err != nil {
+		t.Fatalf("[FATAL]: Could not rotate context handle: %v", err)
+	}
+
+	if *rotatedContext == DefaultContextHandle {
+		t.Errorf("[ERROR]: Expected random context handle but have got default context %v", rotatedContext)
+	}
+
+	return rotatedContext
+}
+
+// Checks whether the context handle is rotated to default context.
+// In simulated context, the rotated handle cannot be made default context handle as a mixture of default and
+// non-default context handles are not allowed.
+// In default context, the rotated handle can be made default context handle when there is no default context handle already.
+func testWithTargetDefaultFlag(d TestDPEInstance, c DPEClient, t *testing.T, handle *ContextHandle, simulation bool) {
+	if simulation {
+		_, err := c.RotateContextHandle(handle, TargetIsDefault)
+		if err == nil {
+			t.Fatalf("[FATAL]: Should return %q for simulation context, but returned no error", StatusInvalidArgument)
+		} else if !errors.Is(err, StatusInvalidArgument) {
+			t.Fatalf("[FATAL]: Incorrect error type. Should return %q, but returned %q", StatusInvalidArgument, err)
+		}
+	} else {
+		rotatedDefaultContext, err := c.RotateContextHandle(handle, TargetIsDefault)
+		if err != nil {
+			t.Fatalf("[FATAL]: Could not rotate context handle: %v", err)
+		}
+
+		// Check whether the rotated context handle is default context handle
+		if *rotatedDefaultContext != DefaultContextHandle {
+			t.Errorf("[ERROR]: TARGET_IS_DEFAULT is set, have got %v but want %v", rotatedDefaultContext, DefaultContextHandle)
+		}
+
+		// Check whether error is reported when TARGET_IS_DEFAULT is set when a default context handle exists already.
+		_, err = c.RotateContextHandle(rotatedDefaultContext, TargetIsDefault)
+		if err == nil {
+			t.Fatalf("[FATAL]: Should return %q for default context, but returned no error", StatusInvalidArgument)
+		} else if !errors.Is(err, StatusInvalidArgument) {
+			t.Fatalf("[FATAL]: Incorrect error type. Should return %q, but returned %q", StatusInvalidArgument, err)
+		}
+	}
+}

--- a/verification/verification.go
+++ b/verification/verification.go
@@ -61,6 +61,7 @@ var RotateContextTestCase = TestCase{
 }
 var RotateContextSimulationTestCase = TestCase{
 	"RotateContextHandleSimulation", TestRotateContextHandleSimulation, []string{"Simulation", "RotateContext"},
+}
 var SignAsymmetricTestCase = TestCase{
 	"Sign", TestAsymmetricSigning, []string{"AutoInit", "X509"},
 }

--- a/verification/verification.go
+++ b/verification/verification.go
@@ -56,6 +56,12 @@ var UnsupportedCommand = TestCase{
 var UnsupportedCommandFlag = TestCase{
 	"CheckSupportForCommmandFlag", TestUnsupportedCommandFlag, []string{"AutoInit", "RotateContext", "ExtendTci"},
 }
+var RotateContextTestCase = TestCase{
+	"RotateContextHandle", TestRotateContextHandle, []string{"AutoInit", "RotateContext"},
+}
+var RotateContextSimulationTestCase = TestCase{
+	"RotateContextHandleSimulation", TestRotateContextHandleSimulation, []string{"Simulation", "RotateContext"},
+}
 
 var AllTestCases = []TestCase{
 	CertifyKeyTestCase,
@@ -63,6 +69,8 @@ var AllTestCases = []TestCase{
 	GetCertificateChainTestCase,
 	ExtendTCITestCase,
 	ExtendDerivedTciTestCase,
+	RotateContextTestCase,
+	RotateContextSimulationTestCase,
 	GetProfileTestCase,
 	InitializeContextTestCase,
 	InitializeContextSimulationTestCase,


### PR DESCRIPTION
Hi @jhand2
Added tests for RotateContextHandle command
- Added a test to check and report invalid handle with a test handle  (moved to negativeCases.go, taken care in PR 255, as a common negative case test)

The following are part of this PR:
- RotateHandle in default context  
- RotateHandle in non-default context
- RotateHandle in with TARGET_DEFAULT flag