### PR TITLE
Add is_certificate and export_cdi flags to DeriveContext

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -170,12 +170,38 @@ pub trait Crypto {
         info: &[u8],
     ) -> Result<Self::Cdi, CryptoError>;
 
+    /// Derive a CDI for an exported private key based on the current base CDI and measurements
+    ///
+    /// # Arguments
+    ///
+    /// * `algs` - Which length of algorithms to use.
+    /// * `measurement` - A digest of the measurements which should be used for CDI derivation
+    /// * `info` - Caller-supplied info string to use in CDI derivation
+    fn derive_cdi_exported(
+        &mut self,
+        algs: AlgLen,
+        measurement: &Digest,
+        info: &[u8],
+    ) -> Result<Self::Cdi, CryptoError>;
+
     /// CFI wrapper around derive_cdi
     ///
     /// To implement this function, you need to add the
     /// cfi_impl_fn proc_macro to derive_cdi.
     #[cfg(not(feature = "no-cfi"))]
     fn __cfi_derive_cdi(
+        &mut self,
+        algs: AlgLen,
+        measurement: &Digest,
+        info: &[u8],
+    ) -> Result<Self::Cdi, CryptoError>;
+
+    /// CFI wrapper around derive_cdi_exported
+    ///
+    /// To implement this function, you need to add the
+    /// cfi_impl_fn proc_macro to derive_cdi.
+    #[cfg(not(feature = "no-cfi"))]
+    fn __cfi_derive_cdi_exported(
         &mut self,
         algs: AlgLen,
         measurement: &Digest,
@@ -199,12 +225,42 @@ pub trait Crypto {
         info: &[u8],
     ) -> Result<(Self::PrivKey, EcdsaPub), CryptoError>;
 
+    /// Derives an exported key pair using a cryptographically secure KDF
+    ///
+    /// # Arguments
+    ///
+    /// * `algs` - Which length of algorithms to use.
+    /// * `cdi` - Caller-supplied private key to use in public key derivation
+    /// * `label` - Caller-supplied label to use in asymmetric key derivation
+    /// * `info` - Caller-supplied info string to use in asymmetric key derivation
+    ///
+    fn derive_key_pair_exported(
+        &mut self,
+        algs: AlgLen,
+        cdi: &Self::Cdi,
+        label: &[u8],
+        info: &[u8],
+    ) -> Result<(Self::PrivKey, EcdsaPub), CryptoError>;
+
     /// CFI wrapper around derive_key_pair
     ///
     /// To implement this function, you need to add the
     /// cfi_impl_fn proc_macro to derive_key_pair.
     #[cfg(not(feature = "no-cfi"))]
     fn __cfi_derive_key_pair(
+        &mut self,
+        algs: AlgLen,
+        cdi: &Self::Cdi,
+        label: &[u8],
+        info: &[u8],
+    ) -> Result<(Self::PrivKey, EcdsaPub), CryptoError>;
+
+    /// CFI wrapper around derive_key_pair_exported
+    ///
+    /// To implement this function, you need to add the
+    /// cfi_impl_fn proc_macro to derive_key_pair.
+    #[cfg(not(feature = "no-cfi"))]
+    fn __cfi_derive_key_pair_exported(
         &mut self,
         algs: AlgLen,
         cdi: &Self::Cdi,

--- a/crypto/src/openssl.rs
+++ b/crypto/src/openssl.rs
@@ -90,6 +90,35 @@ impl OpensslCrypto {
 
         EcKey::from_private_components(&group, priv_key_bn, &pub_point)
     }
+
+    fn derive_key_pair_inner(
+        &mut self,
+        algs: AlgLen,
+        cdi: &<OpensslCrypto as Crypto>::Cdi,
+        label: &[u8],
+        info: &[u8],
+    ) -> Result<(<OpensslCrypto as Crypto>::PrivKey, EcdsaPub), CryptoError> {
+        let priv_key = hkdf_get_priv_key(algs, cdi, label, info)?;
+
+        let ec_priv_key = OpensslCrypto::ec_key_from_priv_key(algs, &priv_key)?;
+        let nid = OpensslCrypto::get_curve(algs);
+
+        let group = EcGroup::from_curve_name(nid).unwrap();
+        let mut bn_ctx = BigNumContext::new().unwrap();
+
+        let mut x = BigNum::new().unwrap();
+        let mut y = BigNum::new().unwrap();
+
+        ec_priv_key
+            .public_key()
+            .affine_coordinates(&group, &mut x, &mut y, &mut bn_ctx)
+            .unwrap();
+
+        let x = CryptoBuf::new(&x.to_vec_padded(algs.size() as i32).unwrap()).unwrap();
+        let y = CryptoBuf::new(&y.to_vec_padded(algs.size() as i32).unwrap()).unwrap();
+
+        Ok((priv_key, EcdsaPub { x, y }))
+    }
 }
 
 impl Default for OpensslCrypto {
@@ -134,6 +163,16 @@ impl Crypto for OpensslCrypto {
     }
 
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    fn derive_cdi_exported(
+        &mut self,
+        algs: AlgLen,
+        measurement: &Digest,
+        info: &[u8],
+    ) -> Result<Self::Cdi, CryptoError> {
+        hkdf_derive_cdi(algs, measurement, info)
+    }
+
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     fn derive_key_pair(
         &mut self,
         algs: AlgLen,
@@ -141,26 +180,18 @@ impl Crypto for OpensslCrypto {
         label: &[u8],
         info: &[u8],
     ) -> Result<(Self::PrivKey, EcdsaPub), CryptoError> {
-        let priv_key = hkdf_get_priv_key(algs, cdi, label, info)?;
+        self.derive_key_pair_inner(algs, cdi, label, info)
+    }
 
-        let ec_priv_key = OpensslCrypto::ec_key_from_priv_key(algs, &priv_key)?;
-        let nid = OpensslCrypto::get_curve(algs);
-
-        let group = EcGroup::from_curve_name(nid).unwrap();
-        let mut bn_ctx = BigNumContext::new().unwrap();
-
-        let mut x = BigNum::new().unwrap();
-        let mut y = BigNum::new().unwrap();
-
-        ec_priv_key
-            .public_key()
-            .affine_coordinates(&group, &mut x, &mut y, &mut bn_ctx)
-            .unwrap();
-
-        let x = CryptoBuf::new(&x.to_vec_padded(algs.size() as i32).unwrap()).unwrap();
-        let y = CryptoBuf::new(&y.to_vec_padded(algs.size() as i32).unwrap()).unwrap();
-
-        Ok((priv_key, EcdsaPub { x, y }))
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    fn derive_key_pair_exported(
+        &mut self,
+        algs: AlgLen,
+        cdi: &Self::Cdi,
+        label: &[u8],
+        info: &[u8],
+    ) -> Result<(Self::PrivKey, EcdsaPub), CryptoError> {
+        self.derive_key_pair_inner(algs, cdi, label, info)
     }
 
     fn ecdsa_sign_with_alias(

--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -20,6 +20,7 @@ disable_csr = []
 disable_internal_info = []
 disable_internal_dice = []
 disable_retain_parent_context = []
+disable_export_cdi = []
 no-cfi = ["crypto/no-cfi"]
 
 [dependencies]

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -12,7 +12,7 @@ use bitflags::bitflags;
 #[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_derive_git::cfi_impl_fn;
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_launder};
+use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
 use cfg_if::cfg_if;
 use crypto::{Crypto, Hasher};
 use platform::{Platform, PlatformError, MAX_ISSUER_NAME_SIZE, MAX_KEY_IDENTIFIER_SIZE};
@@ -397,7 +397,7 @@ impl CommandExecution for DeriveContextCmd {
                 u32::try_from(bytes_written).map_err(|_| DpeErrorCode::InternalError)?
             };
             Ok(Response::DeriveContext(DeriveContextResp {
-                handle: ContextHandle::default(), //TODO(clundin): Create an invalid ContextHandle.
+                handle: ContextHandle::new_invalid(),
                 parent_handle: dpe.contexts[parent_idx].handle,
                 resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
                 exported_cdi: [0; MAX_EXPORTED_CDI_SIZE], // TODO(clundin): Implement CDI storage
@@ -1271,6 +1271,7 @@ mod tests {
             Response::DeriveContext(resp) => resp,
             _ => panic!("Wrong response type."),
         };
+        assert_eq!(ContextHandle::new_invalid(), derive_resp.handle);
         let mut parser = X509CertificateParser::new().with_deep_parse_extensions(true);
         match parser
             .parse(&derive_resp.new_certificate[..derive_resp.certificate_size.try_into().unwrap()])

--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -116,10 +116,16 @@ pub struct ContextHandle(pub [u8; ContextHandle::SIZE]);
 impl ContextHandle {
     pub const SIZE: usize = 16;
     const DEFAULT: ContextHandle = ContextHandle([0; Self::SIZE]);
+    const INVALID: ContextHandle = ContextHandle([0xFF; Self::SIZE]);
 
     /// Returns the default context handle.
     pub const fn default() -> ContextHandle {
         Self::DEFAULT
+    }
+
+    /// Returns an invalid context handle.
+    pub const fn new_invalid() -> ContextHandle {
+        Self::INVALID
     }
 
     /// Whether the handle is the default context handle.

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -25,6 +25,8 @@ pub mod x509;
 
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
+const MAX_EXPORTED_CDI_SIZE: usize = 256;
+
 // Max cert size returned by CertifyKey
 const MAX_CERT_SIZE: usize = 6144;
 #[cfg(not(feature = "arbitrary_max_handles"))]

--- a/dpe/src/response.rs
+++ b/dpe/src/response.rs
@@ -6,7 +6,7 @@ Abstract:
 --*/
 use crate::{
     context::ContextHandle, validation::ValidationError, CURRENT_PROFILE_MAJOR_VERSION,
-    CURRENT_PROFILE_MINOR_VERSION, DPE_PROFILE, MAX_CERT_SIZE, MAX_HANDLES,
+    CURRENT_PROFILE_MINOR_VERSION, DPE_PROFILE, MAX_CERT_SIZE, MAX_EXPORTED_CDI_SIZE, MAX_HANDLES,
 };
 use crypto::CryptoError;
 use platform::{PlatformError, MAX_CHUNK_SIZE};
@@ -139,6 +139,9 @@ pub struct DeriveContextResp {
     pub resp_hdr: ResponseHdr,
     pub handle: ContextHandle,
     pub parent_handle: ContextHandle,
+    pub exported_cdi: [u8; MAX_EXPORTED_CDI_SIZE],
+    pub certificate_size: u32,
+    pub new_certificate: [u8; MAX_CERT_SIZE],
 }
 
 #[repr(C)]

--- a/dpe/src/support.rs
+++ b/dpe/src/support.rs
@@ -18,6 +18,7 @@ bitflags! {
         const INTERNAL_INFO = 1u32 << 22;
         const INTERNAL_DICE = 1u32 << 21;
         const RETAIN_PARENT_CONTEXT = 1u32 << 19;
+        const CDI_EXPORT = 1u32 << 18;
     }
 }
 
@@ -48,6 +49,9 @@ impl Support {
     }
     pub fn retain_parent_context(&self) -> bool {
         self.contains(Support::RETAIN_PARENT_CONTEXT)
+    }
+    pub fn cdi_export(&self) -> bool {
+        self.contains(Support::CDI_EXPORT)
     }
 
     /// Disables supported features based on compilation features
@@ -89,6 +93,10 @@ impl Support {
         #[cfg(feature = "disable_retain_parent_context")]
         {
             support.insert(Support::RETAIN_PARENT_CONTEXT);
+        }
+        #[cfg(feature = "disable_export_cdi")]
+        {
+            support.insert(Support::CDI_EXPORT);
         }
         self.difference(support)
     }
@@ -135,6 +143,8 @@ pub mod test {
         assert_eq!(flags, 1 << 21);
         let flags = Support::RETAIN_PARENT_CONTEXT.bits();
         assert_eq!(flags, 1 << 19);
+        let flags = Support::CDI_EXPORT.bits();
+        assert_eq!(flags, 1 << 18);
         // Supports a couple combos.
         let flags = (Support::SIMULATION
             | Support::AUTO_INIT
@@ -161,6 +171,7 @@ pub mod test {
                 | (1 << 22)
                 | (1 << 21)
                 | (1 << 19)
+                | (1 << 18)
         );
     }
 }


### PR DESCRIPTION
As well as other boiler plate work to make sure the invariants laid out in the spec are enforced.