### PR TITLE
Fix verification tests to pass against Caliptra emulator

### DIFF
--- a/verification/certs.go
+++ b/verification/certs.go
@@ -1,0 +1,69 @@
+// Licensed under the Apache-2.0 license
+
+package verification
+
+import (
+	"crypto/x509"
+	"encoding/asn1"
+	"fmt"
+)
+
+// A tcg-dice-MultiTcbInfo extension.
+// This extension SHOULD be marked as critical.
+func getMultiTcbInfo(c *x509.Certificate) (TcgMultiTcbInfo, error) {
+	var multiTcbInfo TcgMultiTcbInfo
+
+	// Check MultiTcbInfo Extension
+	//tcg-dice-MultiTcbInfo extension
+	for _, ext := range c.Extensions {
+		if ext.Id.Equal(OidExtensionTcgDiceMultiTcbInfo) { // OID for Tcg Dice MultiTcbInfo
+			if !ext.Critical {
+				return multiTcbInfo, fmt.Errorf("[ERROR]: TCG DICE MultiTcbInfo extension is not marked as CRITICAL")
+			}
+			_, err := asn1.Unmarshal(ext.Value, &multiTcbInfo)
+			if err != nil {
+				// multiTcb info is not provided in leaf
+				return multiTcbInfo, fmt.Errorf("[ERROR]: Failed to unmarshal MultiTcbInfo field: %v", err)
+			}
+			break
+		}
+	}
+	return multiTcbInfo, nil
+}
+
+func getTcbInfoForHandle(c DPEClient, handle *ContextHandle) (DiceTcbInfo, error) {
+	// Get digest size
+	profile, err := c.GetProfile()
+	if err != nil {
+		return DiceTcbInfo{}, err
+	}
+
+	digestLen := profile.Profile.GetDigestSize()
+	label := make([]byte, digestLen)
+
+	certifiedKey, err := c.CertifyKey(handle, label, CertifyKeyX509, 0)
+	if err != nil {
+		return DiceTcbInfo{}, err
+	}
+
+	leafCertBytes := certifiedKey.Certificate
+
+	var leafCert *x509.Certificate
+
+	// Check whether certificate is DER encoded.
+	if leafCert, err = x509.ParseCertificate(leafCertBytes); err != nil {
+		return DiceTcbInfo{}, err
+	}
+
+	// Get DICE information from MultiTcbInfo Extension
+	multiTcbInfo, err := getMultiTcbInfo(leafCert)
+	if err != nil {
+		return DiceTcbInfo{}, err
+	}
+
+	if len(multiTcbInfo) == 0 {
+		return DiceTcbInfo{}, fmt.Errorf("Certificate MutliTcbInfo is empty")
+	}
+
+	return multiTcbInfo[0], nil
+}

--- a/verification/negativeCases.go
+++ b/verification/negativeCases.go
@@ -69,9 +69,14 @@ func TestInvalidHandle(d TestDPEInstance, c DPEClient, t *testing.T) {
 // Exceptions are - GetProfile, InitializeContext, GetCertificateChain, commands
 // which do not need context handle as input and hence locality is irrelevant.
 func TestWrongLocality(d TestDPEInstance, c DPEClient, t *testing.T) {
+	if !d.HasLocalityControl() {
+		t.Skipf("Target does not have locality control")
+	}
+
 	// Modify and later restore the locality of DPE instance to test
-	d.SetLocality(DPE_SIMULATOR_OTHER_LOCALITY)
-	defer d.SetLocality(DPE_SIMULATOR_AUTO_INIT_LOCALITY)
+	currentLocality := d.GetLocality()
+	d.SetLocality(currentLocality + 1)
+	defer d.SetLocality(currentLocality)
 
 	// Get default context handle
 	handle := &DefaultContextHandle

--- a/verification/simulator.go
+++ b/verification/simulator.go
@@ -171,6 +171,10 @@ func (s *DpeSimulator) GetSupportedLocalities() []uint32 {
 	return []uint32{DPE_SIMULATOR_AUTO_INIT_LOCALITY, DPE_SIMULATOR_OTHER_LOCALITY}
 }
 
+func (s *DpeSimulator) HasLocalityControl() bool {
+	return true
+}
+
 func (s *DpeSimulator) SetLocality(locality uint32) {
 	s.currentLocality = locality
 }

--- a/verification/transport.go
+++ b/verification/transport.go
@@ -41,6 +41,8 @@ type TestDPEInstance interface {
 	SetIsInitialized(bool)
 	// Returns a slice of all the localities the instance supports.
 	GetSupportedLocalities() []uint32
+	// Whether the target can artificially control the locality of the caller
+	HasLocalityControl() bool
 	// Sets the current locality.
 	SetLocality(locality uint32)
 	// Gets the current locality.


### PR DESCRIPTION
1. Refactor ExtendTCI to calculate the cumulative measurement properly
2. Refactor some helpers for better readability
3. Skip bad locality test for targets that don't have locality control