### PR TITLE
Add DPE Platform function to retrieve Ueid

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -94,6 +94,7 @@ impl CommandExecution for CertifyKeyCmd {
             cdi_label: b"DPE",
             key_label: &self.label,
             context: b"ECC",
+            ueid: &self.label,
         };
         let mut cert = [0; MAX_CERT_SIZE];
 

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -17,6 +17,8 @@ use caliptra_cfi_derive_git::cfi_impl_fn;
 use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
 use cfg_if::cfg_if;
 
+use platform::Platform;
+
 #[repr(C)]
 #[derive(
     Debug,
@@ -299,12 +301,14 @@ impl CommandExecution for DeriveContextCmd {
         } else if self.creates_certificate() && self.exports_cdi() {
             cfg_if! {
                 if #[cfg(not(feature = "disable_export_cdi"))] {
+                    let ueid = &env.platform.get_ueid()?;
                     let args = CreateDpeCertArgs {
                         handle: &self.handle,
                         locality,
                         cdi_label: b"Exported CDI",
                         key_label: b"Exported ECC",
                         context: b"Exported ECC",
+                        ueid
                     };
                     let mut cert = [0; MAX_CERT_SIZE];
                     let CreateDpeCertResult { cert_size, exported_cdi_handle, .. } = create_exported_dpe_cert(

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -2257,6 +2257,8 @@ pub(crate) struct CreateDpeCertArgs<'a> {
     pub key_label: &'a [u8],
     /// Additional info string used in the key derivation
     pub context: &'a [u8],
+    /// Ueid extension value
+    pub ueid: &'a [u8],
 }
 
 /// Results for DPE cert or CSR creation.
@@ -2332,8 +2334,6 @@ fn get_subject_key_identifier(
     Ok(())
 }
 
-// TODO(clundin): Remove this lint when adding the DeriveContext certificate generation code.
-#[allow(unused)]
 pub(crate) fn create_exported_dpe_cert(
     args: &CreateDpeCertArgs,
     dpe: &mut DpeInstance,
@@ -2454,7 +2454,7 @@ fn create_dpe_cert_or_csr(
     };
 
     let measurements = MeasurementData {
-        label: args.key_label,
+        label: args.ueid,
         tci_nodes,
         is_ca,
         supports_recursive,

--- a/platform/src/default.rs
+++ b/platform/src/default.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use crate::{
-    CertValidity, Platform, PlatformError, SignerIdentifier, SubjectAltName, MAX_CHUNK_SIZE,
+    CertValidity, Platform, PlatformError, SignerIdentifier, SubjectAltName, Ueid, MAX_CHUNK_SIZE,
     MAX_ISSUER_NAME_SIZE, MAX_KEY_IDENTIFIER_SIZE,
 };
 use arrayvec::ArrayVec;
@@ -15,6 +15,7 @@ pub const VENDOR_ID: u32 = 0;
 pub const VENDOR_SKU: u32 = 0;
 pub const NOT_BEFORE: &str = "20230227000000Z";
 pub const NOT_AFTER: &str = "99991231235959Z";
+pub const TEST_UEID: Ueid = [0xA; 17];
 
 // Run ./generate.sh to generate all test certs and test private keys
 #[cfg(feature = "dpe_profile_p256_sha256")]
@@ -200,5 +201,8 @@ impl Platform for DefaultPlatform {
 
     fn get_subject_alternative_name(&mut self) -> Result<SubjectAltName, PlatformError> {
         Err(PlatformError::NotImplemented)
+    }
+    fn get_ueid(&mut self) -> Result<Ueid, PlatformError> {
+        Ok(TEST_UEID)
     }
 }

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -23,6 +23,8 @@ pub const MAX_KEY_IDENTIFIER_SIZE: usize = 20;
 pub const MAX_VALIDITY_SIZE: usize = 24;
 pub const MAX_OTHER_NAME_SIZE: usize = 128;
 
+pub type Ueid = [u8; 17];
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum SignerIdentifier {
     IssuerAndSerialNumber {
@@ -61,6 +63,7 @@ pub enum PlatformError {
     CertValidityError(u32) = 0x7,
     IssuerKeyIdentifierError(u32) = 0x8,
     SubjectAlternativeNameError(u32) = 0x9,
+    MissingUeidError = 0xA,
 }
 
 impl PlatformError {
@@ -75,6 +78,7 @@ impl PlatformError {
         match self {
             PlatformError::CertificateChainError => None,
             PlatformError::NotImplemented => None,
+            PlatformError::MissingUeidError => None,
             PlatformError::IssuerNameError(code) => Some(*code),
             PlatformError::PrintError(code) => Some(*code),
             PlatformError::SerialNumberError(code) => Some(*code),
@@ -147,4 +151,9 @@ pub trait Platform {
     /// can be left unimplemented if the SubjectAlternativeName extension is
     /// not needed in the DPE leaf cert or CSR.
     fn get_subject_alternative_name(&mut self) -> Result<SubjectAltName, PlatformError>;
+
+    /// Retrieves the device serial number
+    ///
+    /// This is encoded into certificates created by DPE.
+    fn get_ueid(&mut self) -> Result<Ueid, PlatformError>;
 }


### PR DESCRIPTION
This will be used to populate the Ueid extension in the x509 certificate created by DeriveContext when export-cdi is used.