### PR TITLE
Fix all cert lint errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 [[package]]
 name = "caliptra-cfi-derive-git"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=9f315fcf11fe006e95e62149f54f98620e5244e7#9f315fcf11fe006e95e62149f54f98620e5244e7"
+source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -187,7 +187,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib-git"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=9f315fcf11fe006e95e62149f54f98620e5244e7#9f315fcf11fe006e95e62149f54f98620e5244e7"
+source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
 
 [[package]]
 name = "cc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.dependencies]
-caliptra-cfi-lib-git = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-lib-git", rev = "9f315fcf11fe006e95e62149f54f98620e5244e7", default-features = false, features = ["cfi", "cfi-counter" ] }
-caliptra-cfi-derive-git = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-derive-git", rev = "9f315fcf11fe006e95e62149f54f98620e5244e7"}
+caliptra-cfi-lib-git = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-lib-git", rev = "a98e499d279e81ae85881991b1e9eee354151189", default-features = false, features = ["cfi", "cfi-counter" ] }
+caliptra-cfi-derive-git = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-derive-git", rev = "a98e499d279e81ae85881991b1e9eee354151189"}
 zerocopy = "0.6.6"
 openssl = "0.10.64"

--- a/dpe/fuzz/Cargo.lock
+++ b/dpe/fuzz/Cargo.lock
@@ -116,7 +116,7 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 [[package]]
 name = "caliptra-cfi-derive-git"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=9f315fcf11fe006e95e62149f54f98620e5244e7#9f315fcf11fe006e95e62149f54f98620e5244e7"
+source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -127,7 +127,7 @@ dependencies = [
 [[package]]
 name = "caliptra-cfi-lib-git"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=9f315fcf11fe006e95e62149f54f98620e5244e7#9f315fcf11fe006e95e62149f54f98620e5244e7"
+source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
 
 [[package]]
 name = "cc"

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -334,6 +334,9 @@ impl DpeInstance {
             out_idx += 1;
         }
 
+        if out_idx > nodes.len() {
+            return Err(DpeErrorCode::InternalError);
+        }
         nodes[..out_idx].reverse();
 
         Ok(out_idx)

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -18,7 +18,7 @@ pub mod printer;
 pub const MAX_CHUNK_SIZE: usize = 2048;
 pub const MAX_ISSUER_NAME_SIZE: usize = 128;
 pub const MAX_SN_SIZE: usize = 20;
-pub const MAX_SKI_SIZE: usize = 20;
+pub const MAX_KEY_IDENTIFIER_SIZE: usize = 20;
 pub const MAX_VALIDITY_SIZE: usize = 24;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -27,7 +27,7 @@ pub enum SignerIdentifier {
         issuer_name: ArrayVec<u8, { MAX_ISSUER_NAME_SIZE }>,
         serial_number: ArrayVec<u8, { MAX_SN_SIZE }>,
     },
-    SubjectKeyIdentifier(ArrayVec<u8, { MAX_SKI_SIZE }>),
+    SubjectKeyIdentifier(ArrayVec<u8, { MAX_KEY_IDENTIFIER_SIZE }>),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -46,6 +46,7 @@ pub enum PlatformError {
     SerialNumberError(u32) = 0x5,
     SubjectKeyIdentifierError(u32) = 0x6,
     CertValidityError(u32) = 0x7,
+    IssuerKeyIdentifierError(u32) = 0x8,
 }
 
 impl PlatformError {
@@ -65,6 +66,7 @@ impl PlatformError {
             PlatformError::SerialNumberError(code) => Some(*code),
             PlatformError::SubjectKeyIdentifierError(code) => Some(*code),
             PlatformError::CertValidityError(code) => Some(*code),
+            PlatformError::IssuerKeyIdentifierError(code) => Some(*code),
         }
     }
 }
@@ -99,6 +101,14 @@ pub trait Platform {
     /// This function can simply return an error if the DPE does not support CSRs.
     /// Otherwise, the platform can choose either SubjectKeyIdentifier or IssuerAndSerialNumber.
     fn get_signer_identifier(&mut self) -> Result<SignerIdentifier, PlatformError>;
+
+    /// Retrieves the issuer certificate's key identifier
+    ///
+    /// This function can simply return an error if the DPE does not support CAs or X509s.
+    fn get_issuer_key_identifier(
+        &mut self,
+        out: &mut [u8; MAX_KEY_IDENTIFIER_SIZE],
+    ) -> Result<(), PlatformError>;
 
     fn get_vendor_id(&mut self) -> Result<u32, PlatformError>;
 

--- a/verification/testing/getCertificateChain.go
+++ b/verification/testing/getCertificateChain.go
@@ -58,6 +58,10 @@ func checkCertificateChain(t *testing.T, certData []byte) []*x509.Certificate {
 			// strictly worse and mixing the two formats does not lend itself well
 			// to fixed-sized X.509 templating.
 			"e_wrong_time_format_pre2050",
+			// Certs in the Caliptra cert chain fail this lint currently.
+			// We will need to truncate the serial numbers for those certs and
+			// then enable this lint.
+			"e_subject_dn_serial_number_max_length",
 		},
 	})
 	if err != nil {
@@ -94,6 +98,7 @@ func checkCertificateChain(t *testing.T, certData []byte) []*x509.Certificate {
 				Type:  "CERTIFICATE",
 				Bytes: cert.Raw,
 			})))
+			t.Fatalf("Certificate lint failed!")
 		}
 	}
 


### PR DESCRIPTION
1. Truncate SerialNumber to 64 bits
2. Count unused bits in KeyUsage
3. Add SubjectKeyIdentifier extension
4. Add AuthorityKeyIdentifier extension
5. Make cert lint errors/warns fatal in CI
6. Update caliptra-cfi revision

fixes #74