### PR TITLE
Reduce stack usage for DPE command input structures

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -355,7 +355,7 @@ mod tests {
             .to_vec();
         command.extend(TEST_CERTIFY_KEY_CMD.as_bytes());
         assert_eq!(
-            Ok(Command::CertifyKey(TEST_CERTIFY_KEY_CMD)),
+            Ok(Command::CertifyKey(&TEST_CERTIFY_KEY_CMD)),
             Command::deserialize(&command)
         );
     }

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -390,7 +390,7 @@ mod tests {
             .to_vec();
         command.extend(TEST_DERIVE_CONTEXT_CMD.as_bytes());
         assert_eq!(
-            Ok(Command::DeriveContext(TEST_DERIVE_CONTEXT_CMD)),
+            Ok(Command::DeriveContext(&TEST_DERIVE_CONTEXT_CMD)),
             Command::deserialize(&command)
         );
     }

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -119,7 +119,7 @@ mod tests {
             .to_vec();
         command.extend(TEST_DESTROY_CTX_CMD.as_bytes());
         assert_eq!(
-            Ok(Command::DestroyCtx(TEST_DESTROY_CTX_CMD)),
+            Ok(Command::DestroyCtx(&TEST_DESTROY_CTX_CMD)),
             Command::deserialize(&command)
         );
     }

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -74,7 +74,9 @@ mod tests {
             .to_vec();
         command.extend(TEST_GET_CERTIFICATE_CHAIN_CMD.as_bytes());
         assert_eq!(
-            Ok(Command::GetCertificateChain(TEST_GET_CERTIFICATE_CHAIN_CMD)),
+            Ok(Command::GetCertificateChain(
+                &TEST_GET_CERTIFICATE_CHAIN_CMD
+            )),
             Command::deserialize(&command)
         );
     }

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -132,7 +132,7 @@ mod tests {
             .to_vec();
         command.extend(TEST_INIT_CTX_CMD.as_bytes());
         assert_eq!(
-            Ok(Command::InitCtx(TEST_INIT_CTX_CMD)),
+            Ok(Command::InitCtx(&TEST_INIT_CTX_CMD)),
             Command::deserialize(&command)
         );
     }

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -151,7 +151,7 @@ mod tests {
             .to_vec();
         command.extend(TEST_ROTATE_CTX_CMD.as_bytes());
         assert_eq!(
-            Ok(Command::RotateCtx(TEST_ROTATE_CTX_CMD)),
+            Ok(Command::RotateCtx(&TEST_ROTATE_CTX_CMD)),
             Command::deserialize(&command)
         );
     }

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -230,7 +230,7 @@ mod tests {
         let mut command = CommandHdr::new_for_test(Command::SIGN).as_bytes().to_vec();
         command.extend(TEST_SIGN_CMD.as_bytes());
         assert_eq!(
-            Ok(Command::Sign(TEST_SIGN_CMD)),
+            Ok(Command::Sign(&TEST_SIGN_CMD)),
             Command::deserialize(&command)
         );
     }


### PR DESCRIPTION
Use zerocopy to pass references to DPE command structures, using the input slice as backing storage. This saves a few hundred bytes over copying these values to structs on the stack.