### PR TITLE
Update openssl version for all crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,9 +724,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.59"
+version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a257ad03cd8fb16ad4172fedf8094451e1af1c4b70097636ef2eac9a5f0cc33"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -750,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.95"
+version = "0.9.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a4130519a360279579c2053038317e40eff64d13fd3f004f9e1b72b8a6aaf9"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ members = [
 caliptra-cfi-lib-git = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-lib-git", rev = "9f315fcf11fe006e95e62149f54f98620e5244e7", default-features = false, features = ["cfi", "cfi-counter" ] }
 caliptra-cfi-derive-git = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-derive-git", rev = "9f315fcf11fe006e95e62149f54f98620e5244e7"}
 zerocopy = "0.6.6"
+openssl = "0.10.64"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -18,7 +18,7 @@ caliptra-cfi-derive-git.workspace = true
 ecdsa = { version = "0.16.9", optional = true, features = ["pem"]}
 hkdf = { version = "0.12.3", optional = true }
 hmac = {version="0.12.1", optional = true}
-openssl = {version = "0.10.57", optional = true}
+openssl = {workspace = true, optional = true}
 p256 = {version= "0.13.2", optional = true}
 p384 = {version= "0.13.0", optional = true}
 rand = { version = "0.8.5", optional = true }
@@ -31,7 +31,7 @@ strum = "0.24"
 strum_macros = "0.24"
 
 [build-dependencies]
-openssl = {version = "0.10.57", optional = true}
+openssl = {workspace = true, optional = true}
 rand = {version = "0.8.5", optional = true}
 p256 = {version= "0.13.2", optional = true}
 p384 = {version= "0.13.0", optional = true}

--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -39,7 +39,7 @@ cfg-if = "1.0.0"
 [dev-dependencies]
 asn1 = "0.13.0"
 caliptra-cfi-lib-git = { workspace = true, features = ["cfi-test"] }
-openssl = "0.10.57"
+openssl.workspace = true
 x509-parser = "0.15.1"
 crypto = {path = "../crypto", features = ["deterministic_rand", "openssl"]}
 platform = {path = "../platform", default-features = false, features = ["openssl"]}

--- a/dpe/fuzz/Cargo.lock
+++ b/dpe/fuzz/Cargo.lock
@@ -444,9 +444,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.57"
+version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
  "bitflags 2.4.0",
  "cfg-if",
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.93"
+version = "0.9.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
 dependencies = [
  "cc",
  "libc",
@@ -875,9 +875,9 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "zerocopy"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20707b61725734c595e840fb3704378a0cd2b9c74cc9e6e20724838fc6a1e2f9"
+checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
 dependencies = [
  "byteorder",
  "zerocopy-derive",
@@ -885,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56097d5b91d711293a42be9289403896b68654625021732067eac7a4ca388a1f"
+checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -15,6 +15,6 @@ dpe_profile_p384_sha384 = []
 [dependencies]
 arrayvec = { version = "0.7.4", default-features = false, features = ["zeroize"] }
 cfg-if = "1.0.0"
-openssl = {version = "0.10.57", optional = true}
+openssl = {workspace = true, optional = true}
 ufmt = { git = "https://github.com/korran/ufmt.git", rev = "1d0743c1ffffc68bc05ca8eeb81c166192863f33", features = ["inline"] }
 x509-cert = {version = "0.2.4", optional = true}

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -16,7 +16,7 @@ rustcrypto = ["crypto/rustcrypto", "platform/rustcrypto"]
 
 [dependencies]
 ctrlc = { version = "3.0", features = ["termination"] }
-openssl = {version="0.10.57", optional = true}
+openssl = { workspace = true, optional = true}
 clap = { version = "4.1.8", features = ["derive"] }
 log = "0.4.17"
 env_logger = "0.10.0"


### PR DESCRIPTION
This resolves several dependabot alerts for openssl.