### PR TITLE
Make DICE x509 extensions criticality configurable in DpeInstance

### DIFF
--- a/dpe/fuzz/src/fuzz_target_1.rs
+++ b/dpe/fuzz/src/fuzz_target_1.rs
@@ -5,7 +5,7 @@
 #[cfg(all(not(feature = "libfuzzer-sys"), not(feature = "afl")))]
 compile_error!("Either feature \"libfuzzer-sys\" or \"afl\" must be enabled!");
 
-use dpe::response::DpeErrorCode;
+use dpe::{dpe_instance::DpeInstanceFlags, response::DpeErrorCode};
 #[cfg(feature = "libfuzzer-sys")]
 use libfuzzer_sys::fuzz_target;
 
@@ -65,7 +65,7 @@ fn harness(data: &[u8]) {
         crypto: OpensslCrypto::new(),
         platform: DefaultPlatform,
     };
-    let mut dpe = DpeInstance::new(&mut env, SUPPORT).unwrap();
+    let mut dpe = DpeInstance::new(&mut env, SUPPORT, DpeInstanceFlags::empty()).unwrap();
     let prev_contexts = dpe.contexts;
 
     // Hard-code working locality

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -98,7 +98,10 @@ mod tests {
     use crate::{
         commands::{Command, CommandHdr, DeriveContextCmd, DeriveContextFlags, InitCtxCmd},
         context::{Context, ContextState},
-        dpe_instance::tests::{TestTypes, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES},
+        dpe_instance::{
+            tests::{TestTypes, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES},
+            DpeInstanceFlags,
+        },
         support::{test::SUPPORT, Support},
         DPE_PROFILE,
     };
@@ -131,7 +134,8 @@ mod tests {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
-        let mut dpe = DpeInstance::new(&mut env, Support::default()).unwrap();
+        let mut dpe =
+            DpeInstance::new(&mut env, Support::default(), DpeInstanceFlags::empty()).unwrap();
 
         InitCtxCmd::new_use_default()
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -288,7 +292,7 @@ mod tests {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
-        let mut dpe = DpeInstance::new(&mut env, SUPPORT).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, SUPPORT, DpeInstanceFlags::empty()).unwrap();
 
         // create new context while preserving auto-initialized context
         let handle_1 = match (DeriveContextCmd {
@@ -357,7 +361,7 @@ mod tests {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
-        let mut dpe = DpeInstance::new(&mut env, SUPPORT).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, SUPPORT, DpeInstanceFlags::empty()).unwrap();
 
         // create new context while preserving auto-initialized context
         let parent_handle = match (DeriveContextCmd {

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -53,7 +53,10 @@ mod tests {
     use super::*;
     use crate::{
         commands::{Command, CommandHdr},
-        dpe_instance::tests::{TestTypes, TEST_LOCALITIES},
+        dpe_instance::{
+            tests::{TestTypes, TEST_LOCALITIES},
+            DpeInstanceFlags,
+        },
         support::test::SUPPORT,
     };
     use caliptra_cfi_lib_git::CfiCounter;
@@ -88,7 +91,7 @@ mod tests {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
-        let mut dpe = DpeInstance::new(&mut env, SUPPORT).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, SUPPORT, DpeInstanceFlags::empty()).unwrap();
 
         assert_eq!(
             Err(DpeErrorCode::InvalidArgument),

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -113,7 +113,10 @@ mod tests {
     use crate::{
         commands::{Command, CommandHdr},
         context::ContextState,
-        dpe_instance::tests::{TestTypes, TEST_LOCALITIES},
+        dpe_instance::{
+            tests::{TestTypes, TEST_LOCALITIES},
+            DpeInstanceFlags,
+        },
         support::Support,
     };
     use caliptra_cfi_lib_git::CfiCounter;
@@ -143,7 +146,8 @@ mod tests {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
-        let mut dpe = DpeInstance::new(&mut env, Support::default()).unwrap();
+        let mut dpe =
+            DpeInstance::new(&mut env, Support::default(), DpeInstanceFlags::empty()).unwrap();
 
         let handle = match InitCtxCmd::new_use_default()
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -174,7 +178,8 @@ mod tests {
         );
 
         // Change to support simulation.
-        let mut dpe = DpeInstance::new(&mut env, Support::SIMULATION).unwrap();
+        let mut dpe =
+            DpeInstance::new(&mut env, Support::SIMULATION, DpeInstanceFlags::empty()).unwrap();
 
         // Try setting both flags.
         assert_eq!(

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -128,8 +128,9 @@ mod tests {
     use super::*;
     use crate::{
         commands::{Command, CommandHdr, InitCtxCmd},
-        dpe_instance::tests::{
-            TestTypes, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES,
+        dpe_instance::{
+            tests::{TestTypes, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES},
+            DpeInstanceFlags,
         },
         support::Support,
     };
@@ -163,7 +164,8 @@ mod tests {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
-        let mut dpe = DpeInstance::new(&mut env, Support::default()).unwrap();
+        let mut dpe =
+            DpeInstance::new(&mut env, Support::default(), DpeInstanceFlags::empty()).unwrap();
         // Make sure it returns an error if the command is marked unsupported.
         assert_eq!(
             Err(DpeErrorCode::InvalidCommand),
@@ -175,7 +177,8 @@ mod tests {
         );
 
         // Make a new instance that supports RotateContext.
-        let mut dpe = DpeInstance::new(&mut env, Support::ROTATE_CONTEXT).unwrap();
+        let mut dpe =
+            DpeInstance::new(&mut env, Support::ROTATE_CONTEXT, DpeInstanceFlags::empty()).unwrap();
         InitCtxCmd::new_use_default()
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
             .unwrap();

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -139,13 +139,15 @@ mod tests {
     use super::*;
     use crate::{
         commands::{
-            certify_key::CertifyKeyCmd,
-            certify_key::CertifyKeyFlags,
+            certify_key::{CertifyKeyCmd, CertifyKeyFlags},
             derive_context::DeriveContextFlags,
             tests::{TEST_DIGEST, TEST_LABEL},
             Command, CommandHdr, DeriveContextCmd, InitCtxCmd,
         },
-        dpe_instance::tests::{TestTypes, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_LOCALITIES},
+        dpe_instance::{
+            tests::{TestTypes, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_LOCALITIES},
+            DpeInstanceFlags,
+        },
         support::test::SUPPORT,
     };
     use caliptra_cfi_lib_git::CfiCounter;
@@ -180,7 +182,7 @@ mod tests {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
-        let mut dpe = DpeInstance::new(&mut env, SUPPORT).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, SUPPORT, DpeInstanceFlags::empty()).unwrap();
 
         // Bad handle.
         assert_eq!(
@@ -235,7 +237,7 @@ mod tests {
             crypto: OpensslCrypto::new(),
             platform: DefaultPlatform,
         };
-        let mut dpe = DpeInstance::new(&mut env, SUPPORT).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, SUPPORT, DpeInstanceFlags::empty()).unwrap();
 
         for i in 0..3 {
             DeriveContextCmd {

--- a/dpe/src/validation.rs
+++ b/dpe/src/validation.rs
@@ -446,7 +446,7 @@ pub mod tests {
 
     use crate::{
         context::{Context, ContextHandle, ContextState, ContextType},
-        dpe_instance::{tests::TestTypes, DpeEnv},
+        dpe_instance::{tests::TestTypes, DpeEnv, DpeInstanceFlags},
         support::{test::SUPPORT, Support},
         tci::TciMeasurement,
         validation::{DpeValidator, ValidationError},
@@ -461,7 +461,7 @@ pub mod tests {
             platform: DefaultPlatform,
         };
         let dpe_validator = DpeValidator {
-            dpe: &mut DpeInstance::new(&mut env, SUPPORT).unwrap(),
+            dpe: &mut DpeInstance::new(&mut env, SUPPORT, DpeInstanceFlags::empty()).unwrap(),
         };
 
         // validation fails on graph where child has multiple parents
@@ -524,7 +524,8 @@ pub mod tests {
             platform: DefaultPlatform,
         };
         let dpe_validator = DpeValidator {
-            dpe: &mut DpeInstance::new(&mut env, Support::empty()).unwrap(),
+            dpe: &mut DpeInstance::new(&mut env, Support::empty(), DpeInstanceFlags::empty())
+                .unwrap(),
         };
 
         // test simulation support
@@ -568,8 +569,12 @@ pub mod tests {
             platform: DefaultPlatform,
         };
         let dpe_validator = DpeValidator {
-            dpe: &mut DpeInstance::new(&mut env, Support::all().difference(Support::AUTO_INIT))
-                .unwrap(),
+            dpe: &mut DpeInstance::new(
+                &mut env,
+                Support::all().difference(Support::AUTO_INIT),
+                DpeInstanceFlags::empty(),
+            )
+            .unwrap(),
         };
 
         // inactive context validation
@@ -679,7 +684,8 @@ pub mod tests {
             platform: DefaultPlatform,
         };
         let dpe_validator = DpeValidator {
-            dpe: &mut DpeInstance::new(&mut env, Support::empty()).unwrap(),
+            dpe: &mut DpeInstance::new(&mut env, Support::empty(), DpeInstanceFlags::empty())
+                .unwrap(),
         };
         dpe_validator.dpe.has_initialized = U8Bool::new(true);
 

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -4,6 +4,7 @@
 compile_error!("must provide a crypto implementation");
 
 use clap::Parser;
+use dpe::dpe_instance::DpeInstanceFlags;
 use log::{error, info, trace, warn};
 use platform::default::DefaultPlatform;
 use std::fs;
@@ -116,6 +117,10 @@ struct Args {
     /// Supports the CDI_EXPORT extension to DeriveContext
     #[arg(long)]
     supports_cdi_export: bool,
+
+    /// Mark DICE extensions as critical
+    #[arg(long)]
+    mark_dice_extensions_critical: bool,
 }
 
 struct SimTypes {}
@@ -167,7 +172,12 @@ fn main() -> std::io::Result<()> {
         platform: DefaultPlatform,
     };
 
-    let mut dpe = DpeInstance::new(&mut env, support).map_err(|err| {
+    let mut flags = DpeInstanceFlags::empty();
+    flags.set(
+        DpeInstanceFlags::MARK_DICE_EXTENSIONS_CRITICAL,
+        args.mark_dice_extensions_critical,
+    );
+    let mut dpe = DpeInstance::new(&mut env, support, flags).map_err(|err| {
         Error::new(
             ErrorKind::Other,
             format!("{err:?} while creating new DPE instance"),

--- a/tools/src/sample_dpe_cert.rs
+++ b/tools/src/sample_dpe_cert.rs
@@ -1,6 +1,8 @@
 // Licensed under the Apache-2.0 license
 
+use dpe::dpe_instance::DpeInstanceFlags;
 use std::env;
+
 use {
     crypto::OpensslCrypto,
     dpe::commands::{
@@ -101,7 +103,7 @@ fn main() {
         platform: DefaultPlatform,
     };
 
-    let mut dpe = DpeInstance::new(&mut env, support).unwrap();
+    let mut dpe = DpeInstance::new(&mut env, support, DpeInstanceFlags::empty()).unwrap();
 
     add_tcb_info(
         &mut dpe,

--- a/verification/client/abi.go
+++ b/verification/client/abi.go
@@ -35,6 +35,10 @@ type Support struct {
 	InternalDice        bool
 	RetainParentContext bool
 	CdiExport           bool
+	// Not a compile time feature but a runtime feature to determine if all DICE extensions
+	// should be marked as critical.
+	// It's passed to the caliptra simulator using this flag, but there is no real "Support" feature this maps to.
+	DpeInstanceMarkDiceExtensionsCritical bool
 }
 
 // profileCommandCodes holds command codes for a specific revision of the

--- a/verification/sim/transport.go
+++ b/verification/sim/transport.go
@@ -86,6 +86,9 @@ func (s *DpeSimulator) PowerOn() error {
 	if s.supports.CdiExport {
 		args = append(args, "--supports-cdi-export")
 	}
+	if s.supports.DpeInstanceMarkDiceExtensionsCritical {
+		args = append(args, "--mark-dice-extensions-critical")
+	}
 
 	s.cmd = exec.Command(s.exePath, args...)
 	s.cmd.Stdout = os.Stdout

--- a/verification/testing/deriveContext.go
+++ b/verification/testing/deriveContext.go
@@ -120,7 +120,8 @@ func TestDeriveContextCdiExport(d client.TestDPEInstance, c client.DPEClient, t 
 	}
 
 	// Check all extensions
-	checkCertificateExtension(t, leafCert.Extensions, nil, nil, true, certChain[len(certChain)-1].SubjectKeyId, true)
+	isCritical := d.GetSupport().DpeInstanceMarkDiceExtensionsCritical
+	checkCertificateExtension(t, leafCert.Extensions, nil, nil, true, certChain[len(certChain)-1].SubjectKeyId, true, isCritical)
 
 	// Ensure full certificate chain has valid signatures
 	// This also checks certificate lifetime, signatures as part of cert chain validation
@@ -407,7 +408,7 @@ func TestDeriveContextRecursive(d client.TestDPEInstance, c client.DPEClient, t 
 		tciValue[i] = byte(i)
 	}
 
-	handle, tcbInfo, err := getTcbInfoForHandle(c, handle)
+	handle, tcbInfo, err := getTcbInfoForHandle(d, c, handle)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -424,7 +425,7 @@ func TestDeriveContextRecursive(d client.TestDPEInstance, c client.DPEClient, t 
 
 	// Check current and cumulative measurement by CertifyKey
 	expectedCumulative := computeExpectedCumulative(lastCumulative, tciValue)
-	verifyMeasurements(c, t, handle, tciValue, expectedCumulative)
+	verifyMeasurements(d, c, t, handle, tciValue, expectedCumulative)
 }
 
 // TestDeriveContextRecursiveOnDerivedContexts tests the DeriveContext command with
@@ -484,7 +485,7 @@ func TestDeriveContextRecursiveOnDerivedContexts(d client.TestDPEInstance, c cli
 		}
 	}()
 
-	childHandle, childTcbInfo, err := getTcbInfoForHandle(c, childHandle)
+	childHandle, childTcbInfo, err := getTcbInfoForHandle(d, c, childHandle)
 	if err != nil {
 		t.Fatalf("[FATAL]: Could not get TcbInfo: %v", err)
 	}
@@ -510,7 +511,7 @@ func TestDeriveContextRecursiveOnDerivedContexts(d client.TestDPEInstance, c cli
 	}
 	childHandle = &resp.NewContextHandle
 
-	childHandle, childTcbInfo, err = getTcbInfoForHandle(c, childHandle)
+	childHandle, childTcbInfo, err = getTcbInfoForHandle(d, c, childHandle)
 	if err != nil {
 		t.Fatalf("[FATAL]: Could not get TcbInfo: %v", err)
 	}
@@ -538,8 +539,8 @@ func computeExpectedCumulative(lastCumulative []byte, tciValue []byte) []byte {
 	return hasher.Sum(nil)
 }
 
-func verifyMeasurements(c client.DPEClient, t *testing.T, handle *client.ContextHandle, expectedCurrent []byte, expectedCumulative []byte) {
-	_, tcbInfo, err := getTcbInfoForHandle(c, handle)
+func verifyMeasurements(d client.TestDPEInstance, c client.DPEClient, t *testing.T, handle *client.ContextHandle, expectedCurrent []byte, expectedCumulative []byte) {
+	_, tcbInfo, err := getTcbInfoForHandle(d, c, handle)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/verification/testing/simulator.go
+++ b/verification/testing/simulator.go
@@ -42,6 +42,11 @@ func GetSimulatorTargets() []TestTarget {
 		},
 		{
 			"DefaultSupport",
+			getTestTarget([]string{"AutoInit", "Simulation", "X509", "Csr", "RotateContext", "Recursive", "RetainParentContext", "DpeInstanceMarkDiceExtensionsCritical"}),
+			AllTestCases,
+		},
+		{
+			"DefaultSupportNonCriticalDiceExtensions",
 			getTestTarget([]string{"AutoInit", "Simulation", "X509", "Csr", "RotateContext", "Recursive", "RetainParentContext"}),
 			AllTestCases,
 		},
@@ -122,6 +127,11 @@ func GetSimulatorTargets() []TestTarget {
 		},
 		{
 			"TestDeriveContextCdiExport",
+			getTestTarget([]string{"AutoInit", "CdiExport", "DpeInstanceMarkDiceExtensionsCritical"}),
+			[]TestCase{TestDeriveContextCdiExportTestCase},
+		},
+		{
+			"TestDeriveContextCdiExportNonCritical",
 			getTestTarget([]string{"AutoInit", "CdiExport"}),
 			[]TestCase{TestDeriveContextCdiExportTestCase},
 		},
@@ -152,12 +162,12 @@ func GetSimulatorTargets() []TestTarget {
 		},
 		{
 			"DeriveContext_Recursive",
-			getTestTarget([]string{"AutoInit", "Recursive", "X509"}),
+			getTestTarget([]string{"AutoInit", "Recursive", "X509", "DpeInstanceMarkDiceExtensionsCritical"}),
 			[]TestCase{DeriveContextRecursiveTestCase},
 		},
 		{
 			"DeriveContext_RecursiveOnDerivedContexts",
-			getTestTarget([]string{"AutoInit", "Recursive", "RetainParentContext", "X509", "RotateContext"}),
+			getTestTarget([]string{"AutoInit", "Recursive", "RetainParentContext", "X509", "RotateContext", "DpeInstanceMarkDiceExtensionsCritical"}),
 			[]TestCase{DeriveContextRecursiveOnDerivedContextsTestCase},
 		},
 	}


### PR DESCRIPTION
`DpeInstance::with_flags` adds an API to pass `DpeInstanceFlags` to
configure the behavior of a `DpeInstance`.

`DpeInstanceFlags::MARK_DICE_EXTENSIONS_CRITICAL` will mark all DICE
extensions to be critical.

By default extensions will no longer be marked critical.
