### PR TITLE
Make MAX_HANDLES configurable at runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,7 @@ dependencies = [
  "der",
  "openssl",
  "platform",
+ "rand",
  "spki",
  "ufmt",
  "x509-parser",

--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -9,6 +9,18 @@ edition = "2021"
 default = ["dpe_profile_p256_sha256"]
 dpe_profile_p256_sha256 = ["platform/dpe_profile_p256_sha256"]
 dpe_profile_p384_sha384 = ["platform/dpe_profile_p384_sha384"]
+# Run ARBITRARY_MAX_HANDLES=n cargo build --features arbitrary_max_handles to use this feature
+arbitrary_max_handles = []
+disable_simulation = []
+disable_extend_tci = []
+disable_auto_init = []
+disable_rotate_context = []
+disable_x509 = []
+disable_csr = []
+disable_is_symmetric = []
+disable_internal_info = []
+disable_internal_dice = []
+disable_is_ca = []
 
 [dependencies]
 bitflags = "2.4.0"
@@ -28,3 +40,4 @@ platform = {path = "../platform", default-features = false, features = ["openssl
 cms = "0.2.2"
 der = "0.7.8"
 spki = "0.7.2"
+rand = "0.8.5"

--- a/dpe/build.rs
+++ b/dpe/build.rs
@@ -1,0 +1,30 @@
+// Licensed under the Apache-2.0 license
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+
+fn main() {
+    let default_value: usize = 24;
+
+    let arbitrary_max_handles = env::var("ARBITRARY_MAX_HANDLES")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default_value);
+
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest_path = format!("{}/arbitrary_max_handles.rs", out_dir);
+
+    println!("cargo:rerun-if-env-changed=ARBITRARY_MAX_HANDLES");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let mut file = File::create(&dest_path).unwrap();
+    write!(
+        file,
+        "pub const MAX_HANDLES: usize = {};",
+        arbitrary_max_handles
+    )
+    .unwrap();
+
+    println!("cargo:rerun-if-changed={}", dest_path);
+}

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -59,10 +59,11 @@ impl DpeInstance {
         env: &mut DpeEnv<impl DpeTypes>,
         support: Support,
     ) -> Result<DpeInstance, DpeErrorCode> {
+        let updated_support = support.preprocess_support();
         const CONTEXT_INITIALIZER: Context = Context::new();
         let mut dpe = DpeInstance {
             contexts: [CONTEXT_INITIALIZER; MAX_HANDLES],
-            support,
+            support: updated_support,
             has_initialized: false.into(),
             reserved: [0u8; 3],
         };
@@ -80,11 +81,12 @@ impl DpeInstance {
         tci_type: u32,
         auto_init_measurement: [u8; DPE_PROFILE.get_hash_size()],
     ) -> Result<DpeInstance, DpeErrorCode> {
+        let updated_support = support.preprocess_support();
         // auto-init must be supported to add an auto init measurement
-        if !support.auto_init() {
+        if !updated_support.auto_init() {
             return Err(DpeErrorCode::ArgumentNotSupported);
         }
-        let mut dpe = Self::new(env, support)?;
+        let mut dpe = Self::new(env, updated_support)?;
 
         let locality = env.platform.get_auto_init_locality()?;
         let idx = dpe.get_active_context_pos(&ContextHandle::default(), locality)?;

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -24,7 +24,11 @@ pub mod x509;
 use zerocopy::{AsBytes, FromBytes};
 
 const MAX_CERT_SIZE: usize = 2048;
+#[cfg(not(feature = "arbitrary_max_handles"))]
 pub const MAX_HANDLES: usize = 24;
+#[cfg(feature = "arbitrary_max_handles")]
+include!(concat!(env!("OUT_DIR"), "/arbitrary_max_handles.rs"));
+
 const CURRENT_PROFILE_MAJOR_VERSION: u16 = 0;
 const CURRENT_PROFILE_MINOR_VERSION: u16 = 8;
 

--- a/dpe/src/support.rs
+++ b/dpe/src/support.rs
@@ -3,7 +3,7 @@ use bitflags::bitflags;
 use zerocopy::{AsBytes, FromBytes};
 use zeroize::Zeroize;
 
-#[derive(Default, AsBytes, FromBytes, Zeroize)]
+#[derive(Default, AsBytes, FromBytes, Zeroize, Copy, Clone)]
 #[repr(C)]
 pub struct Support(u32);
 
@@ -52,6 +52,51 @@ impl Support {
     }
     pub fn is_ca(&self) -> bool {
         self.contains(Support::IS_CA)
+    }
+    pub fn preprocess_support(&self) -> Support {
+        #[allow(unused_mut)]
+        let mut support = Support::empty();
+        #[cfg(feature = "disable_simulation")]
+        {
+            support.insert(Support::SIMULATION);
+        }
+        #[cfg(feature = "disable_extend_tci")]
+        {
+            support.insert(Support::EXTEND_TCI);
+        }
+        #[cfg(feature = "disable_auto_init")]
+        {
+            support.insert(Support::AUTO_INIT);
+        }
+        #[cfg(feature = "disable_rotate_context")]
+        {
+            support.insert(Support::ROTATE_CONTEXT);
+        }
+        #[cfg(feature = "disable_x509")]
+        {
+            support.insert(Support::X509);
+        }
+        #[cfg(feature = "disable_csr")]
+        {
+            support.insert(Support::CSR);
+        }
+        #[cfg(feature = "disable_is_symmetric")]
+        {
+            support.insert(Support::IS_SYMMETRIC);
+        }
+        #[cfg(feature = "disable_internal_info")]
+        {
+            support.insert(Support::INTERNAL_INFO);
+        }
+        #[cfg(feature = "disable_internal_dice")]
+        {
+            support.insert(Support::INTERNAL_DICE);
+        }
+        #[cfg(feature = "disable_is_ca")]
+        {
+            support.insert(Support::IS_CA);
+        }
+        self.difference(support)
     }
 }
 


### PR DESCRIPTION
To build DPE with a non-default number of MAX_HANDLES, you can run ARBITRARY_MAX_HANDLES=10 cargo build --features arbitrary_max_handles. If the ARBITRARY_MAX_HANDLES env var is not provided or is badly formatted, the default value of 24 will be used.

Some of the tests will fail for small numbers of max handles, but this is expected since the tests are intended for a DPE with 24 handles. In the future, we should add tests for DPEs where MAX_HANDLES=1, 2, etc.

Also, make support features disableable at compile time. Both of these changes will allow us to reduce the size of the DPE binary. 

fixes #299 
fixes #298 