### PR TITLE
Exclude additional lints in GetCertificateChain and support multiple error codes

### DIFF
--- a/verification/testing/getCertificateChain.go
+++ b/verification/testing/getCertificateChain.go
@@ -62,6 +62,11 @@ func checkCertificateChain(t *testing.T, certData []byte) []*x509.Certificate {
 			// We will need to truncate the serial numbers for those certs and
 			// then enable this lint.
 			"e_subject_dn_serial_number_max_length",
+			// Firmware certificates don't get revocated, so there is no need
+			// for a CRSL to be specified in the CA certificate.
+			"w_distribution_point_missing_ldap_or_uri",
+			// Authority Information Access for CA can also be an HTTPS URI.
+			"w_ext_aia_access_location_missing",
 		},
 	})
 	if err != nil {

--- a/verification/testing/initializeContext.go
+++ b/verification/testing/initializeContext.go
@@ -43,17 +43,17 @@ func testInitContext(d client.TestDPEInstance, c client.DPEClient, t *testing.T,
 	// Try to initialize another default context.
 	_, err := c.InitializeContext(client.InitIsDefault)
 	if err == nil {
-		t.Fatal("The instance should return an error when trying to initialize another default context.")
-	} else if !errors.Is(err, client.StatusArgumentNotSupported) {
-		t.Fatalf("Incorrect error type. Should return %q, but returned %q", client.StatusArgumentNotSupported, err)
+		t.Error("The instance should return an error when trying to initialize another default context.")
+	} else if !(errors.Is(err, client.StatusArgumentNotSupported) || errors.Is(err, client.StatusInvalidArgument)) {
+		t.Errorf("Incorrect error type. Should return %q or %q, but returned %q", client.StatusArgumentNotSupported, client.StatusInvalidArgument, err)
 	}
 
 	// Try to initialize a context that is neither default or simulation.
 	_, err = c.InitializeContext(client.InitCtxFlags(0))
 	if err == nil {
-		t.Fatal("The instance should return an error when not default or simulation.")
+		t.Error("The instance should return an error when not default or simulation.")
 	} else if !errors.Is(err, client.StatusInvalidArgument) {
-		t.Fatalf("Incorrect error type. Should return %q, but returned %q", client.StatusInvalidArgument, err)
+		t.Errorf("Incorrect error type. Should return %q, but returned %q", client.StatusInvalidArgument, err)
 	}
 
 	// TODO: test exhausting handles. This requires the ability to query how


### PR DESCRIPTION
## What does this PR do?
Fix some tests:
- `GetCertificateChain`:
  - Add `w_distribution_point_missing_ldap_or_uri` and `w_ext_aia_access_location_missing` to the certificate linter exclusions.
- `InitializeContext`:
  -  Support both `StatusArgumentNotSupported` and `StatusInvalidArgument` when attempting to reinitialize context: if a DPE implementation doesn't support a given command, it makes sense that it returns invalid (it doesn't know it since it doesn't implement it).
  - Change some failures from Fatal to Error, so all required tests run.