### PR TITLE
Refactor certificate generation code in CertifyKey

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -170,12 +170,38 @@ pub trait Crypto {
         info: &[u8],
     ) -> Result<Self::Cdi, CryptoError>;
 
+    /// Derive a CDI for an exported private key based on the current base CDI and measurements
+    ///
+    /// # Arguments
+    ///
+    /// * `algs` - Which length of algorithms to use.
+    /// * `measurement` - A digest of the measurements which should be used for CDI derivation
+    /// * `info` - Caller-supplied info string to use in CDI derivation
+    fn derive_exported_cdi(
+        &mut self,
+        algs: AlgLen,
+        measurement: &Digest,
+        info: &[u8],
+    ) -> Result<Self::Cdi, CryptoError>;
+
     /// CFI wrapper around derive_cdi
     ///
     /// To implement this function, you need to add the
     /// cfi_impl_fn proc_macro to derive_cdi.
     #[cfg(not(feature = "no-cfi"))]
     fn __cfi_derive_cdi(
+        &mut self,
+        algs: AlgLen,
+        measurement: &Digest,
+        info: &[u8],
+    ) -> Result<Self::Cdi, CryptoError>;
+
+    /// CFI wrapper around derive_cdi_exported
+    ///
+    /// To implement this function, you need to add the
+    /// cfi_impl_fn proc_macro to derive_exported_cdi.
+    #[cfg(not(feature = "no-cfi"))]
+    fn __cfi_derive_exported_cdi(
         &mut self,
         algs: AlgLen,
         measurement: &Digest,
@@ -199,12 +225,42 @@ pub trait Crypto {
         info: &[u8],
     ) -> Result<(Self::PrivKey, EcdsaPub), CryptoError>;
 
+    /// Derives an exported key pair using a cryptographically secure KDF
+    ///
+    /// # Arguments
+    ///
+    /// * `algs` - Which length of algorithms to use.
+    /// * `cdi` - Caller-supplied private key to use in public key derivation
+    /// * `label` - Caller-supplied label to use in asymmetric key derivation
+    /// * `info` - Caller-supplied info string to use in asymmetric key derivation
+    ///
+    fn derive_key_pair_exported(
+        &mut self,
+        algs: AlgLen,
+        cdi: &Self::Cdi,
+        label: &[u8],
+        info: &[u8],
+    ) -> Result<(Self::PrivKey, EcdsaPub), CryptoError>;
+
     /// CFI wrapper around derive_key_pair
     ///
     /// To implement this function, you need to add the
     /// cfi_impl_fn proc_macro to derive_key_pair.
     #[cfg(not(feature = "no-cfi"))]
     fn __cfi_derive_key_pair(
+        &mut self,
+        algs: AlgLen,
+        cdi: &Self::Cdi,
+        label: &[u8],
+        info: &[u8],
+    ) -> Result<(Self::PrivKey, EcdsaPub), CryptoError>;
+
+    /// CFI wrapper around derive_key_pair_exported
+    ///
+    /// To implement this function, you need to add the
+    /// cfi_impl_fn proc_macro to derive_key_pair.
+    #[cfg(not(feature = "no-cfi"))]
+    fn __cfi_derive_key_pair_exported(
         &mut self,
         algs: AlgLen,
         cdi: &Self::Cdi,

--- a/crypto/src/openssl.rs
+++ b/crypto/src/openssl.rs
@@ -90,6 +90,35 @@ impl OpensslCrypto {
 
         EcKey::from_private_components(&group, priv_key_bn, &pub_point)
     }
+
+    fn derive_key_pair_inner(
+        &mut self,
+        algs: AlgLen,
+        cdi: &<OpensslCrypto as Crypto>::Cdi,
+        label: &[u8],
+        info: &[u8],
+    ) -> Result<(<OpensslCrypto as Crypto>::PrivKey, EcdsaPub), CryptoError> {
+        let priv_key = hkdf_get_priv_key(algs, cdi, label, info)?;
+
+        let ec_priv_key = OpensslCrypto::ec_key_from_priv_key(algs, &priv_key)?;
+        let nid = OpensslCrypto::get_curve(algs);
+
+        let group = EcGroup::from_curve_name(nid).unwrap();
+        let mut bn_ctx = BigNumContext::new().unwrap();
+
+        let mut x = BigNum::new().unwrap();
+        let mut y = BigNum::new().unwrap();
+
+        ec_priv_key
+            .public_key()
+            .affine_coordinates(&group, &mut x, &mut y, &mut bn_ctx)
+            .unwrap();
+
+        let x = CryptoBuf::new(&x.to_vec_padded(algs.size() as i32).unwrap()).unwrap();
+        let y = CryptoBuf::new(&y.to_vec_padded(algs.size() as i32).unwrap()).unwrap();
+
+        Ok((priv_key, EcdsaPub { x, y }))
+    }
 }
 
 impl Default for OpensslCrypto {
@@ -104,7 +133,10 @@ type OpensslPrivKey = CryptoBuf;
 
 impl Crypto for OpensslCrypto {
     type Cdi = OpensslCdi;
-    type Hasher<'c> = OpensslHasher where Self: 'c;
+    type Hasher<'c>
+        = OpensslHasher
+    where
+        Self: 'c;
     type PrivKey = OpensslPrivKey;
 
     #[cfg(feature = "deterministic_rand")]
@@ -130,7 +162,19 @@ impl Crypto for OpensslCrypto {
         measurement: &Digest,
         info: &[u8],
     ) -> Result<Self::Cdi, CryptoError> {
-        hkdf_derive_cdi(algs, measurement, info)
+        let cdi = hkdf_derive_cdi(algs, measurement, info)?;
+        Ok(cdi)
+    }
+
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    fn derive_exported_cdi(
+        &mut self,
+        algs: AlgLen,
+        measurement: &Digest,
+        info: &[u8],
+    ) -> Result<Self::Cdi, CryptoError> {
+        let cdi = hkdf_derive_cdi(algs, measurement, info)?;
+        Ok(cdi)
     }
 
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
@@ -141,26 +185,18 @@ impl Crypto for OpensslCrypto {
         label: &[u8],
         info: &[u8],
     ) -> Result<(Self::PrivKey, EcdsaPub), CryptoError> {
-        let priv_key = hkdf_get_priv_key(algs, cdi, label, info)?;
+        self.derive_key_pair_inner(algs, cdi, label, info)
+    }
 
-        let ec_priv_key = OpensslCrypto::ec_key_from_priv_key(algs, &priv_key)?;
-        let nid = OpensslCrypto::get_curve(algs);
-
-        let group = EcGroup::from_curve_name(nid).unwrap();
-        let mut bn_ctx = BigNumContext::new().unwrap();
-
-        let mut x = BigNum::new().unwrap();
-        let mut y = BigNum::new().unwrap();
-
-        ec_priv_key
-            .public_key()
-            .affine_coordinates(&group, &mut x, &mut y, &mut bn_ctx)
-            .unwrap();
-
-        let x = CryptoBuf::new(&x.to_vec_padded(algs.size() as i32).unwrap()).unwrap();
-        let y = CryptoBuf::new(&y.to_vec_padded(algs.size() as i32).unwrap()).unwrap();
-
-        Ok((priv_key, EcdsaPub { x, y }))
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    fn derive_key_pair_exported(
+        &mut self,
+        algs: AlgLen,
+        cdi: &Self::Cdi,
+        label: &[u8],
+        info: &[u8],
+    ) -> Result<(Self::PrivKey, EcdsaPub), CryptoError> {
+        self.derive_key_pair_inner(algs, cdi, label, info)
     }
 
     fn ecdsa_sign_with_alias(

--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -4,22 +4,16 @@ use crate::{
     context::ContextHandle,
     dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
     response::{CertifyKeyResp, DpeErrorCode, Response, ResponseHdr},
-    tci::TciNodeData,
-    x509::{CertWriter, DirectoryString, MeasurementData, Name},
-    DPE_PROFILE, MAX_CERT_SIZE, MAX_HANDLES,
+    x509::{create_dpe_cert, create_dpe_csr, CreateDpeCertArgs, CreateDpeCertResult},
+    DPE_PROFILE, MAX_CERT_SIZE,
 };
 use bitflags::bitflags;
 #[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_derive_git::cfi_impl_fn;
-use caliptra_cfi_lib_git::cfi_launder;
 #[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
 use cfg_if::cfg_if;
-use crypto::{Crypto, Hasher};
 #[cfg(not(feature = "disable_x509"))]
-use platform::MAX_ISSUER_NAME_SIZE;
-use platform::{Platform, PlatformError, MAX_KEY_IDENTIFIER_SIZE};
-
 #[repr(C)]
 #[derive(
     Debug,
@@ -94,115 +88,24 @@ impl CommandExecution for CertifyKeyCmd {
             }
         }
 
-        let algs = DPE_PROFILE.alg_len();
-        let digest = dpe.compute_measurement_hash(env, idx)?;
-        let cdi = env
-            .crypto
-            .derive_cdi(DPE_PROFILE.alg_len(), &digest, b"DPE")?;
-        let key_pair = env.crypto.derive_key_pair(algs, &cdi, &self.label, b"ECC");
-        if cfi_launder(key_pair.is_ok()) {
-            #[cfg(not(feature = "no-cfi"))]
-            cfi_assert!(key_pair.is_ok());
-        } else {
-            #[cfg(not(feature = "no-cfi"))]
-            cfi_assert!(key_pair.is_err());
-        }
-        #[allow(unused_variables)]
-        let (priv_key, pub_key) = key_pair?;
-
-        let mut subj_serial = [0u8; DPE_PROFILE.get_hash_size() * 2];
-        env.crypto
-            .get_pubkey_serial(DPE_PROFILE.alg_len(), &pub_key, &mut subj_serial)?;
-        // The serial number of the subject can be at most 64 bytes
-        let truncated_subj_serial = &subj_serial[..64];
-
-        let subject_name = Name {
-            cn: DirectoryString::PrintableString(b"DPE Leaf"),
-            serial: DirectoryString::PrintableString(truncated_subj_serial),
+        let args = CreateDpeCertArgs {
+            handle: &self.handle,
+            locality,
+            cdi_label: b"DPE",
+            key_label: &self.label,
+            context: b"ECC",
         };
+        let mut cert = [0; MAX_CERT_SIZE];
 
-        // Get TCI Nodes
-        const INITIALIZER: TciNodeData = TciNodeData::new();
-        let mut nodes = [INITIALIZER; MAX_HANDLES];
-        let tcb_count = dpe.get_tcb_nodes(idx, &mut nodes)?;
-        if tcb_count > MAX_HANDLES {
-            return Err(DpeErrorCode::InternalError);
-        }
-
-        let mut subject_key_identifier = [0u8; MAX_KEY_IDENTIFIER_SIZE];
-        // compute key identifier as SHA hash of the DER encoded subject public key
-        let mut hasher = env.crypto.hash_initialize(DPE_PROFILE.alg_len())?;
-        hasher.update(&[0x04])?;
-        hasher.update(pub_key.x.bytes())?;
-        hasher.update(pub_key.y.bytes())?;
-        let hashed_pub_key = hasher.finish()?;
-        if hashed_pub_key.len() < MAX_KEY_IDENTIFIER_SIZE {
-            return Err(DpeErrorCode::InternalError);
-        }
-        // truncate key identifier to 20 bytes
-        subject_key_identifier.copy_from_slice(&hashed_pub_key.bytes()[..MAX_KEY_IDENTIFIER_SIZE]);
-
-        let mut authority_key_identifier = [0u8; MAX_KEY_IDENTIFIER_SIZE];
-        env.platform
-            .get_issuer_key_identifier(&mut authority_key_identifier)?;
-
-        let subject_alt_name = match env.platform.get_subject_alternative_name() {
-            Ok(subject_alt_name) => Some(subject_alt_name),
-            Err(PlatformError::NotImplemented) => None,
-            Err(e) => Err(DpeErrorCode::Platform(e))?,
-        };
-
-        let measurements = MeasurementData {
-            label: &self.label,
-            tci_nodes: &nodes[..tcb_count],
-            is_ca: false,
-            supports_recursive: dpe.support.recursive(),
-            subject_key_identifier,
-            authority_key_identifier,
-            subject_alt_name,
-        };
-
-        let mut cert = [0u8; MAX_CERT_SIZE];
-        let cert_size = match self.format {
+        let CreateDpeCertResult { cert_size, pub_key } = match self.format {
             Self::FORMAT_X509 => {
                 cfg_if! {
                     if #[cfg(not(feature = "disable_x509"))] {
-                        let mut issuer_name = [0u8; MAX_ISSUER_NAME_SIZE];
-                        let issuer_len = env.platform.get_issuer_name(&mut issuer_name)?;
                         #[cfg(not(feature = "no-cfi"))]
                         cfi_assert_eq(self.format, Self::FORMAT_X509);
-                        let mut tbs_buffer = [0u8; MAX_CERT_SIZE];
-                        let mut tbs_writer = CertWriter::new(&mut tbs_buffer, true);
-                        if issuer_len > MAX_ISSUER_NAME_SIZE {
-                            return Err(DpeErrorCode::InternalError);
-                        }
-                        let cert_validity = env.platform.get_cert_validity()?;
-                        let mut bytes_written = tbs_writer.encode_ecdsa_tbs(
-                            /*serial=*/
-                            &subject_name.serial.bytes()[..20], // Serial number must be truncated to 20 bytes
-                            &issuer_name[..issuer_len],
-                            &subject_name,
-                            &pub_key,
-                            &measurements,
-                            &cert_validity,
-                        )?;
-                        if bytes_written > MAX_CERT_SIZE {
-                            return Err(DpeErrorCode::InternalError);
-                        }
-
-                        let tbs_digest = env
-                            .crypto
-                            .hash(DPE_PROFILE.alg_len(), &tbs_buffer[..bytes_written])?;
-                        let sig = env
-                            .crypto
-                            .ecdsa_sign_with_alias(DPE_PROFILE.alg_len(), &tbs_digest)?;
-
-                        let mut cert_writer = CertWriter::new(&mut cert, true);
-                        bytes_written =
-                            cert_writer.encode_ecdsa_certificate(&tbs_buffer[..bytes_written], &sig)?;
-                        u32::try_from(bytes_written).map_err(|_| DpeErrorCode::InternalError)?
+                        create_dpe_cert(&args, dpe, env, &mut cert)
                     } else {
-                        Err(DpeErrorCode::ArgumentNotSupported)?
+                        Err(DpeErrorCode::ArgumentNotSupported)
                     }
                 }
             }
@@ -211,57 +114,14 @@ impl CommandExecution for CertifyKeyCmd {
                     if #[cfg(not(feature = "disable_csr"))] {
                         #[cfg(not(feature = "no-cfi"))]
                         cfi_assert_eq(self.format, Self::FORMAT_CSR);
-                        let mut cert_req_info_buffer = [0u8; MAX_CERT_SIZE];
-                        let mut cert_req_info_writer = CertWriter::new(&mut cert_req_info_buffer, true);
-                        let mut bytes_written = cert_req_info_writer
-                            .encode_certification_request_info(
-                                &pub_key,
-                                &subject_name,
-                                &measurements,
-                            )?;
-                        if bytes_written > MAX_CERT_SIZE {
-                            return Err(DpeErrorCode::InternalError);
-                        }
-
-                        let cert_req_info_digest = env.crypto.hash(
-                            DPE_PROFILE.alg_len(),
-                            &cert_req_info_buffer[..bytes_written],
-                        )?;
-                        // The PKCS#10 CSR is self-signed so the private key signs it instead of the alias key.
-                        let cert_req_info_sig = env.crypto.ecdsa_sign_with_derived(
-                            DPE_PROFILE.alg_len(),
-                            &cert_req_info_digest,
-                            &priv_key,
-                            &pub_key,
-                        )?;
-
-                        let mut csr_buffer = [0u8; MAX_CERT_SIZE];
-                        let mut csr_writer = CertWriter::new(&mut csr_buffer, true);
-                        bytes_written = csr_writer
-                            .encode_csr(&cert_req_info_buffer[..bytes_written], &cert_req_info_sig)?;
-                        if bytes_written > MAX_CERT_SIZE {
-                            return Err(DpeErrorCode::InternalError);
-                        }
-
-                        let csr_digest = env
-                            .crypto
-                            .hash(DPE_PROFILE.alg_len(), &csr_buffer[..bytes_written])?;
-                        let csr_sig = env
-                            .crypto
-                            .ecdsa_sign_with_alias(DPE_PROFILE.alg_len(), &csr_digest)?;
-                        let sid = env.platform.get_signer_identifier()?;
-
-                        let mut cms_writer = CertWriter::new(&mut cert, true);
-                        bytes_written =
-                            cms_writer.encode_cms(&csr_buffer[..bytes_written], &csr_sig, &sid)?;
-                        u32::try_from(bytes_written).map_err(|_| DpeErrorCode::InternalError)?
+                        create_dpe_csr(&args, dpe, env, &mut cert)
                     } else {
-                        Err(DpeErrorCode::ArgumentNotSupported)?
+                        Err(DpeErrorCode::ArgumentNotSupported)
                     }
                 }
             }
             _ => return Err(DpeErrorCode::InvalidArgument),
-        };
+        }?;
 
         let derived_pubkey_x: [u8; DPE_PROFILE.get_ecc_int_size()] =
             pub_key
@@ -297,14 +157,14 @@ mod tests {
         commands::{Command, CommandHdr, DeriveContextCmd, DeriveContextFlags, InitCtxCmd},
         dpe_instance::tests::{TestTypes, SIMULATION_HANDLE, TEST_LOCALITIES},
         support::Support,
-        x509::tests::TcbInfo,
+        x509::{tests::TcbInfo, DirectoryString, Name},
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use cms::{
         content_info::{CmsVersion, ContentInfo},
         signed_data::{SignedData, SignerIdentifier},
     };
-    use crypto::{AlgLen, CryptoBuf, EcdsaPub, OpensslCrypto};
+    use crypto::{AlgLen, Crypto, CryptoBuf, EcdsaPub, OpensslCrypto};
     use der::{Decode, Encode};
     use openssl::{
         bn::BigNum,
@@ -312,7 +172,7 @@ mod tests {
         ecdsa::EcdsaSig,
         nid::*,
     };
-    use platform::default::DefaultPlatform;
+    use platform::{default::DefaultPlatform, Platform};
     use spki::ObjectIdentifier;
     use std::str;
     use x509_parser::nom::Parser;

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -206,8 +206,7 @@ impl CommandExecution for DeriveContextCmd {
             || (!dpe.support.internal_dice() && self.uses_internal_dice_input())
             || (!dpe.support.retain_parent_context() && self.retains_parent())
             || (!dpe.support.x509() && self.allows_x509())
-            || (!dpe.support.cdi_export()
-                && (self.creates_certificate() || self.exports_cdi()))
+            || (!dpe.support.cdi_export() && (self.creates_certificate() || self.exports_cdi()))
             || (!dpe.support.recursive() && self.is_recursive())
         {
             return Err(DpeErrorCode::ArgumentNotSupported);


### PR DESCRIPTION
Refactor certificate generation code in CertifyKey to common code so it can be used in DeriveContext.