### PR TITLE
Move DeriveContext(recursive) returned handle to NEW_CONTEXT_HANDLE

### DIFF
--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -242,10 +242,11 @@ impl CommandExecution for DeriveContextCmd {
                         ..tmp_context
                     };
 
-                    // No child context created so handle is unmeaningful
+                    // Return new handle in new_context_handle
                     Ok(Response::DeriveContext(DeriveContextResp {
-                        handle: ContextHandle::default(),
-                        parent_handle: dpe.contexts[parent_idx].handle,
+                        handle: dpe.contexts[parent_idx].handle,
+                        // Should be ignored since retain_parent cannot be true
+                        parent_handle: ContextHandle::default(),
                         resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
                     }))
                 } else {

--- a/verification/testing/deriveContext.go
+++ b/verification/testing/deriveContext.go
@@ -435,7 +435,7 @@ func TestDeriveContextRecursiveOnDerivedContexts(d client.TestDPEInstance, c cli
 	if err != nil {
 		t.Fatalf("[FATAL]: Could not set TCI value: %v", err)
 	}
-	childHandle = &resp.ParentContextHandle
+	childHandle = &resp.NewContextHandle
 
 	childHandle, childTcbInfo, err = getTcbInfoForHandle(c, childHandle)
 	if err != nil {


### PR DESCRIPTION
This aligns with the spec and is more consistent with all other commands.