### PR TITLE
Remove leftover CertifyKey CA code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,10 @@ jobs:
       # just need to update to use the most recent stable.
       - name: Update rustup
         run: |
-          rustup update
+          # Keep this in sync with rust-toolchain.toml
+          rustup toolchain install 1.83-x86_64-unknown-linux-gnu
+          rustup component add --toolchain 1.83-x86_64-unknown-linux-gnu rustfmt
+          rustup component add --toolchain 1.83-x86_64-unknown-linux-gnu clippy
 
       - name: Restore sccache binary
         uses: actions/cache/restore@v3

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -96,7 +96,6 @@ impl CommandExecution for InitCtxCmd {
             handle: &handle,
             tci_type: 0,
             parent_idx: Context::ROOT_INDEX,
-            allow_ca: true,
             allow_x509: true,
             uses_internal_input_info: false,
             uses_internal_input_dice: false,

--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -27,11 +27,9 @@ pub struct Context {
     pub uses_internal_input_info: U8Bool,
     /// Whether we should hash internal dice info consisting of the certificate chain when deriving the CDI
     pub uses_internal_input_dice: U8Bool,
-    /// Whether this context can emit certificates with IsCA = True
-    pub allow_ca: U8Bool,
     /// Whether this context can emit certificates in X.509 format
     pub allow_x509: U8Bool,
-    pub reserved: [u8; 1],
+    pub reserved: [u8; 2],
 }
 
 impl Default for Context {
@@ -54,9 +52,8 @@ impl Context {
             locality: 0,
             uses_internal_input_info: U8Bool::new(false),
             uses_internal_input_dice: U8Bool::new(false),
-            allow_ca: U8Bool::new(false),
             allow_x509: U8Bool::new(false),
-            reserved: [0; 1],
+            reserved: [0; 2],
         }
     }
 
@@ -65,9 +62,6 @@ impl Context {
     }
     pub fn uses_internal_input_dice(&self) -> bool {
         self.uses_internal_input_dice.get()
-    }
-    pub fn allow_ca(&self) -> bool {
-        self.allow_ca.get()
     }
     pub fn allow_x509(&self) -> bool {
         self.allow_x509.get()
@@ -84,7 +78,6 @@ impl Context {
         self.context_type = args.context_type;
         self.state = ContextState::Active;
         self.locality = args.locality;
-        self.allow_ca = args.allow_ca.into();
         self.allow_x509 = args.allow_x509.into();
         self.uses_internal_input_info = args.uses_internal_input_info.into();
         self.uses_internal_input_dice = args.uses_internal_input_dice.into();
@@ -97,7 +90,6 @@ impl Context {
         self.state = ContextState::Inactive;
         self.uses_internal_input_info = false.into();
         self.uses_internal_input_dice = false.into();
-        self.allow_ca = false.into();
         self.allow_x509 = false.into();
         self.parent_idx = Self::ROOT_INDEX;
     }
@@ -176,7 +168,6 @@ pub struct ActiveContextArgs<'a> {
     pub handle: &'a ContextHandle,
     pub tci_type: u32,
     pub parent_idx: u8,
-    pub allow_ca: bool,
     pub allow_x509: bool,
     pub uses_internal_input_info: bool,
     pub uses_internal_input_dice: bool,

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -448,8 +448,6 @@ impl DpeInstance {
             uses_internal_input_dice =
                 uses_internal_input_dice || context.uses_internal_input_dice();
 
-            // Add allow ca to hash
-            hasher.update(context.allow_ca().as_bytes())?;
             // Add allow x509 to hash
             hasher.update(context.allow_x509().as_bytes())?;
         }
@@ -793,9 +791,6 @@ pub mod tests {
             let context = result.unwrap();
             hasher.update(context.tci.as_bytes()).unwrap();
             hasher
-                .update(/*allow_ca=*/ context.allow_ca().as_bytes())
-                .unwrap();
-            hasher
                 .update(/*allow_x509=*/ context.allow_x509().as_bytes())
                 .unwrap();
         }
@@ -848,10 +843,8 @@ pub mod tests {
         let mut hasher = env.crypto.hash_initialize(DPE_PROFILE.alg_len()).unwrap();
 
         hasher.update(child_context.tci.as_bytes()).unwrap();
-        hasher.update(/*allow_ca=*/ false.as_bytes()).unwrap();
         hasher.update(/*allow_x509=*/ false.as_bytes()).unwrap();
         hasher.update(parent_context.tci.as_bytes()).unwrap();
-        hasher.update(/*allow_ca=*/ true.as_bytes()).unwrap();
         hasher.update(/*allow_x509=*/ true.as_bytes()).unwrap();
         let mut internal_input_info = [0u8; INTERNAL_INPUT_INFO_SIZE];
         dpe.serialize_internal_input_info(&mut env.platform, &mut internal_input_info)
@@ -909,10 +902,8 @@ pub mod tests {
         let mut hasher = env.crypto.hash_initialize(DPE_PROFILE.alg_len()).unwrap();
 
         hasher.update(child_context.tci.as_bytes()).unwrap();
-        hasher.update(/*allow_ca=*/ false.as_bytes()).unwrap();
         hasher.update(/*allow_x509=*/ false.as_bytes()).unwrap();
         hasher.update(parent_context.tci.as_bytes()).unwrap();
-        hasher.update(/*allow_ca=*/ true.as_bytes()).unwrap();
         hasher.update(/*allow_x509=*/ true.as_bytes()).unwrap();
         hasher
             .update(&TEST_CERT_CHAIN[..TEST_CERT_CHAIN.len()])

--- a/verification/client/abi.go
+++ b/verification/client/abi.go
@@ -33,7 +33,6 @@ type Support struct {
 	IsSymmetric         bool
 	InternalInfo        bool
 	InternalDice        bool
-	IsCA                bool
 	RetainParentContext bool
 	CdiExport           bool
 }
@@ -758,9 +757,6 @@ func (s *Support) ToFlags() uint32 {
 	}
 	if s.InternalDice {
 		flags |= (1 << 21)
-	}
-	if s.IsCA {
-		flags |= (1 << 20)
 	}
 	if s.RetainParentContext {
 		flags |= (1 << 19)

--- a/verification/testing/negativeCases.go
+++ b/verification/testing/negativeCases.go
@@ -143,7 +143,6 @@ func TestUnsupportedCommand(d client.TestDPEInstance, c client.DPEClient, t *tes
 // The DPE command may be available but some of its flags may not be supported by DPE.
 // DPE profile supports the below attributes.
 // Simulation	: Allows caller to request for context initialization in simulation mode
-// IsCA			: Allows caller to request the key cert of CA
 // Csr 			: Allows caller to request the key cert in CSR format
 // X509 		: Allows caller to request the key cert in X509 format
 // InternalInfo	: Allows caller to derive child context with InternalInfo


### PR DESCRIPTION
This code is unused / dead code for the previously removed CertifyKey CA feature.
