### PR TITLE
Don't recompile dpe every single time

### DIFF
--- a/dpe/build.rs
+++ b/dpe/build.rs
@@ -20,7 +20,9 @@ fn main() {
     let max_handles_str = format!("pub const MAX_HANDLES: usize = {};", arbitrary_max_handles);
 
     let dest_path = PathBuf::from(&dest_path);
-    if dest_path.exists() && std::fs::read_to_string(&dest_path).unwrap_or_default() != max_handles_str {
+    if dest_path.exists()
+        && std::fs::read_to_string(&dest_path).unwrap_or_default() != max_handles_str
+    {
         std::fs::write(&dest_path, max_handles_str).unwrap();
     }
     println!("cargo:rerun-if-changed={}", dest_path.display());

--- a/dpe/build.rs
+++ b/dpe/build.rs
@@ -1,8 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use std::env;
-use std::fs::File;
-use std::io::Write;
+use std::path::PathBuf;
 
 fn main() {
     let default_value: usize = 24;
@@ -18,13 +17,11 @@ fn main() {
     println!("cargo:rerun-if-env-changed=ARBITRARY_MAX_HANDLES");
     println!("cargo:rerun-if-changed=build.rs");
 
-    let mut file = File::create(&dest_path).unwrap();
-    write!(
-        file,
-        "pub const MAX_HANDLES: usize = {};",
-        arbitrary_max_handles
-    )
-    .unwrap();
+    let max_handles_str = format!("pub const MAX_HANDLES: usize = {};", arbitrary_max_handles);
 
-    println!("cargo:rerun-if-changed={}", dest_path);
+    let dest_path = PathBuf::from(&dest_path);
+    if dest_path.exists() && std::fs::read_to_string(&dest_path).unwrap_or_default() != max_handles_str {
+        std::fs::write(&dest_path, max_handles_str).unwrap();
+    }
+    println!("cargo:rerun-if-changed={}", dest_path.display());
 }

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -2994,10 +2994,7 @@ pub(crate) mod tests {
             _ => (),
         }
 
-        match cert.get_extension_unique(&oid!(2.5.29 .35)) {
-            Err(_) => panic!("multiple authority key identifier extensions found"),
-            _ => (),
-        }
+        if let Err(_) = cert.get_extension_unique(&oid!(2.5.29 .35)) { panic!("multiple authority key identifier extensions found") }
 
         match cert.subject_alternative_name() {
             Ok(Some(ext)) => {

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -1590,7 +1590,7 @@ impl CertWriter<'_> {
     /// AuthorityKeyIdentifier ::= SEQUENCE {
     ///     keyIdentifier             [0] KeyIdentifier           OPTIONAL,
     ///     authorityCertIssuer       [1] GeneralNames            OPTIONAL,
-    ///     authorityCertSerialNumber [2] CertificateSerialNumber OPTIONAL  
+    ///     authorityCertSerialNumber [2] CertificateSerialNumber OPTIONAL
     /// }
     fn encode_authority_key_identifier_extension(
         &mut self,
@@ -2994,7 +2994,9 @@ pub(crate) mod tests {
             _ => (),
         }
 
-        if let Err(_) = cert.get_extension_unique(&oid!(2.5.29 .35)) { panic!("multiple authority key identifier extensions found") }
+        if let Err(_) = cert.get_extension_unique(&oid!(2.5.29 .35)) {
+            panic!("multiple authority key identifier extensions found")
+        }
 
         match cert.subject_alternative_name() {
             Ok(Some(ext)) => {


### PR DESCRIPTION
The build script always writes to `arbitrary_max_handles.rs`, which means that a recompile is always required.

This then triggers a rebuild of any project (i.e., Caliptra) that uses this.

This fixes it so that we only write the file if the contents need to be changed, so the build can be cached.