### PR TITLE
Add is_certificate and export_cdi flags to DeriveContext

### DIFF
--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -20,6 +20,7 @@ disable_csr = []
 disable_internal_info = []
 disable_internal_dice = []
 disable_retain_parent_context = []
+disable_export_cdi = []
 no-cfi = ["crypto/no-cfi"]
 
 [dependencies]

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -25,6 +25,8 @@ pub mod x509;
 
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
+const MAX_EXPORTED_CDI_SIZE: usize = 256;
+
 // Max cert size returned by CertifyKey
 const MAX_CERT_SIZE: usize = 6144;
 #[cfg(not(feature = "arbitrary_max_handles"))]

--- a/dpe/src/response.rs
+++ b/dpe/src/response.rs
@@ -6,7 +6,7 @@ Abstract:
 --*/
 use crate::{
     context::ContextHandle, validation::ValidationError, CURRENT_PROFILE_MAJOR_VERSION,
-    CURRENT_PROFILE_MINOR_VERSION, DPE_PROFILE, MAX_CERT_SIZE, MAX_HANDLES,
+    CURRENT_PROFILE_MINOR_VERSION, DPE_PROFILE, MAX_CERT_SIZE, MAX_EXPORTED_CDI_SIZE, MAX_HANDLES,
 };
 use crypto::CryptoError;
 use platform::{PlatformError, MAX_CHUNK_SIZE};
@@ -139,6 +139,9 @@ pub struct DeriveContextResp {
     pub resp_hdr: ResponseHdr,
     pub handle: ContextHandle,
     pub parent_handle: ContextHandle,
+    pub exported_cdi: [u8; MAX_EXPORTED_CDI_SIZE],
+    pub certificate_size: u32,
+    pub new_certificate: [u8; MAX_CERT_SIZE],
 }
 
 #[repr(C)]

--- a/dpe/src/support.rs
+++ b/dpe/src/support.rs
@@ -18,6 +18,7 @@ bitflags! {
         const INTERNAL_INFO = 1u32 << 22;
         const INTERNAL_DICE = 1u32 << 21;
         const RETAIN_PARENT_CONTEXT = 1u32 << 19;
+        const CDI_EXPORT = 1u32 << 18;
     }
 }
 
@@ -48,6 +49,9 @@ impl Support {
     }
     pub fn retain_parent_context(&self) -> bool {
         self.contains(Support::RETAIN_PARENT_CONTEXT)
+    }
+    pub fn cdi_export(&self) -> bool {
+        self.contains(Support::CDI_EXPORT)
     }
 
     /// Disables supported features based on compilation features
@@ -89,6 +93,10 @@ impl Support {
         #[cfg(feature = "disable_retain_parent_context")]
         {
             support.insert(Support::RETAIN_PARENT_CONTEXT);
+        }
+        #[cfg(feature = "disable_export_cdi")]
+        {
+            support.insert(Support::CDI_EXPORT);
         }
         self.difference(support)
     }
@@ -135,6 +143,8 @@ pub mod test {
         assert_eq!(flags, 1 << 21);
         let flags = Support::RETAIN_PARENT_CONTEXT.bits();
         assert_eq!(flags, 1 << 19);
+        let flags = Support::CDI_EXPORT.bits();
+        assert_eq!(flags, 1 << 18);
         // Supports a couple combos.
         let flags = (Support::SIMULATION
             | Support::AUTO_INIT
@@ -161,6 +171,7 @@ pub mod test {
                 | (1 << 22)
                 | (1 << 21)
                 | (1 << 19)
+                | (1 << 18)
         );
     }
 }


### PR DESCRIPTION
As well as other boiler plate work to make sure the invariants laid out in the spec are enforced.