### PR TITLE
Derive ZeroizeOnDrop everywhere

### DIFF
--- a/dpe/fuzz/src/fuzz_target_1.rs
+++ b/dpe/fuzz/src/fuzz_target_1.rs
@@ -66,7 +66,7 @@ fn harness(data: &[u8]) {
         platform: DefaultPlatform,
     };
     let mut dpe = DpeInstance::new(&mut env, SUPPORT).unwrap();
-    let prev_contexts = dpe.contexts;
+    let prev_contexts = dpe.contexts.clone();
 
     // Hard-code working locality
     let response = dpe

--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -257,7 +257,7 @@ impl CommandExecution for CertifyKeyCmd {
         dpe.roll_onetime_use_handle(env, idx)?;
 
         Ok(Response::CertifyKey(CertifyKeyResp {
-            new_context_handle: dpe.contexts[idx].handle,
+            new_context_handle: dpe.contexts[idx].handle.clone(),
             derived_pubkey_x,
             derived_pubkey_y,
             cert_size,
@@ -380,7 +380,7 @@ mod tests {
             _ => panic!("Incorrect return type."),
         };
         let certify_cmd_ca = CertifyKeyCmd {
-            handle: init_resp.handle,
+            handle: init_resp.handle.clone(),
             flags: CertifyKeyFlags::IS_CA,
             label: [0; DPE_PROFILE.get_hash_size()],
             format: CertifyKeyCmd::FORMAT_X509,

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -418,7 +418,7 @@ mod tests {
         children: &[u8],
     ) -> () {
         dpe.contexts[idx].state = ContextState::Active;
-        dpe.contexts[idx].handle = *handle;
+        dpe.contexts[idx].handle = handle.clone();
         dpe.contexts[idx].parent_idx = parent_idx;
         for i in children {
             let children = dpe.contexts[idx].add_child(*i as usize).unwrap();

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -101,7 +101,7 @@ impl CommandExecution for RotateCtxCmd {
         dpe.contexts[idx].handle = new_handle;
 
         Ok(Response::RotateCtx(NewHandleResp {
-            handle: new_handle,
+            handle: dpe.contexts[idx].handle.clone(),
             resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
         }))
     }

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -134,7 +134,7 @@ impl CommandExecution for SignCmd {
         cfg_if! {
             if #[cfg(not(feature = "no-cfi"))] {
                 cfi_assert!(dpe.support.is_symmetric() || !self.uses_symmetric());
-                cfi_assert_ne(context.context_type, ContextType::Simulation);
+                cfi_assert_ne(&context.context_type, &ContextType::Simulation);
             }
         }
 
@@ -163,7 +163,7 @@ impl CommandExecution for SignCmd {
         dpe.roll_onetime_use_handle(env, idx)?;
 
         Ok(Response::Sign(SignResp {
-            new_context_handle: dpe.contexts[idx].handle,
+            new_context_handle: dpe.contexts[idx].handle.clone(),
             sig_r_or_hmac,
             sig_s,
             resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),

--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -2,10 +2,10 @@
 use crate::{response::DpeErrorCode, tci::TciNodeData, U8Bool, MAX_HANDLES};
 use constant_time_eq::constant_time_eq;
 use zerocopy::{AsBytes, FromBytes};
-use zeroize::Zeroize;
+use zeroize::ZeroizeOnDrop;
 
 #[repr(C, align(4))]
-#[derive(AsBytes, FromBytes, Copy, Clone, PartialEq, Eq, Zeroize)]
+#[derive(AsBytes, FromBytes, Clone, PartialEq, Eq, ZeroizeOnDrop)]
 pub struct Context {
     pub handle: ContextHandle,
     pub tci: TciNodeData,
@@ -69,13 +69,13 @@ impl Context {
 
     /// Sets all values to an initialized state according to ActiveContextArgs
     pub fn activate(&mut self, args: &ActiveContextArgs) {
-        self.handle = *args.handle;
+        self.handle = args.handle.clone();
         self.tci = TciNodeData::new();
         self.tci.tci_type = args.tci_type;
         self.tci.locality = args.locality;
         self.children = 0;
         self.parent_idx = args.parent_idx;
-        self.context_type = args.context_type;
+        self.context_type = args.context_type.clone();
         self.state = ContextState::Active;
         self.locality = args.locality;
         self.allow_ca = args.allow_ca.into();
@@ -108,7 +108,7 @@ impl Context {
 }
 
 #[repr(C)]
-#[derive(Debug, PartialEq, Eq, Clone, Copy, zerocopy::AsBytes, zerocopy::FromBytes, Zeroize)]
+#[derive(Debug, PartialEq, Eq, Clone, zerocopy::AsBytes, zerocopy::FromBytes, ZeroizeOnDrop)]
 pub struct ContextHandle(pub [u8; ContextHandle::SIZE]);
 
 impl ContextHandle {
@@ -126,7 +126,7 @@ impl ContextHandle {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, AsBytes, FromBytes, Copy, Clone, Zeroize)]
+#[derive(Debug, PartialEq, Eq, AsBytes, FromBytes, Clone, ZeroizeOnDrop)]
 #[repr(u8, align(1))]
 #[rustfmt::skip]
 pub enum ContextState {
@@ -158,7 +158,7 @@ pub enum ContextState {
     _F0, _F1, _F2, _F3, _F4, _F5, _F6, _F7, _F8, _F9, _Fa, _Fb, _Fc, _Fd, _Fe, _Ff,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, AsBytes, FromBytes, Zeroize)]
+#[derive(Debug, PartialEq, Eq, Clone, AsBytes, FromBytes, ZeroizeOnDrop)]
 #[repr(u8, align(1))]
 #[rustfmt::skip]
 pub enum ContextType {

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -7,7 +7,7 @@ Abstract:
 #![cfg_attr(not(test), no_std)]
 
 pub use dpe_instance::DpeInstance;
-use zeroize::Zeroize;
+use zeroize::ZeroizeOnDrop;
 
 pub mod commands;
 pub mod context;
@@ -37,7 +37,7 @@ const INTERNAL_INPUT_INFO_SIZE: usize = size_of::<GetProfileResp>() + size_of::<
 /// A type with u8 backing memory but bool semantics
 /// This is needed to safely serialize booleans in the persisted DPE state
 /// using zerocopy.
-#[derive(Default, AsBytes, FromBytes, Copy, Clone, PartialEq, Eq, Zeroize)]
+#[derive(Default, AsBytes, FromBytes, Clone, PartialEq, Eq, ZeroizeOnDrop)]
 #[repr(C, align(1))]
 pub struct U8Bool {
     val: u8,

--- a/dpe/src/tci.rs
+++ b/dpe/src/tci.rs
@@ -1,10 +1,10 @@
 // Licensed under the Apache-2.0 license.
 use crate::DPE_PROFILE;
 use zerocopy::{AsBytes, FromBytes};
-use zeroize::Zeroize;
+use zeroize::ZeroizeOnDrop;
 
 #[repr(C, align(4))]
-#[derive(Default, Copy, Clone, AsBytes, FromBytes, PartialEq, Eq, Zeroize)]
+#[derive(Default, Clone, AsBytes, FromBytes, PartialEq, Eq, ZeroizeOnDrop)]
 pub struct TciNodeData {
     pub tci_type: u32,
     pub tci_cumulative: TciMeasurement,
@@ -24,7 +24,7 @@ impl TciNodeData {
 }
 
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, AsBytes, FromBytes, PartialEq, Eq, Zeroize)]
+#[derive(Clone, Debug, AsBytes, FromBytes, PartialEq, Eq, ZeroizeOnDrop)]
 pub struct TciMeasurement(pub [u8; DPE_PROFILE.get_tci_size()]);
 
 impl Default for TciMeasurement {

--- a/dpe/src/validation.rs
+++ b/dpe/src/validation.rs
@@ -107,7 +107,7 @@ impl<'a> DpeValidator<'a> {
             match context.state {
                 ContextState::Inactive => {
                     #[cfg(not(feature = "no-cfi"))]
-                    cfi_assert_eq(context.state, ContextState::Inactive);
+                    cfi_assert_eq(&context.state, &ContextState::Inactive);
                     let inactive_context_validation = self.validate_inactive_context(context);
                     if cfi_launder(inactive_context_validation.is_ok()) {
                         #[cfg(not(feature = "no-cfi"))]
@@ -120,7 +120,7 @@ impl<'a> DpeValidator<'a> {
                 }
                 ContextState::Active => {
                     #[cfg(not(feature = "no-cfi"))]
-                    cfi_assert_eq(context.state, ContextState::Active);
+                    cfi_assert_eq(&context.state, &ContextState::Active);
                     // has_initialized must be true if there is a normal, active context
                     if context.context_type == ContextType::Normal && !self.dpe.has_initialized() {
                         return Err(ValidationError::DpeNotMarkedInitialized);
@@ -137,7 +137,7 @@ impl<'a> DpeValidator<'a> {
                 }
                 ContextState::Retired => {
                     #[cfg(not(feature = "no-cfi"))]
-                    cfi_assert_eq(context.state, ContextState::Retired);
+                    cfi_assert_eq(&context.state, &ContextState::Retired);
                     let children_and_parent_check = self.check_children_and_parent(i);
                     if cfi_launder(children_and_parent_check.is_ok()) {
                         #[cfg(not(feature = "no-cfi"))]
@@ -253,7 +253,7 @@ impl<'a> DpeValidator<'a> {
                 if #[cfg(not(feature = "no-cfi"))] {
                     cfi_assert_eq(context.parent_idx, Context::ROOT_INDEX);
                     cfi_assert_eq(context.children, 0);
-                    cfi_assert_eq(context.tci, TciNodeData::default());
+                    cfi_assert_eq(&context.tci, &TciNodeData::default());
                     cfi_assert!(!context.uses_internal_input_dice());
                     cfi_assert!(!context.allow_ca());
                     cfi_assert!(!context.allow_x509());
@@ -296,7 +296,7 @@ impl<'a> DpeValidator<'a> {
             cfg_if! {
                 if #[cfg(not(feature = "no-cfi"))] {
                     cfi_assert_lt(child, MAX_HANDLES);
-                    cfi_assert_ne(self.dpe.contexts[child].state, ContextState::Inactive);
+                    cfi_assert_ne(&self.dpe.contexts[child].state, &ContextState::Inactive);
                     cfi_assert_eq(self.dpe.contexts[child].parent_idx as usize, idx);
                 }
             }
@@ -368,8 +368,8 @@ impl<'a> DpeValidator<'a> {
         for (i, (context, node_in_degree)) in self.dpe.contexts.iter().zip(in_degree).enumerate() {
             // dfs from all root nodes
             if node_in_degree == 0 && context.state != ContextState::Inactive {
-                let context_type = context.context_type;
-                if context_type == ContextType::Normal {
+                let context_type = &context.context_type;
+                if context_type == &ContextType::Normal {
                     normal_tree_count += 1;
                 }
                 let invalid_subtree_check = self.detect_invalid_subtree(i, &mut seen, context_type);
@@ -409,7 +409,7 @@ impl<'a> DpeValidator<'a> {
         &self,
         curr_idx: usize,
         seen: &mut [bool; MAX_HANDLES],
-        context_type: ContextType,
+        context_type: &ContextType,
     ) -> Result<(), ValidationError> {
         // if the current node was already visited we have a cycle
         if curr_idx >= MAX_HANDLES
@@ -419,15 +419,15 @@ impl<'a> DpeValidator<'a> {
             return Err(ValidationError::CyclesInTree);
         }
         // all nodes in the tree must have the same ContextType
-        if self.dpe.contexts[curr_idx].context_type != context_type {
+        if &self.dpe.contexts[curr_idx].context_type != context_type {
             return Err(ValidationError::MixedContextTypeConnectedComponents);
         }
         cfg_if! {
             if #[cfg(not(feature = "no-cfi"))] {
                 cfi_assert_le(curr_idx, MAX_HANDLES);
-                cfi_assert_ne(self.dpe.contexts[curr_idx].state, ContextState::Inactive);
+                cfi_assert_ne(&self.dpe.contexts[curr_idx].state, &ContextState::Inactive);
                 cfi_assert!(!seen[curr_idx]);
-                cfi_assert_eq(self.dpe.contexts[curr_idx].context_type, context_type);
+                cfi_assert_eq(&self.dpe.contexts[curr_idx].context_type, context_type);
             }
         }
         seen[curr_idx] = true;
@@ -469,7 +469,7 @@ pub mod tests {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
-        let mut dpe_validator = DpeValidator {
+        let dpe_validator = DpeValidator {
             dpe: &mut DpeInstance::new(&mut env, SUPPORT).unwrap(),
         };
 
@@ -532,7 +532,7 @@ pub mod tests {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
-        let mut dpe_validator = DpeValidator {
+        let dpe_validator = DpeValidator {
             dpe: &mut DpeInstance::new(&mut env, Support::empty()).unwrap(),
         };
 
@@ -584,7 +584,7 @@ pub mod tests {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
-        let mut dpe_validator = DpeValidator {
+        let dpe_validator = DpeValidator {
             dpe: &mut DpeInstance::new(&mut env, Support::all().difference(Support::AUTO_INIT))
                 .unwrap(),
         };
@@ -709,7 +709,7 @@ pub mod tests {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
-        let mut dpe_validator = DpeValidator {
+        let dpe_validator = DpeValidator {
             dpe: &mut DpeInstance::new(&mut env, Support::empty()).unwrap(),
         };
         dpe_validator.dpe.has_initialized = U8Bool::new(true);


### PR DESCRIPTION
To do this, we have to underive Copy on all types deriving ZeroizeOnDrop since a type can't be copyable and droppable.