### PR TITLE
Destroy dangling retired parent contexts in destroy_ctx

### DIFF
--- a/dpe/src/commands/derive_child.rs
+++ b/dpe/src/commands/derive_child.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license.
 use super::CommandExecution;
 use crate::{
-    context::{ActiveContextArgs, Context, ContextHandle, ContextState, ContextType},
+    context::{ActiveContextArgs, Context, ContextHandle, ContextState},
     dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
     response::{DeriveChildResp, DpeErrorCode, Response, ResponseHdr},
     tci::TciMeasurement,
@@ -205,7 +205,7 @@ impl CommandExecution for DeriveChildCmd {
         // Create a temporary context to mutate so that we avoid mutating internal state upon an error.
         let mut tmp_child_context = Context::new();
         tmp_child_context.activate(&ActiveContextArgs {
-            context_type: ContextType::Normal,
+            context_type: dpe.contexts[parent_idx].context_type,
             locality: target_locality,
             handle: &child_handle,
             tci_type: self.tci_type,
@@ -258,6 +258,7 @@ mod tests {
             tests::{TEST_DIGEST, TEST_LABEL},
             CertifyKeyCmd, CertifyKeyFlags, Command, CommandHdr, InitCtxCmd, SignCmd, SignFlags,
         },
+        context::ContextType,
         dpe_instance::tests::{TestTypes, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_LOCALITIES},
         support::Support,
         MAX_HANDLES,

--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -96,7 +96,7 @@ impl Context {
         self.state = ContextState::Inactive;
         self.uses_internal_input_info = false.into();
         self.uses_internal_input_dice = false.into();
-        self.parent_idx = 0xFF;
+        self.parent_idx = Self::ROOT_INDEX;
     }
 
     /// Return the list of children of the context with idx added.


### PR DESCRIPTION
When DestroyContext is called, it is possible that the parents of the context to be destroyed is a chain of retired contexts. These should be destroyed, since otherwise it is impossible to clean them up since their handles are invalid. This could prevent a potential DOS attack.

Fixes #283 