### PR TITLE
Increase max cert size to 6KiB

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -83,7 +83,7 @@ run_verification_tests dpe_profile_p384_sha384 rustcrypto
 # Build fuzz target
 ( cd dpe/fuzz
   rustup toolchain install nightly-2023-11-16
-  cargo +nightly-2023-11-16 install cargo-fuzz cargo-afl
+  cargo +nightly-2023-11-16 install cargo-fuzz cargo-afl --locked
   cargo fmt --check
   cargo clippy --features libfuzzer-sys
   cargo clippy --features afl

--- a/dpe/fuzz/Cargo.lock
+++ b/dpe/fuzz/Cargo.lock
@@ -943,18 +943,18 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.6"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65238aacd5fb83fb03fcaf94823e71643e937000ec03c46e7da94234b10c870"
+checksum = "e031087b26520ba76806365896f191416ce84873ed6c6910a9ab5fe0f98f8ed3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.6"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ca22c4ad176b37bd81a565f66635bde3d654fe6832730c3e52e1018ae1655ee"
+checksum = "568244125ba0fc91ae949b97f2852f82cb1a65c3327bd68e6edadd29e67cca26"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -25,14 +25,15 @@ pub mod x509;
 
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
-const MAX_CERT_SIZE: usize = 2048;
+// Max cert size returned by CertifyKey
+const MAX_CERT_SIZE: usize = 6144;
 #[cfg(not(feature = "arbitrary_max_handles"))]
 pub const MAX_HANDLES: usize = 24;
 #[cfg(feature = "arbitrary_max_handles")]
 include!(concat!(env!("OUT_DIR"), "/arbitrary_max_handles.rs"));
 
 const CURRENT_PROFILE_MAJOR_VERSION: u16 = 0;
-const CURRENT_PROFILE_MINOR_VERSION: u16 = 10;
+const CURRENT_PROFILE_MINOR_VERSION: u16 = 11;
 
 #[cfg(not(feature = "disable_internal_info"))]
 const INTERNAL_INPUT_INFO_SIZE: usize = size_of::<GetProfileResp>() + size_of::<u32>();
@@ -65,8 +66,9 @@ impl From<bool> for U8Bool {
 }
 
 pub enum DpeProfile {
-    P256Sha256 = 1,
-    P384Sha384 = 2,
+    // Note: Min profiles (1 & 2) are not supported by this implementation
+    P256Sha256 = 3,
+    P384Sha384 = 4,
 }
 
 impl DpeProfile {

--- a/dpe/src/response.rs
+++ b/dpe/src/response.rs
@@ -9,7 +9,7 @@ use crate::{
     CURRENT_PROFILE_MINOR_VERSION, DPE_PROFILE, MAX_CERT_SIZE, MAX_HANDLES,
 };
 use crypto::CryptoError;
-use platform::PlatformError;
+use platform::{PlatformError, MAX_CHUNK_SIZE};
 use zerocopy::IntoBytes;
 
 #[cfg_attr(test, derive(PartialEq, Debug, Eq))]
@@ -190,7 +190,7 @@ pub struct SignResp {
 pub struct GetCertificateChainResp {
     pub resp_hdr: ResponseHdr,
     pub certificate_size: u32,
-    pub certificate_chain: [u8; MAX_CERT_SIZE],
+    pub certificate_chain: [u8; MAX_CHUNK_SIZE],
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -15,6 +15,7 @@ pub mod default;
 
 pub mod printer;
 
+// Max cert chunk returned by GetCertificateChain
 pub const MAX_CHUNK_SIZE: usize = 2048;
 pub const MAX_ISSUER_NAME_SIZE: usize = 128;
 pub const MAX_SN_SIZE: usize = 20;

--- a/verification/client/client.go
+++ b/verification/client/client.go
@@ -61,6 +61,10 @@ type DPEClient interface {
 // NewClient returns a new DPE client
 func NewClient(t Transport, p Profile) (DPEClient, error) {
 	switch p {
+	case ProfileMinP256SHA256:
+		return NewDPEABI256Min(t)
+	case ProfileMinP384SHA384:
+		return NewDPEABI384Min(t)
 	case ProfileP256SHA256:
 		return NewDPEABI256(t)
 	case ProfileP384SHA384:

--- a/verification/client/profile.go
+++ b/verification/client/profile.go
@@ -11,17 +11,25 @@ import (
 type Profile uint32
 
 const (
-	// ProfileP256SHA256 is NIST P-256, SHA-256
-	ProfileP256SHA256 Profile = 1
-	// ProfileP384SHA384 is NIST P-384, SHA-384
-	ProfileP384SHA384 Profile = 2
+	// ProfileIrotMinP256SHA256 is NIST P-256, SHA-256 "minimal profile"
+	ProfileMinP256SHA256 Profile = 1
+	// ProfileIrotMinP384SHA384 is NIST P-384, SHA-384 "minimal" profile
+	ProfileMinP384SHA384 Profile = 2
+	// ProfileIrotMinP256SHA256 is NIST P-256, SHA-256 "minimal profile"
+	ProfileP256SHA256 Profile = 3
+	// ProfileIrotP384SHA384 is NIST P-384, SHA-384 "minimal" profile
+	ProfileP384SHA384 Profile = 4
 )
 
 // GetDigestSize gets the digest size of the profile's supported hash algorithm
 func (p Profile) GetDigestSize() int {
 	switch p {
+	case ProfileMinP256SHA256:
+		fallthrough
 	case ProfileP256SHA256:
 		return 32
+	case ProfileMinP384SHA384:
+		fallthrough
 	case ProfileP384SHA384:
 		return 48
 	}
@@ -31,8 +39,12 @@ func (p Profile) GetDigestSize() int {
 // GetECCIntSize gets the ECC int size of the profile's supported ECC curve
 func (p Profile) GetECCIntSize() int {
 	switch p {
+	case ProfileMinP256SHA256:
+		fallthrough
 	case ProfileP256SHA256:
 		return 32
+	case ProfileMinP384SHA384:
+		fallthrough
 	case ProfileP384SHA384:
 		return 48
 	}
@@ -41,8 +53,12 @@ func (p Profile) GetECCIntSize() int {
 
 func (p Profile) String() string {
 	switch p {
+	case ProfileMinP256SHA256:
+		return "DPE_PROFILE_IROT_MIN_P256_SHA256"
 	case ProfileP256SHA256:
 		return "DPE_PROFILE_IROT_P256_SHA256"
+	case ProfileMinP384SHA384:
+		return "DPE_PROFILE_IROT_MIN_P384_SHA384"
 	case ProfileP384SHA384:
 		return "DPE_PROFILE_IROT_P384_SHA384"
 	}
@@ -81,6 +97,32 @@ type DigestAlgorithm interface {
 	SHA256Digest | SHA384Digest
 
 	Bytes() []byte
+}
+
+// DPEMinCertificate represents a certificate for the DPE minimal iRoT profiles
+type DPEMinCertificate [2046]byte
+
+// DPEFullCertificate represents a certificate for the DPE full iRoT profiles
+type DPEFullCertificate [6144]byte
+
+type DPECertificate interface {
+	DPEMinCertificate | DPEFullCertificate
+
+	Bytes() []byte
+}
+
+func CertLen[C DPECertificate]() int {
+	return reflect.TypeOf((*C)(nil)).Elem().Len()
+}
+
+// Bytes returns a byte slice of the DPE min certificate
+func (c DPEMinCertificate) Bytes() []byte {
+	return c[:]
+}
+
+// Bytes returns a byte slice of the DPE full certificate
+func (c DPEFullCertificate) Bytes() []byte {
+	return c[:]
 }
 
 func NewDigest[D DigestAlgorithm](b []byte) (D, error) {

--- a/verification/testing/certifyKey.go
+++ b/verification/testing/certifyKey.go
@@ -690,12 +690,16 @@ func getKeyUsageNames(keyUsage x509.KeyUsage) []string {
 func checkPubKey(t *testing.T, p client.Profile, pubkey any, response client.CertifiedKey) {
 	var pubKeyInResponse ecdsa.PublicKey
 	switch p {
+	case client.ProfileMinP256SHA256:
+		fallthrough
 	case client.ProfileP256SHA256:
 		pubKeyInResponse = ecdsa.PublicKey{
 			Curve: elliptic.P256(),
 			X:     new(big.Int).SetBytes(response.Pub.X),
 			Y:     new(big.Int).SetBytes(response.Pub.Y),
 		}
+	case client.ProfileMinP384SHA384:
+		fallthrough
 	case client.ProfileP384SHA384:
 		pubKeyInResponse = ecdsa.PublicKey{
 			Curve: elliptic.P384(),

--- a/verification/testing/simulator.go
+++ b/verification/testing/simulator.go
@@ -147,7 +147,7 @@ func GetSimulatorTargets() []TestTarget {
 		},
 		{
 			"DeriveContext_MaxTCIs",
-			getTestTarget([]string{"AutoInit", "Simulation"}),
+			getTestTarget([]string{"AutoInit", "Recursive", "X509"}),
 			[]TestCase{DeriveContextMaxTCIsTestCase},
 		},
 		{

--- a/verification/testing/verification.go
+++ b/verification/testing/verification.go
@@ -124,7 +124,7 @@ var DeriveContextSimulationTestCase = TestCase{
 
 // DeriveContextMaxTCIsTestCase checks whether the number of derived contexts is limited by MAX_TCI_NODES attribute of the profile
 var DeriveContextMaxTCIsTestCase = TestCase{
-	"DeriveContext_MaxTCIs", TestMaxTCIs, []string{"AutoInit"},
+	"DeriveContext_MaxTCIs", TestMaxTCIs, []string{"AutoInit", "X509"},
 }
 
 // DeriveContextLocalityTestCase tests DerivedContext with the ChangeLocality flag.


### PR DESCRIPTION
This aligns with the latest DPE iRoT profile. Caliptra supports 32 TCIs which can result in certificates ~5KiB.

Additionally, add support for min v.s. full profiles in the DPE client. This is also defined in the latest 0.11 DPE iRoT profile.