### PR TITLE
Update DPE to the latest zerocopy.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,18 +1379,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.8"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a4e33e6dce36f2adba29746927f8e848ba70989fdb61c772773bbdda8b5d6a7"
+checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.8"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd137b4cc21bde6ecce3bbbb3350130872cda0be2c6888874279ea76e17d4c1"
+checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 [workspace.dependencies]
 caliptra-cfi-lib-git = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-lib-git", rev = "a98e499d279e81ae85881991b1e9eee354151189", default-features = false, features = ["cfi", "cfi-counter" ] }
 caliptra-cfi-derive-git = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-derive-git", rev = "a98e499d279e81ae85881991b1e9eee354151189"}
-zerocopy = { version = "0.8.8", features = ["derive"] }
+zerocopy = { version = "0.8.17", features = ["derive"] }
 openssl = "0.10.64"
 
 [profile.firmware]

--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -24,7 +24,7 @@ use cfg_if::cfg_if;
     zerocopy::Immutable,
     zerocopy::KnownLayout,
 )]
-pub struct CertifyKeyFlags(u32);
+pub struct CertifyKeyFlags(pub u32);
 
 bitflags! {
     impl CertifyKeyFlags: u32 {}

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -29,7 +29,7 @@ use platform::Platform;
     zerocopy::Immutable,
     zerocopy::KnownLayout,
 )]
-pub struct DeriveContextFlags(u32);
+pub struct DeriveContextFlags(pub u32);
 
 bitflags! {
     impl DeriveContextFlags: u32 {

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -22,7 +22,7 @@ use cfg_if::cfg_if;
     zerocopy::Immutable,
     zerocopy::KnownLayout,
 )]
-pub struct InitCtxCmd(u32);
+pub struct InitCtxCmd(pub u32);
 
 bitflags! {
     impl InitCtxCmd: u32 {

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -22,7 +22,7 @@ use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
     zerocopy::Immutable,
     zerocopy::KnownLayout,
 )]
-pub struct RotateCtxFlags(u32);
+pub struct RotateCtxFlags(pub u32);
 
 bitflags! {
     impl RotateCtxFlags: u32 {

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -25,7 +25,7 @@ use crypto::{Crypto, Digest, EcdsaSig};
     zerocopy::Immutable,
     zerocopy::KnownLayout,
 )]
-pub struct SignFlags(u32);
+pub struct SignFlags(pub u32);
 
 bitflags! {
     impl SignFlags: u32 {}

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -45,14 +45,14 @@ pub struct DpeEnv<'a, T: DpeTypes + 'a> {
 #[derive(IntoBytes, TryFromBytes, KnownLayout, Immutable, Zeroize)]
 pub struct DpeInstance {
     pub contexts: [Context; MAX_HANDLES],
-    pub(crate) support: Support,
+    pub support: Support,
 
     /// Can only successfully execute the initialize context command for non-simulation (i.e.
     /// `InitializeContext(simulation=false)`) once per reset cycle.
-    pub(crate) has_initialized: U8Bool,
+    pub has_initialized: U8Bool,
 
     // unused buffer added to make DpeInstance word aligned and remove padding
-    reserved: [u8; 3],
+    pub reserved: [u8; 3],
 }
 
 impl DpeInstance {

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -48,7 +48,7 @@ const INTERNAL_INPUT_INFO_SIZE: usize = size_of::<GetProfileResp>() + size_of::<
 )]
 #[repr(C, align(1))]
 pub struct U8Bool {
-    val: u8,
+    pub val: u8,
 }
 
 impl U8Bool {

--- a/dpe/src/support.rs
+++ b/dpe/src/support.rs
@@ -5,7 +5,7 @@ use zeroize::Zeroize;
 
 #[derive(Default, IntoBytes, FromBytes, KnownLayout, Immutable, Zeroize, Copy, Clone)]
 #[repr(C)]
-pub struct Support(u32);
+pub struct Support(pub u32);
 
 bitflags! {
     impl Support: u32 {


### PR DESCRIPTION
Zerocopy's derive macro for KnownLayout has changed. Compiling DPE in caliptra-sw fails because public interfaces are leaking these private types.

The solution is to mark them as a public field. There may be another workaround, but since these types are being serialized to and from raw bytes, it makes sense that these private fields should be visible to callers.