### PR TITLE
DeriveContext SVN Support

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -525,6 +525,7 @@ mod tests {
             flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INPUT_ALLOW_X509,
             tci_type: 1,
             target_locality: 0,
+            svn: 0,
         };
 
         derive_cmd

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -61,6 +61,7 @@ pub struct DeriveContextCmd {
     pub flags: DeriveContextFlags,
     pub tci_type: u32,
     pub target_locality: u32,
+    pub svn: u32,
 }
 
 impl DeriveContextCmd {
@@ -396,6 +397,7 @@ impl CommandExecution for DeriveContextCmd {
             uses_internal_input_dice,
             allow_export_cdi: self.allows_new_context_to_export()
                 & tmp_parent_context.allow_export_cdi(),
+            svn: self.svn,
         });
 
         dpe.add_tci_measurement(
@@ -455,6 +457,7 @@ mod tests {
         flags: DeriveContextFlags(0x1234_5678),
         tci_type: 0x9876_5432,
         target_locality: 0x10CA_1171,
+        svn: 0,
     };
 
     #[test]
@@ -493,7 +496,8 @@ mod tests {
                 data: [0; DPE_PROFILE.get_tci_size()],
                 flags: DeriveContextFlags::INTERNAL_INPUT_DICE,
                 tci_type: 0,
-                target_locality: 0
+                target_locality: 0,
+                svn: 0
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -512,7 +516,8 @@ mod tests {
                 data: [0; DPE_PROFILE.get_tci_size()],
                 flags: DeriveContextFlags::INTERNAL_INPUT_INFO,
                 tci_type: 0,
-                target_locality: 0
+                target_locality: 0,
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -531,7 +536,8 @@ mod tests {
                 data: [0; DPE_PROFILE.get_tci_size()],
                 flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
                 tci_type: 0,
-                target_locality: 0
+                target_locality: 0,
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -559,7 +565,8 @@ mod tests {
                 data: [0; DPE_PROFILE.get_tci_size()],
                 flags: DeriveContextFlags::empty(),
                 tci_type: 0,
-                target_locality: 0
+                target_locality: 0,
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, 1)
         );
@@ -583,6 +590,7 @@ mod tests {
                 flags: DeriveContextFlags::MAKE_DEFAULT,
                 tci_type: 0,
                 target_locality: 0,
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
             .unwrap();
@@ -596,7 +604,8 @@ mod tests {
                 data: [0; DPE_PROFILE.get_tci_size()],
                 flags: DeriveContextFlags::empty(),
                 tci_type: 0,
-                target_locality: 0
+                target_locality: 0,
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -621,6 +630,7 @@ mod tests {
             flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::CHANGE_LOCALITY,
             tci_type: 7,
             target_locality: TEST_LOCALITIES[1],
+            svn: 0,
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         .unwrap();
@@ -654,6 +664,7 @@ mod tests {
             flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::CHANGE_LOCALITY,
             tci_type: 7,
             target_locality: TEST_LOCALITIES[1],
+            svn: 0,
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         .unwrap();
@@ -690,6 +701,7 @@ mod tests {
                 flags: DeriveContextFlags::MAKE_DEFAULT,
                 tci_type: 0,
                 target_locality: 0,
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -707,6 +719,7 @@ mod tests {
                 flags: DeriveContextFlags::empty(),
                 tci_type: 0,
                 target_locality: 0,
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -747,6 +760,7 @@ mod tests {
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
             tci_type: 0,
             target_locality: 0,
+            svn: 0,
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         {
@@ -782,6 +796,7 @@ mod tests {
                 | DeriveContextFlags::INTERNAL_INPUT_INFO,
             tci_type: 0,
             target_locality: 0,
+            svn: 0,
         })
         .execute(&mut dpe, &mut env, 0)
         {
@@ -837,6 +852,7 @@ mod tests {
                 flags: DeriveContextFlags::MAKE_DEFAULT,
                 tci_type: 0,
                 target_locality: 0,
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -856,6 +872,7 @@ mod tests {
                     | DeriveContextFlags::CHANGE_LOCALITY,
                 tci_type: 0,
                 target_locality: TEST_LOCALITIES[1],
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -880,6 +897,7 @@ mod tests {
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
             tci_type: 0,
             target_locality: 0,
+            svn: 0,
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         .unwrap()
@@ -907,6 +925,7 @@ mod tests {
             flags: DeriveContextFlags::MAKE_DEFAULT,
             tci_type: 0,
             target_locality: 0,
+            svn: 0,
         };
         let parent_idx = 0;
         // No default context.
@@ -947,6 +966,7 @@ mod tests {
             flags: DeriveContextFlags(0),
             tci_type: 0,
             target_locality: 0,
+            svn: 0,
         };
         let parent_idx = 0;
         // No default context.
@@ -978,6 +998,7 @@ mod tests {
                 flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
                 tci_type: 0,
                 target_locality: 0,
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]),
             Err(DpeErrorCode::InvalidArgument)
@@ -1006,6 +1027,7 @@ mod tests {
                 | DeriveContextFlags::CHANGE_LOCALITY,
             tci_type: 7,
             target_locality: TEST_LOCALITIES[1],
+            svn: 0,
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         .unwrap();
@@ -1018,6 +1040,7 @@ mod tests {
                     | DeriveContextFlags::CHANGE_LOCALITY,
                 tci_type: 7,
                 target_locality: TEST_LOCALITIES[1],
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]),
             Err(DpeErrorCode::InvalidArgument)
@@ -1056,6 +1079,7 @@ mod tests {
                     | DeriveContextFlags::INTERNAL_INPUT_DICE,
                 tci_type: 0,
                 target_locality: 0,
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -1069,6 +1093,7 @@ mod tests {
                 | DeriveContextFlags::INTERNAL_INPUT_DICE,
             tci_type: 0,
             target_locality: 0,
+            svn: 0,
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         .unwrap();
@@ -1125,7 +1150,8 @@ mod tests {
                 data: [0; DPE_PROFILE.get_tci_size()],
                 flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CHANGE_LOCALITY,
                 tci_type: 0,
-                target_locality: TEST_LOCALITIES[1]
+                target_locality: TEST_LOCALITIES[1],
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -1136,7 +1162,8 @@ mod tests {
                 data: [0; DPE_PROFILE.get_tci_size()],
                 flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::RECURSIVE,
                 tci_type: 0,
-                target_locality: TEST_LOCALITIES[0]
+                target_locality: TEST_LOCALITIES[0],
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -1149,7 +1176,8 @@ mod tests {
                 data: [0; DPE_PROFILE.get_tci_size()],
                 flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
                 tci_type: 0,
-                target_locality: TEST_LOCALITIES[0]
+                target_locality: TEST_LOCALITIES[0],
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -1169,7 +1197,8 @@ mod tests {
                 data: [0; DPE_PROFILE.get_tci_size()],
                 flags: DeriveContextFlags::CREATE_CERTIFICATE | DeriveContextFlags::EXPORT_CDI,
                 tci_type: 0,
-                target_locality: TEST_LOCALITIES[0]
+                target_locality: TEST_LOCALITIES[0],
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -1184,7 +1213,8 @@ mod tests {
                     | DeriveContextFlags::EXPORT_CDI
                     | DeriveContextFlags::RECURSIVE,
                 tci_type: 0,
-                target_locality: TEST_LOCALITIES[0]
+                target_locality: TEST_LOCALITIES[0],
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -1203,6 +1233,7 @@ mod tests {
             flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
             tci_type: 0,
             target_locality: 0,
+            svn: 0,
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]);
 
@@ -1231,7 +1262,8 @@ mod tests {
                 data: [0; DPE_PROFILE.get_tci_size()],
                 flags: DeriveContextFlags::CREATE_CERTIFICATE | DeriveContextFlags::EXPORT_CDI,
                 tci_type: 0,
-                target_locality: TEST_LOCALITIES[0]
+                target_locality: TEST_LOCALITIES[0],
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -1244,7 +1276,8 @@ mod tests {
                 data: [0; DPE_PROFILE.get_tci_size()],
                 flags: DeriveContextFlags::EXPORT_CDI,
                 tci_type: 0,
-                target_locality: TEST_LOCALITIES[0]
+                target_locality: TEST_LOCALITIES[0],
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -1257,7 +1290,8 @@ mod tests {
                 data: [0; DPE_PROFILE.get_tci_size()],
                 flags: DeriveContextFlags::CREATE_CERTIFICATE,
                 tci_type: 0,
-                target_locality: TEST_LOCALITIES[0]
+                target_locality: TEST_LOCALITIES[0],
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -1283,6 +1317,7 @@ mod tests {
             flags: DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT,
             tci_type: 0,
             target_locality: TEST_LOCALITIES[0],
+            svn: 0,
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]) else {
             panic!("exptected a valid DeriveContextResp");
@@ -1296,6 +1331,7 @@ mod tests {
                 | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
             tci_type: 0,
             target_locality: TEST_LOCALITIES[0],
+            svn: 0,
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]);
 
@@ -1337,6 +1373,7 @@ mod tests {
                 | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
             tci_type: 0,
             target_locality: TEST_LOCALITIES[0],
+            svn: 0,
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]);
 
@@ -1365,6 +1402,7 @@ mod tests {
             flags: DeriveContextFlags::empty(),
             tci_type: 0,
             target_locality: TEST_LOCALITIES[0],
+            svn: 0,
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]) else {
             panic!("Unexpected result!");
@@ -1379,6 +1417,7 @@ mod tests {
             flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
             tci_type: 0,
             target_locality: TEST_LOCALITIES[0],
+            svn: 0,
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]);
         assert_eq!(res, Err(DpeErrorCode::InvalidArgument));
@@ -1399,6 +1438,7 @@ mod tests {
             flags: DeriveContextFlags::empty(),
             tci_type: 0,
             target_locality: TEST_LOCALITIES[0],
+            svn: 0,
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]) else {
             panic!("Unexpected result!");
@@ -1414,6 +1454,7 @@ mod tests {
                 | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT,
             tci_type: 0,
             target_locality: TEST_LOCALITIES[0],
+            svn: 0,
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]);
         assert_eq!(res, Err(DpeErrorCode::InvalidArgument));
@@ -1440,6 +1481,7 @@ mod tests {
                 | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT,
             tci_type: 0,
             target_locality: TEST_LOCALITIES[0],
+            svn: 0,
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]);
         let child_idx = dpe
@@ -1460,6 +1502,7 @@ mod tests {
                 | DeriveContextFlags::CREATE_CERTIFICATE,
             tci_type: 0,
             target_locality: TEST_LOCALITIES[0],
+            svn: 0,
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]);
         let res = match res {
@@ -1493,6 +1536,7 @@ mod tests {
             flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
             tci_type: 0,
             target_locality: 0,
+            svn: 0,
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]);
 
@@ -1537,6 +1581,7 @@ mod tests {
                 | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
             tci_type: 0,
             target_locality: 0,
+            svn: 0,
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]);
 
@@ -1611,6 +1656,7 @@ mod tests {
                         | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT,
                     tci_type: 0,
                     target_locality: TEST_LOCALITIES[0],
+                    svn: 0,
                 },
                 expected_active_contexts,
             );
@@ -1636,6 +1682,7 @@ mod tests {
                 flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
                 tci_type: 0,
                 target_locality: TEST_LOCALITIES[0],
+                svn: 0,
             },
             expected_active_contexts,
         );
@@ -1707,6 +1754,7 @@ mod tests {
                     flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
                     tci_type: 0,
                     target_locality: TEST_LOCALITIES[0],
+                    svn: 0,
                 },
                 expected_active_contexts,
             );
@@ -1729,6 +1777,7 @@ mod tests {
                 flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
                 tci_type: 0,
                 target_locality: TEST_LOCALITIES[0],
+                svn: 0,
             },
             expected_active_contexts,
         );
@@ -1774,6 +1823,7 @@ mod tests {
                 data: [0; DPE_PROFILE.get_tci_size()],
                 tci_type: 0,
                 target_locality: TEST_LOCALITIES[0],
+                svn: 0,
             };
             let derive_resp = match derive_cmd
                 .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -309,6 +309,7 @@ mod tests {
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT | DeriveContextFlags::CHANGE_LOCALITY,
             tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
+            svn: 0,
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         {
@@ -324,6 +325,7 @@ mod tests {
             flags: DeriveContextFlags::empty(),
             tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
+            svn: 0,
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])
         {
@@ -339,6 +341,7 @@ mod tests {
             flags: DeriveContextFlags::empty(),
             tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
+            svn: 0,
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])
         {
@@ -378,6 +381,7 @@ mod tests {
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT | DeriveContextFlags::CHANGE_LOCALITY,
             tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
+            svn: 0,
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         {
@@ -393,6 +397,7 @@ mod tests {
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
             tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
+            svn: 0,
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])
         {
@@ -408,6 +413,7 @@ mod tests {
             flags: DeriveContextFlags::empty(),
             tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
+            svn: 0,
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])
         {

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -100,6 +100,7 @@ impl CommandExecution for InitCtxCmd {
             uses_internal_input_info: false,
             uses_internal_input_dice: false,
             allow_export_cdi: true,
+            svn: 0,
         });
         Ok(Response::InitCtx(NewHandleResp {
             handle,

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -247,6 +247,7 @@ mod tests {
                 flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INPUT_ALLOW_X509,
                 tci_type: i as u32,
                 target_locality: 0,
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
             .unwrap();

--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -97,6 +97,7 @@ impl Context {
         self.tci = TciNodeData::new();
         self.tci.tci_type = args.tci_type;
         self.tci.locality = args.locality;
+        self.tci.svn = args.svn;
         self.children = 0;
         self.parent_idx = args.parent_idx;
         self.context_type = args.context_type;
@@ -205,6 +206,7 @@ pub struct ActiveContextArgs<'a> {
     pub uses_internal_input_info: bool,
     pub uses_internal_input_dice: bool,
     pub allow_export_cdi: bool,
+    pub svn: u32,
 }
 
 pub(crate) struct ChildToRootIter<'a> {

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -815,6 +815,7 @@ pub mod tests {
                 flags: DeriveContextFlags::MAKE_DEFAULT,
                 tci_type: i as u32,
                 target_locality: 0,
+                svn: 0,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
             .unwrap();
@@ -879,6 +880,7 @@ pub mod tests {
             flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INTERNAL_INPUT_INFO,
             tci_type: 0u32,
             target_locality: 0,
+            svn: 0,
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         .unwrap();
@@ -943,6 +945,7 @@ pub mod tests {
             flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INTERNAL_INPUT_DICE,
             tci_type: 0u32,
             target_locality: 0,
+            svn: 0,
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         .unwrap();

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -35,7 +35,7 @@ pub const MAX_HANDLES: usize = 24;
 include!(concat!(env!("OUT_DIR"), "/arbitrary_max_handles.rs"));
 
 const CURRENT_PROFILE_MAJOR_VERSION: u16 = 0;
-const CURRENT_PROFILE_MINOR_VERSION: u16 = 12;
+const CURRENT_PROFILE_MINOR_VERSION: u16 = 13;
 
 #[cfg(not(feature = "disable_internal_info"))]
 const INTERNAL_INPUT_INFO_SIZE: usize = size_of::<GetProfileResp>() + size_of::<u32>();

--- a/dpe/src/tci.rs
+++ b/dpe/src/tci.rs
@@ -12,6 +12,7 @@ pub struct TciNodeData {
     pub tci_cumulative: TciMeasurement,
     pub tci_current: TciMeasurement,
     pub locality: u32,
+    pub svn: u32,
 }
 
 impl TciNodeData {
@@ -21,6 +22,7 @@ impl TciNodeData {
             tci_cumulative: TciMeasurement([0; DPE_PROFILE.get_tci_size()]),
             tci_current: TciMeasurement([0; DPE_PROFILE.get_tci_size()]),
             locality: 0,
+            svn: 0,
         }
     }
 }

--- a/tools/src/sample_dpe_cert.rs
+++ b/tools/src/sample_dpe_cert.rs
@@ -30,6 +30,7 @@ fn add_tcb_info(
     env: &mut DpeEnv<TestTypes>,
     data: &[u8; DPE_PROFILE.get_hash_size()],
     tci_type: u32,
+    svn: u32,
 ) {
     let cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
@@ -37,6 +38,7 @@ fn add_tcb_info(
         flags: DeriveContextFlags::INPUT_ALLOW_X509 | DeriveContextFlags::MAKE_DEFAULT,
         tci_type,
         target_locality: 0, // Unused since flag isn't set
+        svn,
     };
     let cmd_body = cmd.as_bytes().to_vec();
     let cmd_hdr = dpe
@@ -115,6 +117,7 @@ fn main() {
         &mut env,
         &[0; DPE_PROFILE.get_hash_size()],
         u32::from_be_bytes(*b"TEST"),
+        0,
     );
     let cert = certify_key(&mut dpe, &mut env, format);
 

--- a/verification/client/abi.go
+++ b/verification/client/abi.go
@@ -16,7 +16,7 @@ const (
 	RespMagic uint32 = 0x44504552
 
 	CurrentProfileMajorVersion uint16 = 0
-	CurrentProfileMinorVersion uint16 = 12
+	CurrentProfileMinorVersion uint16 = 13
 )
 
 // CommandCode is a DPE command code
@@ -236,6 +236,7 @@ type DeriveContextReq[Digest DigestAlgorithm] struct {
 	Flags          DeriveContextFlags
 	TciType        uint32
 	TargetLocality uint32
+	Svn            uint32
 }
 
 // DeriveContextResp is the output response from DeriveContext
@@ -669,6 +670,7 @@ func (c *DPEABI[_, Digest, _]) DeriveContext(handle *ContextHandle, inputData []
 		Flags:          flags,
 		TciType:        tciType,
 		TargetLocality: targetLocality,
+		Svn:            0,
 	}
 	resp, err := c.DeriveContextABI(&cmd)
 	if err != nil {


### PR DESCRIPTION
Add SVN as a required field to `DeriveContext`.

The SVN will be encoded in the `DiceTcbInfo` extension.
