### PR TITLE
Make the profile in the response header dynamic.

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -3,7 +3,7 @@ use super::CommandExecution;
 use crate::{
     context::ContextHandle,
     dpe_instance::{DpeEnv, DpeInstance, DpeInstanceFlags, DpeTypes},
-    response::{CertifyKeyResp, DpeErrorCode, Response, ResponseHdr},
+    response::{CertifyKeyResp, DpeErrorCode, Response},
     x509::{create_dpe_cert, create_dpe_csr, CreateDpeCertArgs, CreateDpeCertResult},
     DPE_PROFILE, MAX_CERT_SIZE,
 };
@@ -151,7 +151,7 @@ impl CommandExecution for CertifyKeyCmd {
             derived_pubkey_y,
             cert_size,
             cert,
-            resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
+            resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
         }))
     }
 }

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -3,9 +3,7 @@ use super::CommandExecution;
 use crate::{
     context::{ActiveContextArgs, Context, ContextHandle, ContextState, ContextType},
     dpe_instance::{DpeEnv, DpeInstance, DpeInstanceFlags, DpeTypes},
-    response::{
-        DeriveContextExportedCdiResp, DeriveContextResp, DpeErrorCode, Response, ResponseHdr,
-    },
+    response::{DeriveContextExportedCdiResp, DeriveContextResp, DpeErrorCode, Response},
     tci::TciMeasurement,
     x509::{create_exported_dpe_cert, CreateDpeCertArgs, CreateDpeCertResult},
     DPE_PROFILE, MAX_CERT_SIZE,
@@ -282,7 +280,7 @@ impl CommandExecution for DeriveContextCmd {
                         handle: dpe.contexts[parent_idx].handle,
                         // Should be ignored since retain_parent cannot be true
                         parent_handle: ContextHandle::default(),
-                        resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
+                        resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
                     }));
                 } else {
                     Err(DpeErrorCode::ArgumentNotSupported)?
@@ -338,7 +336,7 @@ impl CommandExecution for DeriveContextCmd {
                     return Ok(Response::DeriveContextExportedCdi(DeriveContextExportedCdiResp {
                         handle: ContextHandle::new_invalid(),
                         parent_handle: dpe.contexts[parent_idx].handle,
-                        resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
+                        resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
                         exported_cdi: exported_cdi_handle,
                         certificate_size: cert_size,
                         new_certificate: cert,
@@ -408,7 +406,7 @@ impl CommandExecution for DeriveContextCmd {
         Ok(Response::DeriveContext(DeriveContextResp {
             handle: child_handle,
             parent_handle: dpe.contexts[parent_idx].handle,
-            resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
+            resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
         }))
     }
 }
@@ -670,7 +668,7 @@ mod tests {
             Ok(Response::DeriveContext(DeriveContextResp {
                 handle: ContextHandle::default(),
                 parent_handle: ContextHandle([0xff; ContextHandle::SIZE]),
-                resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
+                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
             })),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
@@ -687,7 +685,7 @@ mod tests {
             Ok(Response::DeriveContext(DeriveContextResp {
                 handle: RANDOM_HANDLE,
                 parent_handle: ContextHandle([0xff; ContextHandle::SIZE]),
-                resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
+                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
             })),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
@@ -817,7 +815,7 @@ mod tests {
             Ok(Response::DeriveContext(DeriveContextResp {
                 handle: ContextHandle::default(),
                 parent_handle: ContextHandle([0xff; ContextHandle::SIZE]),
-                resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
+                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
             })),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
@@ -834,7 +832,7 @@ mod tests {
             Ok(Response::DeriveContext(DeriveContextResp {
                 handle: ContextHandle::default(),
                 parent_handle: ContextHandle::default(),
-                resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
+                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
             })),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
@@ -883,7 +881,7 @@ mod tests {
         assert_eq!(parent_handle, RANDOM_HANDLE);
         assert_eq!(handle, next_random_handle);
         assert_ne!(parent_handle, ContextHandle::default());
-        assert_eq!(resp_hdr, ResponseHdr::new(DpeErrorCode::NoError));
+        assert_eq!(resp_hdr, dpe.response_hdr(DpeErrorCode::NoError));
     }
 
     #[test]
@@ -1033,7 +1031,7 @@ mod tests {
             Ok(Response::DeriveContext(DeriveContextResp {
                 handle: ContextHandle::default(),
                 parent_handle: ContextHandle::default(),
-                resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
+                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
             })),
             DeriveContextCmd {
                 handle: ContextHandle::default(),

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -3,7 +3,7 @@ use super::CommandExecution;
 use crate::{
     context::{Context, ContextHandle, ContextState},
     dpe_instance::{flags_iter, DpeEnv, DpeInstance, DpeTypes},
-    response::{DpeErrorCode, Response, ResponseHdr},
+    response::{DpeErrorCode, Response},
     MAX_HANDLES,
 };
 #[cfg(not(feature = "no-cfi"))]
@@ -86,9 +86,9 @@ impl CommandExecution for DestroyCtxCmd {
             }
         }
 
-        Ok(Response::DestroyCtx(ResponseHdr::new(
-            DpeErrorCode::NoError,
-        )))
+        Ok(Response::DestroyCtx(
+            dpe.response_hdr(DpeErrorCode::NoError),
+        ))
     }
 }
 
@@ -157,9 +157,9 @@ mod tests {
         activate_dummy_context(&mut dpe, 1, 0, &ContextHandle::default(), &[]);
         // destroy context[1]
         assert_eq!(
-            Ok(Response::DestroyCtx(ResponseHdr::new(
-                DpeErrorCode::NoError,
-            ))),
+            Ok(Response::DestroyCtx(
+                dpe.response_hdr(DpeErrorCode::NoError)
+            )),
             DestroyCtxCmd {
                 handle: ContextHandle::default(),
             }
@@ -169,9 +169,9 @@ mod tests {
         assert_eq!(dpe.contexts[0].children, 0);
         // destroy context[0]
         assert_eq!(
-            Ok(Response::DestroyCtx(ResponseHdr::new(
-                DpeErrorCode::NoError,
-            ))),
+            Ok(Response::DestroyCtx(
+                dpe.response_hdr(DpeErrorCode::NoError)
+            )),
             DestroyCtxCmd {
                 handle: TEST_HANDLE,
             }
@@ -231,9 +231,9 @@ mod tests {
 
         // destroy context[0] and all descendents
         assert_eq!(
-            Ok(Response::DestroyCtx(ResponseHdr::new(
-                DpeErrorCode::NoError,
-            ))),
+            Ok(Response::DestroyCtx(
+                dpe.response_hdr(DpeErrorCode::NoError)
+            )),
             DestroyCtxCmd {
                 handle: ContextHandle::default(),
             }
@@ -274,9 +274,9 @@ mod tests {
         );
         // destroy context[1]
         assert_eq!(
-            Ok(Response::DestroyCtx(ResponseHdr::new(
-                DpeErrorCode::NoError,
-            ))),
+            Ok(Response::DestroyCtx(
+                dpe.response_hdr(DpeErrorCode::NoError)
+            )),
             DestroyCtxCmd {
                 handle: ContextHandle([1; ContextHandle::SIZE]),
             }

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -2,7 +2,7 @@
 use super::CommandExecution;
 use crate::{
     dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
-    response::{DpeErrorCode, GetCertificateChainResp, Response, ResponseHdr},
+    response::{DpeErrorCode, GetCertificateChainResp, Response},
 };
 #[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_derive_git::cfi_impl_fn;
@@ -27,7 +27,7 @@ impl CommandExecution for GetCertificateChainCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     fn execute(
         &self,
-        _dpe: &mut DpeInstance,
+        dpe: &mut DpeInstance,
         env: &mut DpeEnv<impl DpeTypes>,
         _locality: u32,
     ) -> Result<Response, DpeErrorCode> {
@@ -43,7 +43,7 @@ impl CommandExecution for GetCertificateChainCmd {
         Ok(Response::GetCertificateChain(GetCertificateChainResp {
             certificate_chain: cert_chunk,
             certificate_size: len,
-            resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
+            resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
         }))
     }
 }

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -3,7 +3,7 @@ use super::CommandExecution;
 use crate::{
     context::{ActiveContextArgs, Context, ContextHandle, ContextType},
     dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
-    response::{DpeErrorCode, NewHandleResp, Response, ResponseHdr},
+    response::{DpeErrorCode, NewHandleResp, Response},
 };
 use bitflags::bitflags;
 #[cfg(not(feature = "no-cfi"))]
@@ -103,7 +103,7 @@ impl CommandExecution for InitCtxCmd {
         });
         Ok(Response::InitCtx(NewHandleResp {
             handle,
-            resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
+            resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
         }))
     }
 }

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -3,7 +3,7 @@ use super::CommandExecution;
 use crate::{
     context::{ContextHandle, ContextState},
     dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
-    response::{DpeErrorCode, NewHandleResp, Response, ResponseHdr},
+    response::{DpeErrorCode, NewHandleResp, Response},
 };
 use bitflags::bitflags;
 #[cfg(not(feature = "no-cfi"))]
@@ -118,7 +118,7 @@ impl CommandExecution for RotateCtxCmd {
 
         Ok(Response::RotateCtx(NewHandleResp {
             handle: new_handle,
-            resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
+            resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
         }))
     }
 }
@@ -216,7 +216,7 @@ mod tests {
         assert_eq!(
             Ok(Response::RotateCtx(NewHandleResp {
                 handle: RANDOM_HANDLE,
-                resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
+                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
             })),
             RotateCtxCmd {
                 handle: ContextHandle::default(),
@@ -244,7 +244,7 @@ mod tests {
         assert_eq!(
             Ok(Response::RotateCtx(NewHandleResp {
                 handle: ContextHandle::default(),
-                resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
+                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
             })),
             RotateCtxCmd {
                 handle: RANDOM_HANDLE,

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -3,7 +3,7 @@ use super::CommandExecution;
 use crate::{
     context::{ContextHandle, ContextType},
     dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
-    response::{DpeErrorCode, Response, ResponseHdr, SignResp},
+    response::{DpeErrorCode, Response, SignResp},
     DPE_PROFILE,
 };
 use bitflags::bitflags;
@@ -129,7 +129,7 @@ impl CommandExecution for SignCmd {
             new_context_handle: dpe.contexts[idx].handle,
             sig_r,
             sig_s,
-            resp_hdr: ResponseHdr::new(DpeErrorCode::NoError),
+            resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
         }))
     }
 }

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -23,7 +23,7 @@ use response::GetProfileResp;
 pub mod tci;
 pub mod x509;
 
-use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, TryFromBytes};
 
 pub use crypto::{ExportedCdiHandle, MAX_EXPORTED_CDI_SIZE};
 
@@ -67,6 +67,10 @@ impl From<bool> for U8Bool {
     }
 }
 
+#[derive(
+    Copy, Clone, Debug, PartialEq, Eq, IntoBytes, TryFromBytes, KnownLayout, Immutable, Zeroize,
+)]
+#[repr(u32)]
 pub enum DpeProfile {
     // Note: Min profiles (1 & 2) are not supported by this implementation
     P256Sha256 = 3,

--- a/dpe/src/response.rs
+++ b/dpe/src/response.rs
@@ -5,7 +5,7 @@ Abstract:
     DPE reponses and serialization.
 --*/
 use crate::{
-    context::ContextHandle, validation::ValidationError, CURRENT_PROFILE_MAJOR_VERSION,
+    context::ContextHandle, validation::ValidationError, DpeProfile, CURRENT_PROFILE_MAJOR_VERSION,
     CURRENT_PROFILE_MINOR_VERSION, DPE_PROFILE, MAX_CERT_SIZE, MAX_EXPORTED_CDI_SIZE, MAX_HANDLES,
 };
 use crypto::CryptoError;
@@ -52,24 +52,24 @@ impl Response {
     PartialEq,
     Eq,
     zerocopy::IntoBytes,
-    zerocopy::FromBytes,
+    zerocopy::TryFromBytes,
     zerocopy::Immutable,
     zerocopy::KnownLayout,
 )]
 pub struct ResponseHdr {
     pub magic: u32,
     pub status: u32,
-    pub profile: u32,
+    pub profile: DpeProfile,
 }
 
 impl ResponseHdr {
     pub const DPE_RESPONSE_MAGIC: u32 = u32::from_be_bytes(*b"DPER");
 
-    pub fn new(error_code: DpeErrorCode) -> ResponseHdr {
+    pub fn new(profile: DpeProfile, error_code: DpeErrorCode) -> ResponseHdr {
         ResponseHdr {
             magic: Self::DPE_RESPONSE_MAGIC,
             status: error_code.get_error_code(),
-            profile: DPE_PROFILE as u32,
+            profile,
         }
     }
 }
@@ -80,7 +80,7 @@ impl ResponseHdr {
     PartialEq,
     Eq,
     zerocopy::IntoBytes,
-    zerocopy::FromBytes,
+    zerocopy::TryFromBytes,
     zerocopy::Immutable,
     zerocopy::KnownLayout,
 )]
@@ -95,7 +95,12 @@ pub struct GetProfileResp {
 }
 
 impl GetProfileResp {
-    pub const fn new(flags: u32, vendor_id: u32, vendor_sku: u32) -> GetProfileResp {
+    pub const fn new(
+        profile: DpeProfile,
+        flags: u32,
+        vendor_id: u32,
+        vendor_sku: u32,
+    ) -> GetProfileResp {
         GetProfileResp {
             major_version: CURRENT_PROFILE_MAJOR_VERSION,
             minor_version: CURRENT_PROFILE_MINOR_VERSION,
@@ -106,7 +111,7 @@ impl GetProfileResp {
             resp_hdr: ResponseHdr {
                 magic: ResponseHdr::DPE_RESPONSE_MAGIC,
                 status: 0,
-                profile: DPE_PROFILE as u32,
+                profile,
             },
         }
     }
@@ -118,7 +123,7 @@ impl GetProfileResp {
     PartialEq,
     Eq,
     zerocopy::IntoBytes,
-    zerocopy::FromBytes,
+    zerocopy::TryFromBytes,
     zerocopy::KnownLayout,
     zerocopy::Immutable,
 )]
@@ -133,7 +138,7 @@ pub struct NewHandleResp {
     PartialEq,
     Eq,
     zerocopy::IntoBytes,
-    zerocopy::FromBytes,
+    zerocopy::TryFromBytes,
     zerocopy::Immutable,
     zerocopy::KnownLayout,
 )]
@@ -149,7 +154,7 @@ pub struct DeriveContextResp {
     PartialEq,
     Eq,
     zerocopy::IntoBytes,
-    zerocopy::FromBytes,
+    zerocopy::TryFromBytes,
     zerocopy::Immutable,
     zerocopy::KnownLayout,
 )]
@@ -168,7 +173,7 @@ pub struct DeriveContextExportedCdiResp {
     PartialEq,
     Eq,
     zerocopy::IntoBytes,
-    zerocopy::FromBytes,
+    zerocopy::TryFromBytes,
     zerocopy::Immutable,
     zerocopy::KnownLayout,
 )]
@@ -187,7 +192,7 @@ pub struct CertifyKeyResp {
     PartialEq,
     Eq,
     zerocopy::IntoBytes,
-    zerocopy::FromBytes,
+    zerocopy::TryFromBytes,
     zerocopy::Immutable,
     zerocopy::KnownLayout,
 )]
@@ -204,7 +209,7 @@ pub struct SignResp {
     PartialEq,
     Eq,
     zerocopy::IntoBytes,
-    zerocopy::FromBytes,
+    zerocopy::TryFromBytes,
     zerocopy::Immutable,
     zerocopy::KnownLayout,
 )]


### PR DESCRIPTION
This makes all of the constructors for `ResponseHdr` take a parameter for the profile. This is the first step in removing the cargo features for the different profiles. Instead it will be stored in the `DpeInstance` and filled in at runtime.