### PR TITLE
Common client code and few bug fixes

### DIFF
--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -15,7 +15,7 @@ pub struct SignFlags(u32);
 
 bitflags! {
     impl SignFlags: u32 {
-        const IS_SYMMETRIC = 1u32 << 31;
+        const IS_SYMMETRIC = 1u32 << 30;
     }
 }
 
@@ -83,7 +83,7 @@ impl CommandExecution for SignCmd {
     ) -> Result<Response, DpeErrorCode> {
         // Make sure the operation is supported.
         if !dpe.support.is_symmetric() && self.uses_symmetric() {
-            return Err(DpeErrorCode::InvalidArgument);
+            return Err(DpeErrorCode::ArgumentNotSupported);
         }
 
         let idx = dpe.get_active_context_pos(&self.handle, locality)?;
@@ -190,7 +190,7 @@ mod tests {
 
         // Bad argument
         assert_eq!(
-            Err(DpeErrorCode::InvalidArgument),
+            Err(DpeErrorCode::ArgumentNotSupported),
             SignCmd {
                 handle: ContextHandle([0xff; ContextHandle::SIZE]),
                 label: TEST_LABEL,

--- a/verification/certifyKey.go
+++ b/verification/certifyKey.go
@@ -432,7 +432,7 @@ func checkCertificateStructure(t *testing.T, certBytes []byte) *x509.Certificate
 }
 
 func testCertifyKey(d TestDPEInstance, client DPEClient, t *testing.T, simulation bool) {
-	ctx := getContextHandle(d, client, t, simulation)
+	ctx := getInitialContextHandle(d, client, t, simulation)
 	if simulation {
 		defer client.DestroyContext(ctx, 0)
 	}

--- a/verification/client.go
+++ b/verification/client.go
@@ -33,6 +33,12 @@ type DPETCI struct {
 	CurrentTCI    []byte
 }
 
+type DPESignedHash struct {
+	Handle           ContextHandle
+	HmacOrSignatureR []byte
+	SignatureS       []byte
+}
+
 type DPEClient interface {
 	InitializeContext(flags InitCtxFlags) (*ContextHandle, error)
 	GetProfile() (*GetProfileResp, error)
@@ -41,6 +47,10 @@ type DPEClient interface {
 	TagTCI(handle *ContextHandle, tag TCITag) (*ContextHandle, error)
 	GetTaggedTCI(tag TCITag) (*DPETCI, error)
 	DestroyContext(handle *ContextHandle, flags DestroyCtxFlags) error
+	DeriveChild(handle *ContextHandle, inputData []byte, flags DeriveChildFlags, tciType uint32, targetLocality uint32) (*DeriveChildResp, error)
+	RotateContextHandle(handle *ContextHandle, flags RotateContextHandleFlags) (*ContextHandle, error)
+	Sign(handle *ContextHandle, label []byte, flags SignFlags, toBeSigned []byte) (*DPESignedHash, error)
+	ExtendTCI(handle *ContextHandle, inputData []byte) (*ContextHandle, error)
 }
 
 func NewClient(t Transport, p Profile) (DPEClient, error) {
@@ -50,6 +60,6 @@ func NewClient(t Transport, p Profile) (DPEClient, error) {
 	case ProfileP384SHA384:
 		return NewDPEABI384(t)
 	default:
-		return nil, fmt.Errorf("Cannot create a DPE client for profile %d", p)
+		return nil, fmt.Errorf("cannot create a DPE client for profile %d", p)
 	}
 }

--- a/verification/initializeContext.go
+++ b/verification/initializeContext.go
@@ -67,3 +67,27 @@ func testInitContext(d TestDPEInstance, client DPEClient, t *testing.T, simulati
 		}
 	}
 }
+
+func getContextHandle(d TestDPEInstance, c DPEClient, t *testing.T, simulation bool) *ContextHandle {
+	var handle *ContextHandle
+	var err error
+	if simulation {
+		if d.GetSupport().Simulation {
+			handle, err = c.InitializeContext(InitIsSimulation)
+			if err != nil {
+				t.Fatal("The instance should be able to create a simulation context.")
+			}
+			// Could prove difficult to prove it is a cryptographically secure random.
+			if *handle == ContextHandle([16]byte{0}) {
+				t.Fatal("Incorrect simulation context handle.")
+			}
+		} else {
+			t.Fatal("[FATAL]:  DPE instance doesn't support simulation contexts.")
+		}
+	} else {
+		//default context
+		handle = &DefaultContextHandle
+	}
+
+	return handle
+}

--- a/verification/initializeContext.go
+++ b/verification/initializeContext.go
@@ -68,7 +68,10 @@ func testInitContext(d TestDPEInstance, client DPEClient, t *testing.T, simulati
 	}
 }
 
-func getContextHandle(d TestDPEInstance, c DPEClient, t *testing.T, simulation bool) *ContextHandle {
+// When simulation is set to false, returns a default context handle.
+// Else initializes a simulation context and returns its handle. To get simulation
+// context handle, the DPE profile must support simulation context creation.
+func getInitialContextHandle(d TestDPEInstance, c DPEClient, t *testing.T, simulation bool) *ContextHandle {
 	var handle *ContextHandle
 	var err error
 	if simulation {
@@ -77,7 +80,6 @@ func getContextHandle(d TestDPEInstance, c DPEClient, t *testing.T, simulation b
 			if err != nil {
 				t.Fatal("The instance should be able to create a simulation context.")
 			}
-			// Could prove difficult to prove it is a cryptographically secure random.
 			if *handle == ContextHandle([16]byte{0}) {
 				t.Fatal("Incorrect simulation context handle.")
 			}

--- a/verification/negativeCases.go
+++ b/verification/negativeCases.go
@@ -9,15 +9,11 @@ import (
 
 var InvalidHandle = ContextHandle{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 
-func TestInvalidHandle(d TestDPEInstance, c DPEClient, t *testing.T) {
-	testInvalidHandle(d, c, t)
-}
-
 // Checks whether error is reported when non-existent handle is passed as input to DPE commands.
 // Exceptions are - GetProfile, InitializeContext, GetCertificateChain, GetTaggedTCI commands
 // which do not need context handle as input parameter.
-func testInvalidHandle(d TestDPEInstance, c DPEClient, t *testing.T) {
-	ctx := getContextHandle(d, c, t, true)
+func TestInvalidHandle(d TestDPEInstance, c DPEClient, t *testing.T) {
+	ctx := getInitialContextHandle(d, c, t, true)
 	defer c.DestroyContext(ctx, DestroyDescendants)
 
 	profile, err := GetTransportProfile(d)
@@ -76,14 +72,10 @@ func testInvalidHandle(d TestDPEInstance, c DPEClient, t *testing.T) {
 	}
 }
 
-func TestWrongLocality(d TestDPEInstance, c DPEClient, t *testing.T) {
-	testWrongLocality(d, c, t)
-}
-
 // Checks whether error is reported when caller from one locality issues DPE commands in another locality.
 // Exceptions are - GetProfile, InitializeContext, GetCertificateChain, GetTaggedTCI commands
 // which do not need context handle as input and hence locality is irrelevant.
-func testWrongLocality(d TestDPEInstance, c DPEClient, t *testing.T) {
+func TestWrongLocality(d TestDPEInstance, c DPEClient, t *testing.T) {
 	// Modify and later restore the locality of DPE instance to test
 	d.SetLocality(DPE_SIMULATOR_OTHER_LOCALITY)
 	defer d.SetLocality(DPE_SIMULATOR_AUTO_INIT_LOCALITY)
@@ -149,14 +141,10 @@ func testWrongLocality(d TestDPEInstance, c DPEClient, t *testing.T) {
 	}
 }
 
-func TestUnsupportedCommand(d TestDPEInstance, c DPEClient, t *testing.T) {
-	testUnsupportedCommand(d, c, t)
-}
-
 // Checks whether error is reported while using commands that are turned off in DPE.
 // DPE commands - TagTCI, RotateContextHandle, ExtendTCI, require support to be enabled in DPE profile
 // before being called.
-func testUnsupportedCommand(d TestDPEInstance, c DPEClient, t *testing.T) {
+func TestUnsupportedCommand(d TestDPEInstance, c DPEClient, t *testing.T) {
 	ctx := &DefaultContextHandle
 
 	profile, err := GetTransportProfile(d)
@@ -187,10 +175,6 @@ func testUnsupportedCommand(d TestDPEInstance, c DPEClient, t *testing.T) {
 	}
 }
 
-func TestUnsupportedCommandFlag(d TestDPEInstance, c DPEClient, t *testing.T) {
-	testUnsupportedCommandFlag(d, c, t)
-}
-
 // Checks whether error is reported while enabling command flags that are turned off in DPE.
 // The DPE command may be available but some of its flags may not be supported by DPE.
 // DPE profile supports the below attributes.
@@ -201,7 +185,7 @@ func TestUnsupportedCommandFlag(d TestDPEInstance, c DPEClient, t *testing.T) {
 // IsSymmetric 	: Allows caller to request for symmetric signing
 // InternalInfo	: Allows caller to derive child context with InternalInfo
 // InternalDice	: Allows caller to derive child context with InternalDice
-func testUnsupportedCommandFlag(d TestDPEInstance, c DPEClient, t *testing.T) {
+func TestUnsupportedCommandFlag(d TestDPEInstance, c DPEClient, t *testing.T) {
 	handle := &DefaultContextHandle
 
 	profile, err := GetTransportProfile(d)

--- a/verification/negativeCases.go
+++ b/verification/negativeCases.go
@@ -1,0 +1,275 @@
+// Licensed under the Apache-2.0 license
+
+package verification
+
+import (
+	"errors"
+	"testing"
+)
+
+var InvalidHandle = ContextHandle{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
+
+func TestInvalidHandle(d TestDPEInstance, c DPEClient, t *testing.T) {
+	testInvalidHandle(d, c, t)
+}
+
+// Checks whether error is reported when non-existent handle is passed as input to DPE commands.
+// Exceptions are - GetProfile, InitializeContext, GetCertificateChain, GetTaggedTCI commands
+// which do not need context handle as input parameter.
+func testInvalidHandle(d TestDPEInstance, c DPEClient, t *testing.T) {
+	ctx := getContextHandle(d, c, t, true)
+	defer c.DestroyContext(ctx, DestroyDescendants)
+
+	profile, err := GetTransportProfile(d)
+	if err != nil {
+		t.Fatalf("Could not get profile: %v", err)
+	}
+	digestLen := profile.GetDigestSize()
+
+	// Check DeriveChild with invalid handle
+	if _, err := c.DeriveChild(&InvalidHandle, make([]byte, digestLen), 0, 0, 0); err == nil {
+		t.Errorf("[ERROR]: DeriveChild should return %q, but returned no error", StatusInvalidHandle)
+	} else if !errors.Is(err, StatusInvalidHandle) {
+		t.Errorf("[ERROR]: Incorrect error type. DeriveChild should return %q, but returned %q", StatusInvalidHandle, err)
+	}
+
+	// Check CertifyKey with invalid handle
+	if _, err := c.CertifyKey(&InvalidHandle, make([]byte, digestLen), 0, 0); err == nil {
+		t.Errorf("[ERROR]: CertifyKey should return %q, but returned no error", StatusInvalidHandle)
+	} else if !errors.Is(err, StatusInvalidHandle) {
+		t.Errorf("[ERROR]: Incorrect error type. CertifyKey should return %q, but returned %q", StatusInvalidHandle, err)
+	}
+
+	// Check Sign with invalid handle
+	if _, err := c.Sign(&InvalidHandle, make([]byte, digestLen), 0, make([]byte, digestLen)); err == nil {
+		t.Errorf("[ERROR]: Sign should return %q, but returned no error", StatusInvalidHandle)
+	} else if !errors.Is(err, StatusInvalidHandle) {
+		t.Errorf("[ERROR]: Incorrect error type. Sign should return %q, but returned %q", StatusInvalidHandle, err)
+	}
+
+	// Check RotateContextHandle with invalid handle
+	if _, err := c.RotateContextHandle(&InvalidHandle, RotateContextHandleFlags(TargetIsDefault)); err == nil {
+		t.Errorf("[ERROR]: RotateContextHandle should return %q, but returned no error", StatusInvalidHandle)
+	} else if !errors.Is(err, StatusInvalidHandle) {
+		t.Errorf("[ERROR]: Incorrect error type. RotateContextHandle should return %q, but returned %q", StatusInvalidHandle, err)
+	}
+
+	// Check DestroyContext with invalid handle
+	if err := c.DestroyContext(&InvalidHandle, 0); err == nil {
+		t.Errorf("[ERROR]: DestroyContext should return %q, but returned no error", StatusInvalidHandle)
+	} else if !errors.Is(err, StatusInvalidHandle) {
+		t.Errorf("[ERROR]: Incorrect error type. DestroyContext should return %q, but returned %q", StatusInvalidHandle, err)
+	}
+
+	// Check ExtendTCI with invalid handle
+	if _, err := c.ExtendTCI(&InvalidHandle, make([]byte, digestLen)); err == nil {
+		t.Errorf("[ERROR]: ExtendTCI should return %q, but returned no error", StatusInvalidHandle)
+	} else if !errors.Is(err, StatusInvalidHandle) {
+		t.Errorf("[ERROR]: Incorrect error type. ExtendTCI should return %q, but returned %q", StatusInvalidHandle, err)
+	}
+
+	// Check TagTCI with invalid handle
+	if _, err := c.TagTCI(&InvalidHandle, 0); err == nil {
+		t.Errorf("[ERROR]: TagTCI should return %q, but returned no error", StatusInvalidHandle)
+	} else if !errors.Is(err, StatusInvalidHandle) {
+		t.Errorf("[ERROR]: Incorrect error type. TagTCI should return %q, but returned %q", StatusInvalidHandle, err)
+	}
+}
+
+func TestWrongLocality(d TestDPEInstance, c DPEClient, t *testing.T) {
+	testWrongLocality(d, c, t)
+}
+
+// Checks whether error is reported when caller from one locality issues DPE commands in another locality.
+// Exceptions are - GetProfile, InitializeContext, GetCertificateChain, GetTaggedTCI commands
+// which do not need context handle as input and hence locality is irrelevant.
+func testWrongLocality(d TestDPEInstance, c DPEClient, t *testing.T) {
+	// Modify and later restore the locality of DPE instance to test
+	d.SetLocality(DPE_SIMULATOR_OTHER_LOCALITY)
+	defer d.SetLocality(DPE_SIMULATOR_AUTO_INIT_LOCALITY)
+
+	// Get default context handle
+	handle := &DefaultContextHandle
+
+	// Get digest size
+	profile, err := GetTransportProfile(d)
+	if err != nil {
+		t.Fatalf("Could not get profile: %v", err)
+	}
+
+	digestLen := profile.GetDigestSize()
+
+	// Check DeriveChild from wrong context
+	if _, err := c.DeriveChild(handle, make([]byte, digestLen), 0, 0, 0); err == nil {
+		t.Errorf("[ERROR]: DeriveChild should return %q, but returned no error", StatusInvalidLocality)
+	} else if !errors.Is(err, StatusInvalidLocality) {
+		t.Errorf("[ERROR]: Incorrect error type. DeriveChild should return %q, but returned %q", StatusInvalidLocality, err)
+	}
+
+	// Check CertifyKey from wrong locality
+	if _, err := c.CertifyKey(handle, make([]byte, digestLen), 0, 0); err == nil {
+		t.Errorf("[ERROR]: CertifyKey should return %q, but returned no error", StatusInvalidLocality)
+	} else if !errors.Is(err, StatusInvalidLocality) {
+		t.Errorf("[ERROR]: Incorrect error type. CertifyKey should return %q, but returned %q", StatusInvalidLocality, err)
+	}
+
+	// Check Sign from wrong locality
+	if _, err := c.Sign(handle, make([]byte, digestLen), 0, make([]byte, digestLen)); err == nil {
+		t.Errorf("[ERROR]: Sign should return %q, but returned no error", StatusInvalidLocality)
+	} else if !errors.Is(err, StatusInvalidLocality) {
+		t.Errorf("[ERROR]: Incorrect error type. Sign should return %q, but returned %q", StatusInvalidLocality, err)
+	}
+
+	// Check RotateContextHandle from wrong locality
+	if _, err := c.RotateContextHandle(handle, RotateContextHandleFlags(TargetIsDefault)); err == nil {
+		t.Errorf("[ERROR]: RotateContextHandle should return %q, but returned no error", StatusInvalidLocality)
+	} else if !errors.Is(err, StatusInvalidLocality) {
+		t.Errorf("[ERROR]: Incorrect error type. RotateContextHandle should return %q, but returned %q", StatusInvalidLocality, err)
+	}
+
+	// Check DestroyContext from wrong locality
+	if err := c.DestroyContext(handle, 0); err == nil {
+		t.Errorf("[ERROR]: DestroyContext should return %q, but returned no error", StatusInvalidLocality)
+	} else if !errors.Is(err, StatusInvalidLocality) {
+		t.Errorf("[ERROR]: Incorrect error type. DestroyContext should return %q, but returned %q", StatusInvalidLocality, err)
+	}
+
+	// Check ExtendTCI from wrong locality
+	if _, err := c.ExtendTCI(handle, make([]byte, digestLen)); err == nil {
+		t.Errorf("[ERROR]: ExtendTCI should return %q, but returned no error", StatusInvalidLocality)
+	} else if !errors.Is(err, StatusInvalidLocality) {
+		t.Errorf("[ERROR]: Incorrect error type. ExtendTCI should return %q, but returned %q", StatusInvalidLocality, err)
+	}
+
+	// Check TagTCI from wrong locality
+	if _, err := c.TagTCI(handle, 0); err == nil {
+		t.Errorf("[ERROR]: TagTCI should return %q, but returned no error", StatusInvalidLocality)
+	} else if !errors.Is(err, StatusInvalidLocality) {
+		t.Errorf("[ERROR]: Incorrect error type. TagTCI should return %q, but returned %q", StatusInvalidLocality, err)
+	}
+}
+
+func TestUnsupportedCommand(d TestDPEInstance, c DPEClient, t *testing.T) {
+	testUnsupportedCommand(d, c, t)
+}
+
+// Checks whether error is reported while using commands that are turned off in DPE.
+// DPE commands - TagTCI, RotateContextHandle, ExtendTCI, require support to be enabled in DPE profile
+// before being called.
+func testUnsupportedCommand(d TestDPEInstance, c DPEClient, t *testing.T) {
+	ctx := &DefaultContextHandle
+
+	profile, err := GetTransportProfile(d)
+	if err != nil {
+		t.Fatalf("Could not get profile: %v", err)
+	}
+	digestLen := profile.GetDigestSize()
+
+	// Check whether RotateContextHandle is unsupported by DPE profile
+	if _, err := c.RotateContextHandle(ctx, RotateContextHandleFlags(TargetIsDefault)); err == nil {
+		t.Errorf("[ERROR]: RotateContextHandle is not supported by DPE, should return %q, but returned no error", StatusInvalidCommand)
+	} else if !errors.Is(err, StatusInvalidCommand) {
+		t.Errorf("[ERROR]: Incorrect error type. RotateContextHandle is not supported by DPE, should return %q, but returned %q", StatusInvalidCommand, err)
+	}
+
+	// Check whether ExtendTCI is unsupported by DPE profile
+	if _, err := c.ExtendTCI(ctx, make([]byte, digestLen)); err == nil {
+		t.Errorf("[ERROR]: ExtendTCI is not supported by DPE, should return %q, but returned no error", StatusInvalidCommand)
+	} else if !errors.Is(err, StatusInvalidCommand) {
+		t.Errorf("[ERROR]: Incorrect error type. ExtendTCI is not supported by DPE, should return %q, but returned %q", StatusInvalidCommand, err)
+	}
+
+	// Check whether TagTCI is unsupported by DPE profile
+	if _, err := c.TagTCI(ctx, 0); err == nil {
+		t.Errorf("[ERROR]: TagTCI is not supported by DPE, should return %q, but returned no error", StatusInvalidCommand)
+	} else if !errors.Is(err, StatusInvalidCommand) {
+		t.Errorf("[ERROR]: Incorrect error type. TagTCI is not supported by DPE, should return %q, but returned %q", StatusInvalidCommand, err)
+	}
+}
+
+func TestUnsupportedCommandFlag(d TestDPEInstance, c DPEClient, t *testing.T) {
+	testUnsupportedCommandFlag(d, c, t)
+}
+
+// Checks whether error is reported while enabling command flags that are turned off in DPE.
+// The DPE command may be available but some of its flags may not be supported by DPE.
+// DPE profile supports the below attributes.
+// Simulation	: Allows caller to request for context iniitialization in simulation mode
+// IsCA			: Allows caller to request the key cert of CA
+// Csr 			: Allows caller to request the key cert in CSR format
+// X509 		: Allows caller to request the key cert in X509 format
+// IsSymmetric 	: Allows caller to request for symmetric signing
+// InternalInfo	: Allows caller to derive child context with InternalInfo
+// InternalDice	: Allows caller to derive child context with InternalDice
+func testUnsupportedCommandFlag(d TestDPEInstance, c DPEClient, t *testing.T) {
+	handle := &DefaultContextHandle
+
+	profile, err := GetTransportProfile(d)
+	if err != nil {
+		t.Fatalf("Could not get profile: %v", err)
+	}
+	digestLen := profile.GetDigestSize()
+
+	// Check whether error is returned since simulation context initialization is unsupported by DPE profile
+	if _, err := c.InitializeContext(InitIsSimulation); err == nil {
+		t.Errorf("[ERROR]: Simulation is not supported by DPE, InitializeContext should return %q, but returned no error", StatusArgumentNotSupported)
+	} else if !errors.Is(err, StatusArgumentNotSupported) {
+		t.Errorf("[ERROR]: Incorrect error type. Simulation is not supported by DPE, InitializeContext supported by DPE, should return %q, but returned %q", StatusArgumentNotSupported, err)
+	}
+
+	// Check whether error is returned since CA certificate request is unsupported by DPE profile
+	if _, err := c.CertifyKey(handle, make([]byte, digestLen), CertifyKeyX509, CertifyAddIsCA); err == nil {
+		t.Errorf("[ERROR]: IS_CA is not supported by DPE, CertifyKey should return %q, but returned no error", StatusArgumentNotSupported)
+	} else if !errors.Is(err, StatusArgumentNotSupported) {
+		t.Errorf("[ERROR]: Incorrect error type. IS_CA is not supported by DPE, CertifyKey should return %q, but returned %q", StatusArgumentNotSupported, err)
+	}
+
+	// Check whether error is returned since CSR format is unsupported by DPE profile
+	if _, err := c.CertifyKey(handle, make([]byte, digestLen), CertifyKeyCsr, 0); err == nil {
+		t.Errorf("[ERROR]: CSR format is not supported by DPE, CertifyKey should return %q, but returned no error", StatusArgumentNotSupported)
+	} else if !errors.Is(err, StatusArgumentNotSupported) {
+		t.Errorf("[ERROR]: Incorrect error type. CSR format is not supported by DPE, CertifyKey should return %q, but returned %q", StatusArgumentNotSupported, err)
+	}
+
+	// Check whether error is returned since X509 format is unsupported by DPE profile
+	if _, err := c.CertifyKey(handle, make([]byte, digestLen), CertifyKeyX509, 0); err == nil {
+		t.Errorf("[ERROR]: X509 format is not supported by DPE, CertifyKey should return %q, but returned no error", StatusArgumentNotSupported)
+	} else if !errors.Is(err, StatusArgumentNotSupported) {
+		t.Errorf("[ERROR]: Incorrect error type. X509 format is not supported by DPE, CertifyKey should return %q, but returned %q", StatusArgumentNotSupported, err)
+	}
+
+	// Check whether error is returned since symmetric signing is unsupported by DPE profile
+	if _, err := c.Sign(handle, make([]byte, digestLen), SignFlags(IsSymmetric), make([]byte, digestLen)); err == nil {
+		t.Errorf("[ERROR]: Symmetric signing is not supported by DPE, Sign should return %q, but returned no error", StatusInvalidArgument)
+	} else if !errors.Is(err, StatusArgumentNotSupported) {
+		t.Errorf("[ERROR]: Incorrect error type.  Symmetric signing is not supported by DPE, Sign should return %q, but returned %q", StatusInvalidArgument, err)
+	}
+
+	// Check whether error is returned since InternalInfo usage is unsupported by DPE profile
+	if _, err := c.DeriveChild(handle, make([]byte, digestLen), DeriveChildFlags(InternalInputInfo), 0, 0); err == nil {
+		t.Errorf("[ERROR]:InternalInfo is not supported by DPE, DeriveChild should return %q, but returned no error", StatusArgumentNotSupported)
+	} else if !errors.Is(err, StatusArgumentNotSupported) {
+		t.Errorf("[ERROR]: Incorrect error type. InternalInfo is not supported by DPE, DeriveChild should return %q, but returned %q", StatusArgumentNotSupported, err)
+	}
+
+	// Check whether error is returned since InternalDice usgae is unsupported by DPE profile
+	if _, err := c.DeriveChild(handle, make([]byte, digestLen), DeriveChildFlags(InternalInputDice), 0, 0); err == nil {
+		t.Errorf("[ERROR]:InternalDice is not supported by DPE, DeriveChild should return %q, but returned no error", StatusArgumentNotSupported)
+	} else if !errors.Is(err, StatusArgumentNotSupported) {
+		t.Errorf("[ERROR]: Incorrect error type. InternalDice is not supported by DPE, DeriveChild should return %q, but returned %q", StatusArgumentNotSupported, err)
+	}
+
+	// Check whether error is returned since InternalInfo usage is unsupported by DPE profile
+	if _, err := c.DeriveChild(handle, make([]byte, digestLen), DeriveChildFlags(InputAllowCA), 0, 0); err == nil {
+		t.Errorf("[ERROR]:IS_CA is not supported by DPE, DeriveChild should return %q, but returned no error", StatusArgumentNotSupported)
+	} else if !errors.Is(err, StatusArgumentNotSupported) {
+		t.Errorf("[ERROR]: Incorrect error type. IS_CA is not supported by DPE, DeriveChild should return %q, but returned %q", StatusArgumentNotSupported, err)
+	}
+
+	// Check whether error is returned since InternalDice usgae is unsupported by DPE profile
+	if _, err := c.DeriveChild(handle, make([]byte, digestLen), DeriveChildFlags(InputAllowX509), 0, 0); err == nil {
+		t.Errorf("[ERROR]:X509 is not supported by DPE, DeriveChild should return %q, but returned no error", StatusArgumentNotSupported)
+	} else if !errors.Is(err, StatusArgumentNotSupported) {
+		t.Errorf("[ERROR]: Incorrect error type. X509 is not supported by DPE, DeriveChild should return %q, but returned %q", StatusArgumentNotSupported, err)
+	}
+}

--- a/verification/simulator.go
+++ b/verification/simulator.go
@@ -304,16 +304,6 @@ func GetSimulatorTargets() []TestTarget {
 			[]TestCase{GetProfileTestCase},
 		},
 		{
-			"NegativeCase_InvalidHandle",
-			getTestTarget([]string{"Simulation", "RotateContext", "ExtendTci", "Tagging"}),
-			[]TestCase{InvalidHandleTestCase},
-		},
-		{
-			"NegativeCase_WrongLocality",
-			getTestTarget([]string{"AutoInit", "RotateContext", "ExtendTci", "Tagging"}),
-			[]TestCase{WrongLocalityTestCase},
-		},
-		{
 			"NegativeCase_UnsupportedCommandByDPE",
 			getTestTarget([]string{"AutoInit"}),
 			[]TestCase{UnsupportedCommand},

--- a/verification/simulator.go
+++ b/verification/simulator.go
@@ -230,7 +230,7 @@ func GetSimulatorTargets() []TestTarget {
 		},
 		{
 			"DefaultSupport",
-			getTestTarget([]string{"AutoInit", "Simulation", "X509", "IsCA", "Tagging"}),
+			getTestTarget([]string{"AutoInit", "Simulation", "X509", "IsCA", "Tagging", "RotateContext", "ExtendTci"}),
 			AllTestCases,
 		},
 		{
@@ -302,6 +302,26 @@ func GetSimulatorTargets() []TestTarget {
 			"GetProfile_All",
 			getTestTarget([]string{"Simulation", "ExtendTci", "AutoInit", "Tagging", "RotateContext", "X509", "Csr", "IsSymmetric", "InternalInfo", "InternalDice", "IsCA"}),
 			[]TestCase{GetProfileTestCase},
+		},
+		{
+			"NegativeCase_InvalidHandle",
+			getTestTarget([]string{"Simulation", "RotateContext", "ExtendTci", "Tagging"}),
+			[]TestCase{InvalidHandleTestCase},
+		},
+		{
+			"NegativeCase_WrongLocality",
+			getTestTarget([]string{"AutoInit", "RotateContext", "ExtendTci", "Tagging"}),
+			[]TestCase{WrongLocalityTestCase},
+		},
+		{
+			"NegativeCase_UnsupportedCommandByDPE",
+			getTestTarget([]string{"AutoInit"}),
+			[]TestCase{UnsupportedCommand},
+		},
+		{
+			"NegativeCase_UnsupportedFeatureByDPE",
+			getTestTarget([]string{"AutoInit", "RotateContext", "ExtendTci", "Tagging"}),
+			[]TestCase{UnsupportedCommandFlag},
 		},
 	}
 }

--- a/verification/tagTCI.go
+++ b/verification/tagTCI.go
@@ -8,16 +8,14 @@ import (
 	"testing"
 )
 
-// This file is used to test the tagTCI command.
-
 func TestTagTCI(d TestDPEInstance, client DPEClient, t *testing.T) {
-	// Try to create the default context if isn't done automatically.
-	if !d.GetSupport().AutoInit {
-		handle, err := client.InitializeContext(InitIsDefault)
-		if err != nil {
-			t.Fatalf("Failed to initialize default context: %v", err)
-		}
-		defer client.DestroyContext(handle, DestroyDescendants)
+	testTagTCI(d, client, t, false)
+}
+
+func testTagTCI(d TestDPEInstance, client DPEClient, t *testing.T, simulation bool) {
+	ctx := getContextHandle(d, client, t, simulation)
+	if simulation {
+		defer client.DestroyContext(ctx, DestroyDescendants)
 	}
 
 	tag := TCITag(12345)
@@ -27,14 +25,12 @@ func TestTagTCI(d TestDPEInstance, client DPEClient, t *testing.T) {
 	}
 
 	// Tag the default context
-	var ctx ContextHandle
-
-	handle, err := client.TagTCI(&ctx, tag)
+	handle, err := client.TagTCI(ctx, tag)
 	if err != nil {
 		t.Fatalf("Could not tag TCI: %v", err)
 	}
 
-	if *handle != ctx {
+	if *handle != *ctx {
 		t.Errorf("New context handle from TagTCI was %x, expected %x", handle, ctx)
 	}
 

--- a/verification/tagTCI.go
+++ b/verification/tagTCI.go
@@ -9,14 +9,8 @@ import (
 )
 
 func TestTagTCI(d TestDPEInstance, client DPEClient, t *testing.T) {
-	testTagTCI(d, client, t, false)
-}
-
-func testTagTCI(d TestDPEInstance, client DPEClient, t *testing.T, simulation bool) {
-	ctx := getContextHandle(d, client, t, simulation)
-	if simulation {
-		defer client.DestroyContext(ctx, DestroyDescendants)
-	}
+	useSimulation := false
+	ctx := getInitialContextHandle(d, client, t, useSimulation)
 
 	tag := TCITag(12345)
 	// Check to see our tag is not yet found.

--- a/verification/verification.go
+++ b/verification/verification.go
@@ -2,7 +2,9 @@
 
 package verification
 
-import "testing"
+import (
+	"testing"
+)
 
 type DpeTestFunc func(d TestDPEInstance, c DPEClient, t *testing.T)
 
@@ -38,6 +40,18 @@ var TagTCITestCase = TestCase{
 }
 var GetProfileTestCase = TestCase{
 	"GetProfile", TestGetProfile, []string{},
+}
+var InvalidHandleTestCase = TestCase{
+	"CheckInvalidHandle", TestInvalidHandle, []string{"Simulation", "RotateContext", "ExtendTci", "Tagging"},
+}
+var WrongLocalityTestCase = TestCase{
+	"CheckWrongLocality", TestWrongLocality, []string{"AutoInit", "RotateContext", "ExtendTci", "Tagging"},
+}
+var UnsupportedCommand = TestCase{
+	"CheckSupportForCommand", TestUnsupportedCommand, []string{"AutoInit"},
+}
+var UnsupportedCommandFlag = TestCase{
+	"CheckSupportForCommmandFlag", TestUnsupportedCommandFlag, []string{"AutoInit", "RotateContext", "ExtendTci", "Tagging"},
 }
 
 var AllTestCases = []TestCase{

--- a/verification/verification.go
+++ b/verification/verification.go
@@ -62,6 +62,8 @@ var AllTestCases = []TestCase{
 	GetProfileTestCase,
 	InitializeContextTestCase,
 	InitializeContextSimulationTestCase,
+	InvalidHandleTestCase,
+	WrongLocalityTestCase,
 }
 
 func RunTargetTestCases(target TestTarget, t *testing.T) {


### PR DESCRIPTION
Hi @jhand2 

Have added
- **Files: abi.go, client.go**: Code to issue RotateContextHandle, DeriveChild, ExtendTCI and Sign commands
- **File- sign.rs**: Bug fix for IS_SYMMETRIC flag in sign.rs file
- **File- sign.rs**: Bug fix  for DPE error code in sign.rs. It must be "ArgumentNotSupported" instead of "InvalidArgument" when DPE profile does not support a command flag.
- **File - CertifyKey.go, TagTci.go**:  Bug fix, the context handle created for Simulation mode is not used in code. The contexthandle is stored in variable "handle", but variable "ctx" is used
- **File - InitializeContext.go**: Separated out code for simulated context handle creation and put it as a func in InitializeContext.go file. This block was repeated many times.
-  **Files - negativeCases.go, simulator.go, verification.go**: Added a negativeCases.go - it will test InvalidHandle, wrongLocality, Unsupported DPE command, Unsupported command flags. Tried to address your comment in TagTCI PR by writing a separate function for checking WrongLocality and other negative cases..   

When this is merged I shall change other PRs in tune to the main branch with these changes. Kindly let us know the comments. 
