### PR TITLE
Minor updates to RustCrypto impl

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -11,7 +11,6 @@ pub use signer::*;
 
 #[cfg(feature = "rustcrypto")]
 pub use crate::rustcrypto::*;
-pub use signer::*;
 
 #[cfg(feature = "openssl")]
 pub mod openssl;


### PR DESCRIPTION
* Remove redundant `use` in crypto
* Reorganize default platform parsing options