### PR TITLE
Update DPE to Rust 1.85

### DIFF
--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -1412,7 +1412,7 @@ mod tests {
         // Create a new env to clear cached exported CDIs
         let mut env = DpeEnv::<TestTypes> {
             crypto: OpensslCrypto::new(),
-            platform: DefaultPlatform,
+            platform: DEFAULT_PLATFORM,
         };
         dpe = DpeInstance::new(
             &mut env,

--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -109,7 +109,7 @@ impl Context {
         if idx >= MAX_HANDLES {
             return Err(DpeErrorCode::InternalError);
         }
-        let children_with_idx = self.children | 1 << idx;
+        let children_with_idx = self.children | (1 << idx);
         Ok(children_with_idx)
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # Licensed under the Apache-2.0 license
 
 [toolchain]
-channel = "1.83"
+channel = "1.85"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
* Tracks Caliptra-SW (Updated in
  https://github.com/chipsalliance/caliptra-sw/pull/2118).
* Unblocks ml-dsa 0.0.4.
