### PR TITLE
Fix caliptra-sw cold build

### DIFF
--- a/dpe/build.rs
+++ b/dpe/build.rs
@@ -20,10 +20,10 @@ fn main() {
     let max_handles_str = format!("pub const MAX_HANDLES: usize = {};", arbitrary_max_handles);
 
     let dest_path = PathBuf::from(&dest_path);
-    if dest_path.exists()
-        && std::fs::read_to_string(&dest_path).unwrap_or_default() != max_handles_str
-    {
-        std::fs::write(&dest_path, max_handles_str).unwrap();
+    match std::fs::read_to_string(&dest_path) {
+        // arbitrary_max_handles.rs already exists with the data we want.
+        Ok(handles) if handles.contains(&max_handles_str) => (),
+        _ => std::fs::write(&dest_path, max_handles_str).unwrap(),
     }
     println!("cargo:rerun-if-changed={}", dest_path.display());
 }


### PR DESCRIPTION
[Build improvement commit](https://github.com/chipsalliance/caliptra-dpe/commit/387034197f091694610c09548b2513731101ea54) improves the DPE build by checking if arbitrary_handles.rs has changed.

Caliptra-sw fails to compile after this change if the build is cold, since the arbitrary_handles.rs file is never created.