### PR TITLE
Switch order of label and format in CertifyKey Req to match spec

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -33,8 +33,8 @@ bitflags! {
 pub struct CertifyKeyCmd {
     pub handle: ContextHandle,
     pub flags: CertifyKeyFlags,
-    pub label: [u8; DPE_PROFILE.get_hash_size()],
     pub format: u32,
+    pub label: [u8; DPE_PROFILE.get_hash_size()],
 }
 
 impl CertifyKeyCmd {

--- a/verification/client/abi.go
+++ b/verification/client/abi.go
@@ -167,8 +167,8 @@ const (
 type CertifyKeyReq[Digest DigestAlgorithm] struct {
 	ContextHandle ContextHandle
 	Flags         CertifyKeyFlags
-	Label         Digest
 	Format        CertifyKeyFormat
+	Label         Digest
 }
 
 // CertifyKeyResp is the output response from CertifyKey


### PR DESCRIPTION
fixes #315 