### PR TITLE
Add a version to `DpeInstance`.

### DIFF
--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -1412,7 +1412,7 @@ mod tests {
         // Create a new env to clear cached exported CDIs
         let mut env = DpeEnv::<TestTypes> {
             crypto: OpensslCrypto::new(),
-            platform: DefaultPlatform,
+            platform: DEFAULT_PLATFORM,
         };
         dpe = DpeInstance::new(
             &mut env,

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -66,6 +66,9 @@ bitflags! {
 #[repr(C, align(4))]
 #[derive(IntoBytes, TryFromBytes, KnownLayout, Immutable, Zeroize)]
 pub struct DpeInstance {
+    /// Layout version of this structure. If the layout of this structure changes, Self::VERSION
+    /// must be updated.
+    pub version: u32,
     pub contexts: [Context; MAX_HANDLES],
     pub support: Support,
     pub flags: DpeInstanceFlags,
@@ -78,6 +81,7 @@ pub struct DpeInstance {
 const _: () = assert!(align_of::<DpeInstance>() == 4);
 
 impl DpeInstance {
+    pub const VERSION: u32 = 1;
     const MAX_NEW_HANDLE_ATTEMPTS: usize = 8;
 
     /// Create a new DPE instance.
@@ -96,6 +100,7 @@ impl DpeInstance {
         let updated_support = support.preprocess_support();
         const CONTEXT_INITIALIZER: Context = Context::new();
         let mut dpe = DpeInstance {
+            version: Self::VERSION,
             contexts: [CONTEXT_INITIALIZER; MAX_HANDLES],
             support: updated_support,
             flags,


### PR DESCRIPTION
When Caliptra performs a hitless update, it retains the DPE state across a warm reset so it can continue with the same measurements.

The structure needs to change to be able to remove the profile feature flags. This version number can be used to ensure the firmware can correctly interpret the structure. Ideally this would be communicated before the hitless update is applied. In the meantime, this will at least cause an error without silently causing problems later.