### PR TITLE
RustCrypto implementation of DPE crypto.

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -10,19 +10,19 @@ function build_rust_targets() {
   cargo build --release --manifest-path crypto/Cargo.toml --no-default-features
   cargo build --release --manifest-path platform/Cargo.toml --features=$profile --no-default-features
   cargo build --release --manifest-path dpe/Cargo.toml --features=$profile --no-default-features
-  cargo build --release --manifest-path simulator/Cargo.toml --features=$profile --no-default-features
+  cargo build --release --manifest-path simulator/Cargo.toml --features=$profile,openssl --no-default-features
   cargo build --release --manifest-path tools/Cargo.toml --features=$profile --no-default-features
 
   cargo build --manifest-path crypto/Cargo.toml --no-default-features
   cargo build --manifest-path platform/Cargo.toml --features=$profile --no-default-features
   cargo build --manifest-path dpe/Cargo.toml --features=$profile --no-default-features
-  cargo build --manifest-path simulator/Cargo.toml --features=$profile --no-default-features
+  cargo build --manifest-path simulator/Cargo.toml --features=$profile,openssl --no-default-features
   cargo build --manifest-path tools/Cargo.toml --features=$profile --no-default-features
 
   cargo clippy --manifest-path crypto/Cargo.toml --no-default-features -- --deny=warnings
   cargo clippy --manifest-path platform/Cargo.toml --features=$profile --no-default-features -- --deny=warnings
   cargo clippy --manifest-path dpe/Cargo.toml --features=$profile --no-default-features -- --deny=warnings
-  cargo clippy --manifest-path simulator/Cargo.toml --features=$profile --no-default-features -- --deny=warnings
+  cargo clippy --manifest-path simulator/Cargo.toml --features=$profile,openssl --no-default-features -- --deny=warnings
   cargo clippy --manifest-path tools/Cargo.toml --features=$profile --no-default-features -- --deny=warnings
 }
 
@@ -47,7 +47,7 @@ function test_rust_targets() {
   cargo test --manifest-path platform/Cargo.toml --features=$profile --no-default-features
   cargo test --manifest-path crypto/Cargo.toml --no-default-features
   cargo test --manifest-path dpe/Cargo.toml --features=$profile --no-default-features
-  cargo test --manifest-path simulator/Cargo.toml --features=$profile --no-default-features
+  cargo test --manifest-path simulator/Cargo.toml --features=$profile,openssl --no-default-features
 }
 
 # TODO: Support building the simulator for different profiles

--- a/ci.sh
+++ b/ci.sh
@@ -53,8 +53,9 @@ function test_rust_targets() {
 # TODO: Support building the simulator for different profiles
 function run_verification_tests() {
   profile=$1
+  crypto=$2
 
-  cargo build --manifest-path simulator/Cargo.toml --features=$profile --no-default-features
+  cargo build --manifest-path simulator/Cargo.toml --features=$profile,$crypto --no-default-features
 
   ( cd verification
     go test -v
@@ -67,12 +68,14 @@ format_go_targets
 # Run tests for P256 profile
 build_rust_targets dpe_profile_p256_sha256
 test_rust_targets dpe_profile_p256_sha256
-run_verification_tests dpe_profile_p256_sha256
+run_verification_tests dpe_profile_p256_sha256 openssl
+run_verification_tests dpe_profile_p256_sha256 rustcrypto
 
 # Run tests for P384 profile
 build_rust_targets dpe_profile_p384_sha384
 test_rust_targets dpe_profile_p384_sha384
-run_verification_tests dpe_profile_p384_sha384
+run_verification_tests dpe_profile_p384_sha384 openssl
+run_verification_tests dpe_profile_p384_sha384 rustcrypto
 
 # Build fuzz target
 ( cd dpe/fuzz

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -7,20 +7,32 @@ edition = "2021"
 
 [features]
 openssl = ["dep:openssl", "dep:hkdf", "dep:sha2"]
+rustcrypto = ["dep:hkdf", "dep:hmac", "dep:p256", "dep:p384", "dep:rand", "dep:sha2", "dep:base64ct", "dep:ecdsa", "dep:sec1"]
 deterministic_rand = ["dep:rand"]
 
 [dependencies]
 arrayvec = { version = "0.7.4", default-features = false, features = ["zeroize"] }
-hkdf = {version = "0.12.3", optional = true}
+ecdsa = { version = "0.16.9", optional = true, features = ["pem"]}
+hkdf = { version = "0.12.3", optional = true }
+hmac = {version="0.12.1", optional = true}
 openssl = {version = "0.10.57", optional = true}
-rand = {version = "0.8.5", optional = true}
-sha2 = {version = "0.10.6", optional = true}
+p256 = {version= "0.13.2", optional = true}
+p384 = {version= "0.13.0", optional = true}
+rand = { version = "0.8.5", optional = true }
+sec1 = {version="0.7.3", optional = true}
+sha2 = { version = "0.10.6", optional = true }
 zeroize = { version = "1.6.0", default-features = false, features = ["zeroize_derive"] }
 
 [dev-dependencies]
 strum = "0.24"
 strum_macros = "0.24"
+elliptic-curve = "0.13.8"
 
 [build-dependencies]
 openssl = {version = "0.10.57", optional = true}
 rand = {version = "0.8.5", optional = true}
+p256 = {version= "0.13.2", optional = true}
+p384 = {version= "0.13.0", optional = true}
+ecdsa = { version = "0.16.9", optional = true, features = ["pem"]}
+base64ct = {version= "1.6.0", optional= true}
+sec1 = {version="0.7.3", optional = true}

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -26,7 +26,6 @@ zeroize = { version = "1.6.0", default-features = false, features = ["zeroize_de
 [dev-dependencies]
 strum = "0.24"
 strum_macros = "0.24"
-elliptic-curve = "0.13.8"
 
 [build-dependencies]
 openssl = {version = "0.10.57", optional = true}

--- a/crypto/build.rs
+++ b/crypto/build.rs
@@ -1,5 +1,8 @@
 // Licensed under the Apache-2.0 license
 
+#[cfg(feature = "rustcrypto")]
+use std::ops::Deref;
+
 fn main() {
     #[cfg(feature = "openssl")]
     {
@@ -56,5 +59,62 @@ fn main() {
         let path_384 = Path::new(&out_dir).join("alias_priv_384.pem");
         let mut sample_alias_key_file_384 = File::create(path_384).unwrap();
         sample_alias_key_file_384.write_all(&pem_384).unwrap();
+    }
+    #[cfg(feature = "rustcrypto")]
+    {
+        use {
+            base64ct::LineEnding,
+            ecdsa::SigningKey,
+            fs::File,
+            p256::NistP256,
+            p384::NistP384,
+            rand::{rngs::StdRng, SeedableRng},
+            sec1::{DecodeEcPrivateKey, EncodeEcPrivateKey},
+            std::env,
+            std::fs,
+            std::io::Write,
+            std::path::Path,
+            std::str,
+        };
+
+        const ALIAS_PRIV_256: &str = "../platform/src/test_data/key_256.pem";
+        const ALIAS_PRIV_384: &str = "../platform/src/test_data/key_384.pem";
+
+        println!("cargo:rerun-if-changed={ALIAS_PRIV_256}");
+        println!("cargo:rerun-if-changed={ALIAS_PRIV_384}");
+
+        let out_dir = env::var_os("OUT_DIR").unwrap();
+
+        // generate 256 bit private key in PEM format
+        let pem_256 = if Path::new(ALIAS_PRIV_256).exists() {
+            let ec_secret = SigningKey::<NistP256>::read_sec1_pem_file(ALIAS_PRIV_256).unwrap();
+            ec_secret.to_sec1_pem(LineEnding::default()).unwrap()
+        } else {
+            let ec_secret = SigningKey::<NistP256>::random(&mut StdRng::from_entropy());
+            ec_secret.to_sec1_pem(LineEnding::default()).unwrap()
+        };
+
+        // generate 384 bit private key in PEM format
+        let pem_384 = if Path::new(ALIAS_PRIV_384).exists() {
+            let ec_secret = SigningKey::<NistP384>::read_sec1_pem_file(ALIAS_PRIV_384).unwrap();
+            ec_secret.to_sec1_pem(LineEnding::default()).unwrap()
+        } else {
+            let ec_secret = SigningKey::<NistP384>::random(&mut StdRng::from_entropy());
+            ec_secret.to_sec1_pem(LineEnding::default()).unwrap()
+        };
+
+        // write 256 bit private key to file
+        let path_256 = Path::new(&out_dir).join("alias_priv_256.pem");
+        let mut sample_alias_key_file_256 = File::create(path_256).unwrap();
+        sample_alias_key_file_256
+            .write_all(pem_256.deref().as_bytes())
+            .unwrap();
+
+        // write 384 bit private key to file
+        let path_384 = Path::new(&out_dir).join("alias_priv_384.pem");
+        let mut sample_alias_key_file_384 = File::create(path_384).unwrap();
+        sample_alias_key_file_384
+            .write_all(pem_384.deref().as_bytes())
+            .unwrap();
     }
 }

--- a/crypto/src/hkdf.rs
+++ b/crypto/src/hkdf.rs
@@ -1,0 +1,58 @@
+// Licensed under the Apache-2.0 license
+
+use crate::{AlgLen, CryptoBuf, CryptoError, Digest};
+use hkdf::Hkdf;
+use sha2::{Sha256, Sha384};
+
+impl From<hkdf::InvalidLength> for CryptoError {
+    fn from(_: hkdf::InvalidLength) -> Self {
+        CryptoError::HashError(0)
+    }
+}
+
+pub fn hkdf_derive_cdi(
+    algs: AlgLen,
+    measurement: &Digest,
+    info: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    match algs {
+        AlgLen::Bit256 => {
+            let hk = Hkdf::<Sha256>::new(Some(info), measurement.bytes());
+            let mut cdi = [0u8; AlgLen::Bit256.size()];
+            hk.expand(measurement.bytes(), &mut cdi)?;
+
+            Ok(cdi.to_vec())
+        }
+        AlgLen::Bit384 => {
+            let hk = Hkdf::<Sha384>::new(Some(info), measurement.bytes());
+            let mut cdi = [0u8; AlgLen::Bit384.size()];
+            hk.expand(measurement.bytes(), &mut cdi)?;
+
+            Ok(cdi.to_vec())
+        }
+    }
+}
+
+pub fn hkdf_get_priv_key(
+    algs: AlgLen,
+    cdi: &[u8],
+    label: &[u8],
+    info: &[u8],
+) -> Result<CryptoBuf, CryptoError> {
+    match algs {
+        AlgLen::Bit256 => {
+            let hk = Hkdf::<Sha256>::new(Some(info), cdi);
+            let mut priv_key = [0u8; AlgLen::Bit256.size()];
+            hk.expand(label, &mut priv_key)?;
+
+            Ok(CryptoBuf::new(&priv_key).unwrap())
+        }
+        AlgLen::Bit384 => {
+            let hk = Hkdf::<Sha384>::new(Some(info), cdi);
+            let mut priv_key = [0u8; AlgLen::Bit384.size()];
+            hk.expand(label, &mut priv_key)?;
+
+            Ok(CryptoBuf::new(&priv_key).unwrap())
+        }
+    }
+}

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -3,18 +3,27 @@ Licensed under the Apache-2.0 license.
 Abstract:
     Generic trait definition of Cryptographic functions.
 --*/
-#![cfg_attr(not(any(feature = "openssl", test)), no_std)]
+#![cfg_attr(not(any(feature = "openssl", feature = "rustcrypto", test)), no_std)]
 
 #[cfg(feature = "openssl")]
 pub use crate::openssl::*;
 pub use signer::*;
 
+#[cfg(feature = "rustcrypto")]
+pub use crate::rustcrypto::*;
+pub use signer::*;
+
 #[cfg(feature = "openssl")]
 pub mod openssl;
+
+#[cfg(feature = "rustcrypto")]
+pub mod rustcrypto;
 
 #[cfg(feature = "deterministic_rand")]
 pub use rand::*;
 
+#[cfg(any(feature = "openssl", feature = "rustcrypto"))]
+mod hkdf;
 mod signer;
 
 #[derive(Debug, Clone, Copy)]

--- a/crypto/src/rustcrypto.rs
+++ b/crypto/src/rustcrypto.rs
@@ -1,0 +1,200 @@
+// Licensed under the Apache-2.0 license
+
+use crate::{
+    hkdf::*, AlgLen, Crypto, CryptoBuf, CryptoError, Digest, EcdsaPub, EcdsaSig, Hasher, HmacSig,
+};
+use core::ops::Deref;
+use ecdsa::{signature::hazmat::PrehashSigner, Signature};
+use hmac::{Hmac, Mac};
+use p256::NistP256;
+use p384::NistP384;
+use rand::{rngs::StdRng, RngCore, SeedableRng};
+use sec1::DecodeEcPrivateKey;
+use sha2::{digest::DynDigest, Sha256, Sha384};
+use std::boxed::Box;
+
+const RUSTCRYPTO_ECDSA_ERROR: CryptoError = CryptoError::CryptoLibError(1);
+const RUSTCRYPTO_SEC_ERROR: CryptoError = CryptoError::CryptoLibError(2);
+
+impl From<ecdsa::Error> for CryptoError {
+    fn from(_value: ecdsa::Error) -> Self {
+        RUSTCRYPTO_ECDSA_ERROR
+    }
+}
+
+impl From<sec1::Error> for CryptoError {
+    fn from(_value: sec1::Error) -> Self {
+        RUSTCRYPTO_SEC_ERROR
+    }
+}
+
+impl TryFrom<Signature<NistP256>> for EcdsaSig {
+    type Error = CryptoError;
+
+    fn try_from(value: Signature<NistP256>) -> Result<Self, Self::Error> {
+        let r = CryptoBuf::new(&value.r().deref().to_bytes())?;
+        let s = CryptoBuf::new(&value.s().deref().to_bytes())?;
+        Ok(EcdsaSig { r, s })
+    }
+}
+impl TryFrom<Signature<NistP384>> for EcdsaSig {
+    type Error = CryptoError;
+
+    fn try_from(value: Signature<NistP384>) -> Result<Self, Self::Error> {
+        let r = CryptoBuf::new(&value.r().deref().to_bytes())?;
+        let s = CryptoBuf::new(&value.s().deref().to_bytes())?;
+        Ok(EcdsaSig { r, s })
+    }
+}
+
+pub struct RustCryptoHasher(Box<dyn DynDigest>);
+impl Hasher for RustCryptoHasher {
+    fn update(&mut self, bytes: &[u8]) -> Result<(), CryptoError> {
+        Ok(self.0.update(bytes))
+    }
+    fn finish(self) -> Result<Digest, CryptoError> {
+        Digest::new(&self.0.finalize())
+    }
+}
+
+pub struct RustCryptoImpl(StdRng);
+impl RustCryptoImpl {
+    #[cfg(not(feature = "deterministic_rand"))]
+    pub fn new() -> Self {
+        RustCryptoImpl(StdRng::from_entropy())
+    }
+
+    #[cfg(feature = "deterministic_rand")]
+    pub fn new() -> Self {
+        const SEED: [u8; 32] = [1; 32];
+        let seeded_rng = StdRng::from_seed(SEED);
+        RustCryptoImpl(seeded_rng)
+    }
+}
+
+impl Crypto for RustCryptoImpl {
+    type Cdi = Vec<u8>;
+    type Hasher<'c>  = RustCryptoHasher where Self: 'c;
+    type PrivKey = CryptoBuf;
+
+    fn hash_initialize(&mut self, algs: AlgLen) -> Result<Self::Hasher<'_>, CryptoError> {
+        let hasher = match algs {
+            AlgLen::Bit256 => RustCryptoHasher(Box::new(Sha256::default())),
+            AlgLen::Bit384 => RustCryptoHasher(Box::new(Sha384::default())),
+        };
+        Ok(hasher)
+    }
+
+    fn rand_bytes(&mut self, dst: &mut [u8]) -> Result<(), CryptoError> {
+        StdRng::fill_bytes(&mut self.0, dst);
+        Ok(())
+    }
+
+    fn derive_cdi(
+        &mut self,
+        algs: AlgLen,
+        measurement: &Digest,
+        info: &[u8],
+    ) -> Result<Self::Cdi, CryptoError> {
+        hkdf_derive_cdi(algs, measurement, info)
+    }
+
+    fn derive_key_pair(
+        &mut self,
+        algs: AlgLen,
+        cdi: &Self::Cdi,
+        label: &[u8],
+        info: &[u8],
+    ) -> Result<(Self::PrivKey, EcdsaPub), CryptoError> {
+        let secret = hkdf_get_priv_key(algs, cdi, label, info)?;
+        match algs {
+            AlgLen::Bit256 => {
+                let signing = p256::ecdsa::SigningKey::from_slice(&secret.bytes())?;
+                let verifying = p256::ecdsa::VerifyingKey::from(&signing);
+                let point = verifying.to_encoded_point(false);
+                let x = CryptoBuf::new(point.x().ok_or(RUSTCRYPTO_ECDSA_ERROR)?.as_slice())?;
+                let y = CryptoBuf::new(point.y().ok_or(RUSTCRYPTO_ECDSA_ERROR)?.as_slice())?;
+                Ok((secret, EcdsaPub { x, y }))
+            }
+            AlgLen::Bit384 => {
+                let signing = p384::ecdsa::SigningKey::from_slice(&secret.bytes())?;
+                let verifying = p384::ecdsa::VerifyingKey::from(&signing);
+                let point = verifying.to_encoded_point(false);
+                let x = CryptoBuf::new(point.x().ok_or(RUSTCRYPTO_ECDSA_ERROR)?.as_slice())?;
+                let y = CryptoBuf::new(point.y().ok_or(RUSTCRYPTO_ECDSA_ERROR)?.as_slice())?;
+                Ok((secret, EcdsaPub { x, y }))
+            }
+        }
+    }
+
+    fn ecdsa_sign_with_alias(
+        &mut self,
+        algs: AlgLen,
+        digest: &Digest,
+    ) -> Result<EcdsaSig, CryptoError> {
+        match algs {
+            AlgLen::Bit256 => {
+                let signing_key = p256::ecdsa::SigningKey::read_sec1_pem_file(concat!(
+                    env!("OUT_DIR"),
+                    "/alias_priv_256.pem"
+                ))?;
+                let sig: p256::ecdsa::Signature = signing_key.sign_prehash(digest.bytes())?;
+                sig.try_into()
+            }
+            AlgLen::Bit384 => {
+                let signing_key = p384::ecdsa::SigningKey::read_sec1_pem_file(concat!(
+                    env!("OUT_DIR"),
+                    "/alias_priv_384.pem"
+                ))?;
+                let sig: p384::ecdsa::Signature = signing_key.sign_prehash(digest.bytes())?;
+                sig.try_into()
+            }
+        }
+    }
+
+    fn ecdsa_sign_with_derived(
+        &mut self,
+        algs: AlgLen,
+        digest: &Digest,
+        priv_key: &Self::PrivKey,
+        _pub_key: &EcdsaPub,
+    ) -> Result<EcdsaSig, CryptoError> {
+        match algs {
+            AlgLen::Bit256 => {
+                let sig: p256::ecdsa::Signature =
+                    p256::ecdsa::SigningKey::from_slice(priv_key.bytes())?
+                        .sign_prehash(digest.bytes())?;
+                sig.try_into()
+            }
+            AlgLen::Bit384 => {
+                let sig: p384::ecdsa::Signature =
+                    p384::ecdsa::SigningKey::from_slice(priv_key.bytes())?
+                        .sign_prehash(digest.bytes())?;
+                sig.try_into()
+            }
+        }
+    }
+
+    fn hmac_sign_with_derived(
+        &mut self,
+        algs: AlgLen,
+        cdi: &Self::Cdi,
+        label: &[u8],
+        info: &[u8],
+        digest: &Digest,
+    ) -> Result<HmacSig, CryptoError> {
+        let (symmetric_key, _) = self.derive_key_pair(algs, cdi, label, info)?;
+        match algs {
+            AlgLen::Bit256 => {
+                let mut hmac = Hmac::<Sha256>::new_from_slice(symmetric_key.bytes()).unwrap();
+                Mac::update(&mut hmac, digest.bytes());
+                HmacSig::new(hmac.finalize().into_bytes().as_slice())
+            }
+            AlgLen::Bit384 => {
+                let mut hmac = Hmac::<Sha384>::new_from_slice(symmetric_key.bytes()).unwrap();
+                Mac::update(&mut hmac, digest.bytes());
+                HmacSig::new(hmac.finalize().into_bytes().as_slice())
+            }
+        }
+    }
+}

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -6,13 +6,14 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["dpe_profile_p256_sha256", "openssl"]
+default = ["dpe_profile_p256_sha256", "openssl", "rustcrypto"]
 openssl = ["dep:openssl"]
 rustcrypto = ["dep:x509-cert"]
 dpe_profile_p256_sha256 = []
 dpe_profile_p384_sha384 = []
 
 [dependencies]
+cfg-if = "1.0.0"
 openssl = {version = "0.10.57", optional = true}
 ufmt = { git = "https://github.com/korran/ufmt.git", rev = "1d0743c1ffffc68bc05ca8eeb81c166192863f33", features = ["inline"] }
 x509-cert = {version = "0.2.4", optional = true}

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -6,11 +6,13 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["dpe_profile_p256_sha256"]
+default = ["dpe_profile_p256_sha256", "openssl"]
 openssl = ["dep:openssl"]
+rustcrypto = ["dep:x509-cert"]
 dpe_profile_p256_sha256 = []
 dpe_profile_p384_sha384 = []
 
 [dependencies]
 openssl = {version = "0.10.57", optional = true}
 ufmt = { git = "https://github.com/korran/ufmt.git", rev = "1d0743c1ffffc68bc05ca8eeb81c166192863f33", features = ["inline"] }
+x509-cert = {version = "0.2.4", optional = true}

--- a/platform/src/default.rs
+++ b/platform/src/default.rs
@@ -1,8 +1,19 @@
 // Licensed under the Apache-2.0 license
 
+#[cfg(all(feature = "openssl", feature = "rustcrypto"))]
+compile_error!("feature \"openssl\" and feature \"rustcrypto\" cannot be enabled at the same time, because they provide duplicate definitions");
+
 use crate::{Platform, PlatformError, MAX_CHUNK_SIZE, MAX_SN_SIZE};
 use core::cmp::min;
+
+#[cfg(feature = "openssl")]
 use openssl::x509::X509;
+
+#[cfg(feature = "rustcrypto")]
+use x509_cert::{
+    certificate::Certificate,
+    der::{DecodePem, Encode},
+};
 
 pub struct DefaultPlatform;
 
@@ -22,6 +33,47 @@ pub const TEST_CERT_PEM: &[u8] = include_bytes!("test_data/cert_256.pem");
 
 #[cfg(feature = "dpe_profile_p384_sha384")]
 pub const TEST_CERT_PEM: &[u8] = include_bytes!("test_data/cert_384.pem");
+
+impl DefaultPlatform {
+    #[cfg(feature = "openssl")]
+    fn parse_issuer_name() -> Vec<u8> {
+        X509::from_pem(TEST_CERT_PEM)
+            .unwrap()
+            .subject_name()
+            .to_der()
+            .unwrap()
+    }
+
+    #[cfg(feature = "openssl")]
+    fn parse_issuer_sn() -> Vec<u8> {
+        X509::from_pem(TEST_CERT_PEM)
+            .unwrap()
+            .serial_number()
+            .to_bn()
+            .unwrap()
+            .to_vec()
+    }
+
+    #[cfg(feature = "rustcrypto")]
+    fn parse_issuer_name() -> Vec<u8> {
+        Certificate::from_pem(TEST_CERT_PEM)
+            .unwrap()
+            .tbs_certificate
+            .subject
+            .to_der()
+            .unwrap()
+    }
+
+    #[cfg(feature = "rustcrypto")]
+    fn parse_issuer_sn() -> Vec<u8> {
+        Certificate::from_pem(TEST_CERT_PEM)
+            .unwrap()
+            .tbs_certificate
+            .serial_number
+            .as_bytes()
+            .to_vec()
+    }
+}
 
 impl Platform for DefaultPlatform {
     fn get_certificate_chain(
@@ -47,11 +99,7 @@ impl Platform for DefaultPlatform {
     }
 
     fn get_issuer_name(&mut self, out: &mut [u8; MAX_CHUNK_SIZE]) -> Result<usize, PlatformError> {
-        let issuer_name = X509::from_pem(TEST_CERT_PEM)
-            .unwrap()
-            .subject_name()
-            .to_der()
-            .unwrap();
+        let issuer_name = DefaultPlatform::parse_issuer_name();
         if issuer_name.len() > out.len() {
             return Err(PlatformError::IssuerNameError(0));
         }
@@ -60,12 +108,7 @@ impl Platform for DefaultPlatform {
     }
 
     fn get_issuer_sn(&mut self, out: &mut [u8; MAX_SN_SIZE]) -> Result<usize, PlatformError> {
-        let sn = X509::from_pem(TEST_CERT_PEM)
-            .unwrap()
-            .serial_number()
-            .to_bn()
-            .unwrap()
-            .to_vec();
+        let sn = DefaultPlatform::parse_issuer_sn();
         if sn.len() > out.len() {
             return Err(PlatformError::IssuerNameError(0));
         }

--- a/platform/src/default.rs
+++ b/platform/src/default.rs
@@ -1,19 +1,19 @@
 // Licensed under the Apache-2.0 license
 
-#[cfg(all(feature = "openssl", feature = "rustcrypto"))]
-compile_error!("feature \"openssl\" and feature \"rustcrypto\" cannot be enabled at the same time, because they provide duplicate definitions");
-
 use crate::{Platform, PlatformError, MAX_CHUNK_SIZE, MAX_SN_SIZE};
+use cfg_if::cfg_if;
 use core::cmp::min;
 
-#[cfg(feature = "openssl")]
-use openssl::x509::X509;
-
-#[cfg(feature = "rustcrypto")]
-use x509_cert::{
-    certificate::Certificate,
-    der::{DecodePem, Encode},
-};
+cfg_if! {
+    if #[cfg(feature = "openssl")] {
+        use openssl::x509::X509;
+    } else if  #[cfg(feature = "rustcrypto")] {
+        use x509_cert::{
+            certificate::Certificate,
+            der::{DecodePem, Encode},
+        };
+    }
+}
 
 pub struct DefaultPlatform;
 
@@ -35,43 +35,45 @@ pub const TEST_CERT_PEM: &[u8] = include_bytes!("test_data/cert_256.pem");
 pub const TEST_CERT_PEM: &[u8] = include_bytes!("test_data/cert_384.pem");
 
 impl DefaultPlatform {
-    #[cfg(feature = "openssl")]
-    fn parse_issuer_name() -> Vec<u8> {
-        X509::from_pem(TEST_CERT_PEM)
-            .unwrap()
-            .subject_name()
-            .to_der()
-            .unwrap()
-    }
+    cfg_if! {
+        if #[cfg(feature = "openssl")] {
+        fn parse_issuer_name() -> Vec<u8> {
+            X509::from_pem(TEST_CERT_PEM)
+                .unwrap()
+                .subject_name()
+                .to_der()
+                .unwrap()
+        }} else if  #[cfg(feature = "rustcrypto")] {
+               fn parse_issuer_name() -> Vec<u8> {
+            Certificate::from_pem(TEST_CERT_PEM)
+                .unwrap()
+                .tbs_certificate
+                .subject
+                .to_der()
+                .unwrap()
+        }
+    }}
 
-    #[cfg(feature = "openssl")]
-    fn parse_issuer_sn() -> Vec<u8> {
-        X509::from_pem(TEST_CERT_PEM)
-            .unwrap()
-            .serial_number()
-            .to_bn()
-            .unwrap()
-            .to_vec()
-    }
-
-    #[cfg(feature = "rustcrypto")]
-    fn parse_issuer_name() -> Vec<u8> {
-        Certificate::from_pem(TEST_CERT_PEM)
-            .unwrap()
-            .tbs_certificate
-            .subject
-            .to_der()
-            .unwrap()
-    }
-
-    #[cfg(feature = "rustcrypto")]
-    fn parse_issuer_sn() -> Vec<u8> {
-        Certificate::from_pem(TEST_CERT_PEM)
-            .unwrap()
-            .tbs_certificate
-            .serial_number
-            .as_bytes()
-            .to_vec()
+    cfg_if! {
+        if #[cfg(feature = "openssl")] {
+       fn parse_issuer_sn() -> Vec<u8> {
+            X509::from_pem(TEST_CERT_PEM)
+                .unwrap()
+                .serial_number()
+                .to_bn()
+                .unwrap()
+                .to_vec()
+        }
+        } else if  #[cfg(feature = "rustcrypto")] {
+          fn parse_issuer_sn() -> Vec<u8> {
+            Certificate::from_pem(TEST_CERT_PEM)
+                .unwrap()
+                .tbs_certificate
+                .serial_number
+                .as_bytes()
+                .to_vec()
+        }
+        }
     }
 }
 

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -3,12 +3,12 @@ Licensed under the Apache-2.0 license.
 Abstract:
     Generic trait definition of platform.
 --*/
-#![cfg_attr(not(any(feature = "openssl", test)), no_std)]
+#![cfg_attr(not(any(feature = "openssl", feature = "rustcrypto", test)), no_std)]
 
 #[cfg(feature = "openssl")]
 pub use openssl::x509::X509;
 
-#[cfg(feature = "openssl")]
+#[cfg(any(feature = "openssl", feature = "rustcrypto"))]
 pub mod default;
 
 pub mod printer;

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -6,18 +6,20 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["dpe_profile_p256_sha256"]
+default = ["dpe_profile_p256_sha256", "openssl"]
 dpe_profile_p256_sha256 = ["dpe/dpe_profile_p256_sha256", "platform/dpe_profile_p256_sha256"]
 dpe_profile_p384_sha384 = ["dpe/dpe_profile_p384_sha384", "platform/dpe_profile_p384_sha384"]
+openssl = ["dep:openssl", "crypto/openssl", "platform/openssl"]
+rustcrypto = ["crypto/rustcrypto", "platform/rustcrypto"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 ctrlc = { version = "3.0", features = ["termination"] }
-openssl = "0.10.57"
+openssl = {version="0.10.57", optional = true}
 clap = { version = "4.1.8", features = ["derive"] }
 log = "0.4.17"
 env_logger = "0.10.0"
 dpe = { path = "../dpe", default-features = false }
-crypto = { path = "../crypto", default-features = false, features = ["openssl"] }
-platform = { path = "../platform", default-features = false, features = ["openssl"] }
+crypto = { path = "../crypto", default-features = false }
+platform = { path = "../platform", default-features = false}

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -1,7 +1,9 @@
 // Licensed under the Apache-2.0 license
 
+#[cfg(not(any(feature = "openssl", feature = "rustcrypto")))]
+compile_error!("must provide a crypto implementation");
+
 use clap::Parser;
-use crypto::OpensslCrypto;
 use log::{error, info, trace, warn};
 use platform::default::DefaultPlatform;
 use std::fs;
@@ -17,6 +19,12 @@ use dpe::{
     support::Support,
     DpeInstance,
 };
+
+#[cfg(feature = "rustcrypto")]
+use crypto::RustCryptoImpl;
+
+#[cfg(feature = "openssl")]
+use crypto::OpensslCrypto;
 
 const SOCKET_PATH: &str = "/tmp/dpe-sim.socket";
 
@@ -113,7 +121,11 @@ struct Args {
 struct SimTypes {}
 
 impl DpeTypes for SimTypes {
+    #[cfg(feature = "rustcrypto")]
+    type Crypto<'a> = RustCryptoImpl;
+    #[cfg(feature = "openssl")]
     type Crypto<'a> = OpensslCrypto;
+
     type Platform<'a> = DefaultPlatform;
 }
 
@@ -148,7 +160,7 @@ fn main() -> std::io::Result<()> {
     support.set(Support::IS_SYMMETRIC, args.supports_is_symmetric);
 
     let mut env = DpeEnv::<SimTypes> {
-        crypto: OpensslCrypto::new(),
+        crypto: <SimTypes as DpeTypes>::Crypto::new(),
         platform: DefaultPlatform,
     };
 


### PR DESCRIPTION
Adds a RustCrypto implementation as an alternative to openssl. Openssl is set as the default, and for platform/simulator the two are mutually exclusive.

For the Crypto trait impl, I generally did not use generics across curves even though it is possible, because the trait bounds needed were often longer than the actual shared logic.
There is some shared logic with the openssl impl using the hkdf crate, which I've moved into a shared module.