### PR TITLE
Add encoding options struct to modify behavior of the x509 encoder

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -94,6 +94,7 @@ impl CommandExecution for CertifyKeyCmd {
             cdi_label: b"DPE",
             key_label: &self.label,
             context: b"ECC",
+            encoding_override: None,
         };
         let mut cert = [0; MAX_CERT_SIZE];
 

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -7,7 +7,7 @@ use crate::{
         DeriveContextExportedCdiResp, DeriveContextResp, DpeErrorCode, Response, ResponseHdr,
     },
     tci::TciMeasurement,
-    x509::{create_exported_dpe_cert, CreateDpeCertArgs, CreateDpeCertResult},
+    x509::{create_exported_dpe_cert, CreateDpeCertArgs, CreateDpeCertResult, EncodingOptions},
     DPE_PROFILE, MAX_CERT_SIZE, MAX_EXPORTED_CDI_SIZE,
 };
 use bitflags::bitflags;
@@ -310,6 +310,7 @@ impl CommandExecution for DeriveContextCmd {
                         cdi_label: b"Exported CDI",
                         key_label: b"Exported ECC",
                         context: &exported_cdi_handle,
+                        encoding_override: Some(EncodingOptions{ encode_ueid: false, ..Default::default()}),
                     };
                     let mut cert = [0; MAX_CERT_SIZE];
                     let CreateDpeCertResult { cert_size, .. } = create_exported_dpe_cert(


### PR DESCRIPTION
For example, this allows DeriveContext to disable ueid encoding