### PR TITLE
Reduce size of DpeProfile function names.

### DIFF
--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -56,7 +56,7 @@ bitflags! {
 )]
 pub struct DeriveContextCmd {
     pub handle: ContextHandle,
-    pub data: [u8; DPE_PROFILE.get_hash_size()],
+    pub data: [u8; DPE_PROFILE.hash_size()],
     pub flags: DeriveContextFlags,
     pub tci_type: u32,
     pub target_locality: u32,
@@ -476,7 +476,7 @@ mod tests {
             Err(DpeErrorCode::ArgumentNotSupported),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
+                data: [0; DPE_PROFILE.tci_size()],
                 flags: DeriveContextFlags::INTERNAL_INPUT_DICE,
                 tci_type: 0,
                 target_locality: 0
@@ -495,7 +495,7 @@ mod tests {
             Err(DpeErrorCode::ArgumentNotSupported),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
+                data: [0; DPE_PROFILE.tci_size()],
                 flags: DeriveContextFlags::INTERNAL_INPUT_INFO,
                 tci_type: 0,
                 target_locality: 0
@@ -514,7 +514,7 @@ mod tests {
             Err(DpeErrorCode::ArgumentNotSupported),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
+                data: [0; DPE_PROFILE.tci_size()],
                 flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
                 tci_type: 0,
                 target_locality: 0
@@ -542,7 +542,7 @@ mod tests {
             Err(DpeErrorCode::InvalidLocality),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
+                data: [0; DPE_PROFILE.tci_size()],
                 flags: DeriveContextFlags::empty(),
                 tci_type: 0,
                 target_locality: 0
@@ -565,7 +565,7 @@ mod tests {
         for _ in 0..MAX_HANDLES - 1 {
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
+                data: [0; DPE_PROFILE.tci_size()],
                 flags: DeriveContextFlags::MAKE_DEFAULT,
                 tci_type: 0,
                 target_locality: 0,
@@ -579,7 +579,7 @@ mod tests {
             Err(DpeErrorCode::MaxTcis),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
+                data: [0; DPE_PROFILE.tci_size()],
                 flags: DeriveContextFlags::empty(),
                 tci_type: 0,
                 target_locality: 0
@@ -603,7 +603,7 @@ mod tests {
             .unwrap();
         DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: [0; DPE_PROFILE.get_tci_size()],
+            data: [0; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::CHANGE_LOCALITY,
             tci_type: 7,
             target_locality: TEST_LOCALITIES[1],
@@ -636,7 +636,7 @@ mod tests {
 
         DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: [0; DPE_PROFILE.get_tci_size()],
+            data: [0; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::CHANGE_LOCALITY,
             tci_type: 7,
             target_locality: TEST_LOCALITIES[1],
@@ -672,7 +672,7 @@ mod tests {
             })),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
+                data: [0; DPE_PROFILE.tci_size()],
                 flags: DeriveContextFlags::MAKE_DEFAULT,
                 tci_type: 0,
                 target_locality: 0,
@@ -689,7 +689,7 @@ mod tests {
             })),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
+                data: [0; DPE_PROFILE.tci_size()],
                 flags: DeriveContextFlags::empty(),
                 tci_type: 0,
                 target_locality: 0,
@@ -729,7 +729,7 @@ mod tests {
 
         let parent_handle = match (DeriveContextCmd {
             handle,
-            data: [0; DPE_PROFILE.get_tci_size()],
+            data: [0; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
             tci_type: 0,
             target_locality: 0,
@@ -763,7 +763,7 @@ mod tests {
 
         let parent_handle = match (DeriveContextCmd {
             handle: new_context_handle,
-            data: [0; DPE_PROFILE.get_tci_size()],
+            data: [0; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT
                 | DeriveContextFlags::INTERNAL_INPUT_INFO,
             tci_type: 0,
@@ -819,7 +819,7 @@ mod tests {
             })),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
+                data: [0; DPE_PROFILE.tci_size()],
                 flags: DeriveContextFlags::MAKE_DEFAULT,
                 tci_type: 0,
                 target_locality: 0,
@@ -836,7 +836,7 @@ mod tests {
             })),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
+                data: [0; DPE_PROFILE.tci_size()],
                 flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT
                     | DeriveContextFlags::MAKE_DEFAULT
                     | DeriveContextFlags::CHANGE_LOCALITY,
@@ -862,7 +862,7 @@ mod tests {
             ..
         }) = DeriveContextCmd {
             handle: dpe.contexts[old_default_idx].handle,
-            data: [0; DPE_PROFILE.get_tci_size()],
+            data: [0; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
             tci_type: 0,
             target_locality: 0,
@@ -986,7 +986,7 @@ mod tests {
 
         DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: [0; DPE_PROFILE.get_tci_size()],
+            data: [0; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT
                 | DeriveContextFlags::MAKE_DEFAULT
                 | DeriveContextFlags::CHANGE_LOCALITY,
@@ -999,7 +999,7 @@ mod tests {
         assert_eq!(
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
+                data: [0; DPE_PROFILE.tci_size()],
                 flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT
                     | DeriveContextFlags::CHANGE_LOCALITY,
                 tci_type: 7,
@@ -1035,7 +1035,7 @@ mod tests {
             })),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [1; DPE_PROFILE.get_tci_size()],
+                data: [1; DPE_PROFILE.tci_size()],
                 flags: DeriveContextFlags::MAKE_DEFAULT
                     | DeriveContextFlags::RECURSIVE
                     | DeriveContextFlags::INTERNAL_INPUT_INFO
@@ -1048,7 +1048,7 @@ mod tests {
 
         DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: [2; DPE_PROFILE.get_tci_size()],
+            data: [2; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::MAKE_DEFAULT
                 | DeriveContextFlags::RECURSIVE
                 | DeriveContextFlags::INTERNAL_INPUT_INFO
@@ -1071,14 +1071,12 @@ mod tests {
 
         // check tci_cumulative correctly computed
         let mut hasher = env.crypto.hash_initialize(DPE_PROFILE.alg_len()).unwrap();
-        hasher.update(&[0u8; DPE_PROFILE.get_hash_size()]).unwrap();
-        hasher.update(&[1u8; DPE_PROFILE.get_hash_size()]).unwrap();
+        hasher.update(&[0u8; DPE_PROFILE.hash_size()]).unwrap();
+        hasher.update(&[1u8; DPE_PROFILE.hash_size()]).unwrap();
         let temp_digest = hasher.finish().unwrap();
         let mut hasher_2 = env.crypto.hash_initialize(DPE_PROFILE.alg_len()).unwrap();
         hasher_2.update(temp_digest.bytes()).unwrap();
-        hasher_2
-            .update(&[2u8; DPE_PROFILE.get_hash_size()])
-            .unwrap();
+        hasher_2.update(&[2u8; DPE_PROFILE.hash_size()]).unwrap();
         let digest = hasher_2.finish().unwrap();
         assert_eq!(digest.bytes(), dpe.contexts[child_idx].tci.tci_cumulative.0);
     }
@@ -1108,7 +1106,7 @@ mod tests {
             Err(DpeErrorCode::InvalidArgument),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
+                data: [0; DPE_PROFILE.tci_size()],
                 flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CHANGE_LOCALITY,
                 tci_type: 0,
                 target_locality: TEST_LOCALITIES[1]
@@ -1119,7 +1117,7 @@ mod tests {
             Err(DpeErrorCode::InvalidArgument),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
+                data: [0; DPE_PROFILE.tci_size()],
                 flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::RECURSIVE,
                 tci_type: 0,
                 target_locality: TEST_LOCALITIES[0]
@@ -1132,7 +1130,7 @@ mod tests {
             Err(DpeErrorCode::InvalidArgument),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
+                data: [0; DPE_PROFILE.tci_size()],
                 flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
                 tci_type: 0,
                 target_locality: TEST_LOCALITIES[0]
@@ -1152,7 +1150,7 @@ mod tests {
             Err(DpeErrorCode::InvalidArgument),
             DeriveContextCmd {
                 handle: simulation_handle,
-                data: [0; DPE_PROFILE.get_tci_size()],
+                data: [0; DPE_PROFILE.tci_size()],
                 flags: DeriveContextFlags::CREATE_CERTIFICATE | DeriveContextFlags::EXPORT_CDI,
                 tci_type: 0,
                 target_locality: TEST_LOCALITIES[0]
@@ -1165,7 +1163,7 @@ mod tests {
             Err(DpeErrorCode::InvalidArgument),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
+                data: [0; DPE_PROFILE.tci_size()],
                 flags: DeriveContextFlags::CREATE_CERTIFICATE
                     | DeriveContextFlags::EXPORT_CDI
                     | DeriveContextFlags::RECURSIVE,
@@ -1185,7 +1183,7 @@ mod tests {
         // Happy case!
         let res = DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: [0; DPE_PROFILE.get_tci_size()],
+            data: [0; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
             tci_type: 0,
             target_locality: TEST_LOCALITIES[0],
@@ -1214,7 +1212,7 @@ mod tests {
             Err(DpeErrorCode::ArgumentNotSupported),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
+                data: [0; DPE_PROFILE.tci_size()],
                 flags: DeriveContextFlags::CREATE_CERTIFICATE | DeriveContextFlags::EXPORT_CDI,
                 tci_type: 0,
                 target_locality: TEST_LOCALITIES[0]
@@ -1227,7 +1225,7 @@ mod tests {
             Err(DpeErrorCode::ArgumentNotSupported),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
+                data: [0; DPE_PROFILE.tci_size()],
                 flags: DeriveContextFlags::EXPORT_CDI,
                 tci_type: 0,
                 target_locality: TEST_LOCALITIES[0]
@@ -1240,7 +1238,7 @@ mod tests {
             Err(DpeErrorCode::ArgumentNotSupported),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [0; DPE_PROFILE.get_tci_size()],
+                data: [0; DPE_PROFILE.tci_size()],
                 flags: DeriveContextFlags::CREATE_CERTIFICATE,
                 tci_type: 0,
                 target_locality: TEST_LOCALITIES[0]
@@ -1265,7 +1263,7 @@ mod tests {
 
         let Ok(Response::DeriveContext(DeriveContextResp { handle, .. })) = DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: [0; DPE_PROFILE.get_tci_size()],
+            data: [0; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT,
             tci_type: 0,
             target_locality: TEST_LOCALITIES[0],
@@ -1276,7 +1274,7 @@ mod tests {
 
         let res = DeriveContextCmd {
             handle,
-            data: [0; DPE_PROFILE.get_tci_size()],
+            data: [0; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::EXPORT_CDI
                 | DeriveContextFlags::CREATE_CERTIFICATE
                 | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
@@ -1317,7 +1315,7 @@ mod tests {
         // returned. If the default handle was used, it should be the default handle.
         let res = DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: [0; DPE_PROFILE.get_tci_size()],
+            data: [0; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::EXPORT_CDI
                 | DeriveContextFlags::CREATE_CERTIFICATE
                 | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
@@ -1347,7 +1345,7 @@ mod tests {
 
         let Ok(Response::DeriveContext(res)) = DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: [0xA; DPE_PROFILE.get_tci_size()],
+            data: [0xA; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::empty(),
             tci_type: 0,
             target_locality: TEST_LOCALITIES[0],
@@ -1361,7 +1359,7 @@ mod tests {
 
         let res = DeriveContextCmd {
             handle: res.handle,
-            data: [0; DPE_PROFILE.get_tci_size()],
+            data: [0; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
             tci_type: 0,
             target_locality: TEST_LOCALITIES[0],
@@ -1381,7 +1379,7 @@ mod tests {
 
         let Ok(Response::DeriveContext(res)) = DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: [0xA; DPE_PROFILE.get_tci_size()],
+            data: [0xA; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::empty(),
             tci_type: 0,
             target_locality: TEST_LOCALITIES[0],
@@ -1394,7 +1392,7 @@ mod tests {
 
         let res = DeriveContextCmd {
             handle: res.handle,
-            data: [0; DPE_PROFILE.get_tci_size()],
+            data: [0; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::EXPORT_CDI
                 | DeriveContextFlags::CREATE_CERTIFICATE
                 | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT,
@@ -1421,7 +1419,7 @@ mod tests {
 
         let res = DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: [0xA; DPE_PROFILE.get_tci_size()],
+            data: [0xA; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::MAKE_DEFAULT
                 | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT,
             tci_type: 0,
@@ -1440,7 +1438,7 @@ mod tests {
 
         let res = DeriveContextCmd {
             handle: res.handle,
-            data: [0; DPE_PROFILE.get_tci_size()],
+            data: [0; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::MAKE_DEFAULT
                 | DeriveContextFlags::EXPORT_CDI
                 | DeriveContextFlags::CREATE_CERTIFICATE,
@@ -1487,7 +1485,7 @@ mod tests {
             let derive_cmd = DeriveContextCmd {
                 handle: init_resp.handle,
                 flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
-                data: [0; DPE_PROFILE.get_tci_size()],
+                data: [0; DPE_PROFILE.tci_size()],
                 tci_type: 0,
                 target_locality: TEST_LOCALITIES[0],
             };

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -299,7 +299,7 @@ mod tests {
         // create new context while preserving auto-initialized context
         let handle_1 = match (DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: [0u8; DPE_PROFILE.get_tci_size()],
+            data: [0u8; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT | DeriveContextFlags::CHANGE_LOCALITY,
             tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
@@ -314,7 +314,7 @@ mod tests {
         // retire context with handle 1 and create new context
         let handle_2 = match (DeriveContextCmd {
             handle: handle_1,
-            data: [0u8; DPE_PROFILE.get_tci_size()],
+            data: [0u8; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::empty(),
             tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
@@ -329,7 +329,7 @@ mod tests {
         // retire context with handle 2 and create new context
         let handle_3 = match (DeriveContextCmd {
             handle: handle_2,
-            data: [0u8; DPE_PROFILE.get_tci_size()],
+            data: [0u8; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::empty(),
             tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
@@ -368,7 +368,7 @@ mod tests {
         // create new context while preserving auto-initialized context
         let parent_handle = match (DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: [0u8; DPE_PROFILE.get_tci_size()],
+            data: [0u8; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT | DeriveContextFlags::CHANGE_LOCALITY,
             tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
@@ -383,7 +383,7 @@ mod tests {
         // derive one child from the parent
         let parent_handle = match (DeriveContextCmd {
             handle: parent_handle,
-            data: [0u8; DPE_PROFILE.get_tci_size()],
+            data: [0u8; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
             tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
@@ -398,7 +398,7 @@ mod tests {
         // derive another child while retiring the parent handle
         let handle_b = match (DeriveContextCmd {
             handle: parent_handle,
-            data: [0u8; DPE_PROFILE.get_tci_size()],
+            data: [0u8; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::empty(),
             tci_type: 0,
             target_locality: TEST_LOCALITIES[1],

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -184,23 +184,23 @@ pub mod tests {
     use zerocopy::IntoBytes;
 
     #[cfg(feature = "dpe_profile_p256_sha256")]
-    pub const TEST_DIGEST: [u8; DPE_PROFILE.get_hash_size()] = [
+    pub const TEST_DIGEST: [u8; DPE_PROFILE.hash_size()] = [
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
         26, 27, 28, 29, 30, 31, 32,
     ];
     #[cfg(feature = "dpe_profile_p384_sha384")]
-    pub const TEST_DIGEST: [u8; DPE_PROFILE.get_hash_size()] = [
+    pub const TEST_DIGEST: [u8; DPE_PROFILE.hash_size()] = [
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
         26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
     ];
 
     #[cfg(feature = "dpe_profile_p256_sha256")]
-    pub const TEST_LABEL: [u8; DPE_PROFILE.get_hash_size()] = [
+    pub const TEST_LABEL: [u8; DPE_PROFILE.hash_size()] = [
         32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10,
         9, 8, 7, 6, 5, 4, 3, 2, 1,
     ];
     #[cfg(feature = "dpe_profile_p384_sha384")]
-    pub const TEST_LABEL: [u8; DPE_PROFILE.get_hash_size()] = [
+    pub const TEST_LABEL: [u8; DPE_PROFILE.hash_size()] = [
         48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26,
         25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
     ];

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -43,9 +43,9 @@ bitflags! {
 )]
 pub struct SignCmd {
     pub handle: ContextHandle,
-    pub label: [u8; DPE_PROFILE.get_hash_size()],
+    pub label: [u8; DPE_PROFILE.hash_size()],
     pub flags: SignFlags,
-    pub digest: [u8; DPE_PROFILE.get_hash_size()],
+    pub digest: [u8; DPE_PROFILE.hash_size()],
 }
 
 impl SignCmd {
@@ -112,12 +112,12 @@ impl CommandExecution for SignCmd {
         let digest = Digest::new(&self.digest)?;
         let EcdsaSig { r, s } = self.ecdsa_sign(dpe, env, idx, &digest)?;
 
-        let sig_r: [u8; DPE_PROFILE.get_ecc_int_size()] = r
+        let sig_r: [u8; DPE_PROFILE.ecc_int_size()] = r
             .bytes()
             .try_into()
             .map_err(|_| DpeErrorCode::InternalError)?;
 
-        let sig_s: [u8; DPE_PROFILE.get_ecc_int_size()] = s
+        let sig_s: [u8; DPE_PROFILE.ecc_int_size()] = s
             .bytes()
             .try_into()
             .map_err(|_| DpeErrorCode::InternalError)?;
@@ -241,7 +241,7 @@ mod tests {
         for i in 0..3 {
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [i; DPE_PROFILE.get_hash_size()],
+                data: [i; DPE_PROFILE.hash_size()],
                 flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INPUT_ALLOW_X509,
                 tci_type: i as u32,
                 target_locality: 0,

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -135,7 +135,7 @@ impl DpeInstance {
         env: &mut DpeEnv<impl DpeTypes>,
         support: Support,
         tci_type: u32,
-        auto_init_measurement: [u8; DPE_PROFILE.get_hash_size()],
+        auto_init_measurement: [u8; DPE_PROFILE.hash_size()],
         flags: DpeInstanceFlags,
     ) -> Result<DpeInstance, DpeErrorCode> {
         let updated_support = support.preprocess_support();
@@ -689,7 +689,7 @@ pub mod tests {
         let mut dpe =
             DpeInstance::new(&mut env, Support::AUTO_INIT, DpeInstanceFlags::empty()).unwrap();
 
-        let data = [1; DPE_PROFILE.get_hash_size()];
+        let data = [1; DPE_PROFILE.hash_size()];
         let mut context = dpe.contexts[0];
         dpe.add_tci_measurement(
             &mut env,
@@ -703,14 +703,14 @@ pub mod tests {
 
         // Compute cumulative.
         let mut hasher = env.crypto.hash_initialize(DPE_PROFILE.alg_len()).unwrap();
-        hasher.update(&[0; DPE_PROFILE.get_hash_size()]).unwrap();
+        hasher.update(&[0; DPE_PROFILE.hash_size()]).unwrap();
         hasher.update(&data).unwrap();
         let first_cumulative = hasher.finish().unwrap();
 
         // Make sure the cumulative was computed correctly.
         assert_eq!(first_cumulative.bytes(), context.tci.tci_cumulative.0);
 
-        let data = [2; DPE_PROFILE.get_hash_size()];
+        let data = [2; DPE_PROFILE.hash_size()];
         dpe.add_tci_measurement(
             &mut env,
             &mut context,
@@ -802,7 +802,7 @@ pub mod tests {
         for i in 0..3 {
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [i; DPE_PROFILE.get_hash_size()],
+                data: [i; DPE_PROFILE.hash_size()],
                 flags: DeriveContextFlags::MAKE_DEFAULT,
                 tci_type: i as u32,
                 target_locality: 0,
@@ -866,7 +866,7 @@ pub mod tests {
             .unwrap();
         DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: [0; DPE_PROFILE.get_hash_size()],
+            data: [0; DPE_PROFILE.hash_size()],
             flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INTERNAL_INPUT_INFO,
             tci_type: 0u32,
             target_locality: 0,
@@ -930,7 +930,7 @@ pub mod tests {
             .unwrap();
         DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: [0; DPE_PROFILE.get_hash_size()],
+            data: [0; DPE_PROFILE.hash_size()],
             flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INTERNAL_INPUT_DICE,
             tci_type: 0u32,
             target_locality: 0,
@@ -978,7 +978,7 @@ pub mod tests {
             platform: DEFAULT_PLATFORM,
         };
         let tci_type = 0xdeadbeef_u32;
-        let auto_init_measurement = [0x1; DPE_PROFILE.get_hash_size()];
+        let auto_init_measurement = [0x1; DPE_PROFILE.hash_size()];
         let auto_init_locality = env.platform.get_auto_init_locality().unwrap();
         let mut dpe = DpeInstance::new_auto_init(
             &mut env,

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -78,17 +78,17 @@ pub enum DpeProfile {
 }
 
 impl DpeProfile {
-    pub const fn get_tci_size(&self) -> usize {
+    pub const fn tci_size(&self) -> usize {
         match self {
             DpeProfile::P256Sha256 => 32,
             DpeProfile::P384Sha384 => 48,
         }
     }
-    pub const fn get_ecc_int_size(&self) -> usize {
-        self.get_tci_size()
+    pub const fn ecc_int_size(&self) -> usize {
+        self.tci_size()
     }
-    pub const fn get_hash_size(&self) -> usize {
-        self.get_tci_size()
+    pub const fn hash_size(&self) -> usize {
+        self.tci_size()
     }
     pub const fn alg_len(&self) -> crypto::AlgLen {
         match self {

--- a/dpe/src/response.rs
+++ b/dpe/src/response.rs
@@ -180,8 +180,8 @@ pub struct DeriveContextExportedCdiResp {
 pub struct CertifyKeyResp {
     pub resp_hdr: ResponseHdr,
     pub new_context_handle: ContextHandle,
-    pub derived_pubkey_x: [u8; DPE_PROFILE.get_ecc_int_size()],
-    pub derived_pubkey_y: [u8; DPE_PROFILE.get_ecc_int_size()],
+    pub derived_pubkey_x: [u8; DPE_PROFILE.ecc_int_size()],
+    pub derived_pubkey_y: [u8; DPE_PROFILE.ecc_int_size()],
     pub cert_size: u32,
     pub cert: [u8; MAX_CERT_SIZE],
 }
@@ -199,8 +199,8 @@ pub struct CertifyKeyResp {
 pub struct SignResp {
     pub resp_hdr: ResponseHdr,
     pub new_context_handle: ContextHandle,
-    pub sig_r: [u8; DPE_PROFILE.get_ecc_int_size()],
-    pub sig_s: [u8; DPE_PROFILE.get_ecc_int_size()],
+    pub sig_r: [u8; DPE_PROFILE.ecc_int_size()],
+    pub sig_s: [u8; DPE_PROFILE.ecc_int_size()],
 }
 
 #[repr(C)]

--- a/dpe/src/tci.rs
+++ b/dpe/src/tci.rs
@@ -18,8 +18,8 @@ impl TciNodeData {
     pub const fn new() -> TciNodeData {
         TciNodeData {
             tci_type: 0,
-            tci_cumulative: TciMeasurement([0; DPE_PROFILE.get_tci_size()]),
-            tci_current: TciMeasurement([0; DPE_PROFILE.get_tci_size()]),
+            tci_cumulative: TciMeasurement([0; DPE_PROFILE.tci_size()]),
+            tci_current: TciMeasurement([0; DPE_PROFILE.tci_size()]),
             locality: 0,
         }
     }
@@ -29,10 +29,10 @@ impl TciNodeData {
 #[derive(
     Copy, Clone, Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq, Zeroize,
 )]
-pub struct TciMeasurement(pub [u8; DPE_PROFILE.get_tci_size()]);
+pub struct TciMeasurement(pub [u8; DPE_PROFILE.tci_size()]);
 
 impl Default for TciMeasurement {
     fn default() -> Self {
-        Self([0; DPE_PROFILE.get_tci_size()])
+        Self([0; DPE_PROFILE.tci_size()])
     }
 }

--- a/dpe/src/validation.rs
+++ b/dpe/src/validation.rs
@@ -601,8 +601,7 @@ pub mod tests {
         );
 
         dpe_validator.dpe.contexts[0].children = 0;
-        dpe_validator.dpe.contexts[0].tci.tci_current =
-            TciMeasurement([1; DPE_PROFILE.get_tci_size()]);
+        dpe_validator.dpe.contexts[0].tci.tci_current = TciMeasurement([1; DPE_PROFILE.tci_size()]);
         assert_eq!(
             dpe_validator.validate_dpe_state(),
             Err(ValidationError::InactiveContextWithMeasurement)

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -2446,7 +2446,7 @@ fn create_dpe_cert_or_csr(
     }
     let (priv_key, pub_key) = key_pair?;
 
-    let mut subj_serial = [0u8; DPE_PROFILE.get_hash_size() * 2];
+    let mut subj_serial = [0u8; DPE_PROFILE.hash_size() * 2];
     let subject_name = get_subject_name(env, &pub_key, &mut subj_serial)?;
 
     const INITIALIZER: TciNodeData = TciNodeData::new();
@@ -2634,7 +2634,7 @@ pub(crate) mod tests {
 
     const TEST_ISSUER: Name = Name {
         cn: DirectoryString::PrintableString(b"Caliptra Alias"),
-        serial: DirectoryString::PrintableString(&[0x00; DPE_PROFILE.get_hash_size() * 2]),
+        serial: DirectoryString::PrintableString(&[0x00; DPE_PROFILE.hash_size() * 2]),
     };
 
     fn encode_test_issuer() -> Vec<u8> {
@@ -2684,7 +2684,7 @@ pub(crate) mod tests {
         let mut cert = [0u8; 256];
         let test_name = Name {
             cn: DirectoryString::PrintableString(b"Caliptra Alias"),
-            serial: DirectoryString::PrintableString(&[0x0u8; DPE_PROFILE.get_hash_size() * 2]),
+            serial: DirectoryString::PrintableString(&[0x0u8; DPE_PROFILE.hash_size() * 2]),
         };
 
         let mut w = CertWriter::new(&mut cert, true);
@@ -2730,8 +2730,8 @@ pub(crate) mod tests {
         let mut node = TciNodeData::new();
 
         node.tci_type = 0x11223344;
-        node.tci_cumulative = TciMeasurement([0xaau8; DPE_PROFILE.get_hash_size()]);
-        node.tci_current = TciMeasurement([0xbbu8; DPE_PROFILE.get_hash_size()]);
+        node.tci_cumulative = TciMeasurement([0xaau8; DPE_PROFILE.hash_size()]);
+        node.tci_current = TciMeasurement([0xbbu8; DPE_PROFILE.hash_size()]);
         node.locality = 0xFFFFFFFF;
 
         let mut cert = [0u8; 256];
@@ -2819,10 +2819,10 @@ pub(crate) mod tests {
 
         let test_subject_name = Name {
             cn: DirectoryString::PrintableString(b"DPE Leaf"),
-            serial: DirectoryString::PrintableString(&[0x00; DPE_PROFILE.get_hash_size() * 2]),
+            serial: DirectoryString::PrintableString(&[0x00; DPE_PROFILE.hash_size() * 2]),
         };
 
-        const ECC_INT_SIZE: usize = DPE_PROFILE.get_ecc_int_size();
+        const ECC_INT_SIZE: usize = DPE_PROFILE.ecc_int_size();
         let test_pub = EcdsaPub {
             x: CryptoBuf::new(&[0xAA; ECC_INT_SIZE]).unwrap(),
             y: CryptoBuf::new(&[0xBB; ECC_INT_SIZE]).unwrap(),
@@ -2831,7 +2831,7 @@ pub(crate) mod tests {
         let node = TciNodeData::new();
 
         let measurements = MeasurementData {
-            label: &[0xCC; DPE_PROFILE.get_hash_size()],
+            label: &[0xCC; DPE_PROFILE.hash_size()],
             tci_nodes: &[node],
             is_ca: false,
             supports_recursive: true,
@@ -2886,14 +2886,14 @@ pub(crate) mod tests {
     const TEST_SERIAL: &[u8] = &[0x1F; 20];
     const TEST_ISSUER_NAME: Name = Name {
         cn: DirectoryString::PrintableString(b"Caliptra Alias"),
-        serial: DirectoryString::PrintableString(&[0x00; DPE_PROFILE.get_hash_size() * 2]),
+        serial: DirectoryString::PrintableString(&[0x00; DPE_PROFILE.hash_size() * 2]),
     };
     const TEST_SUBJECT_NAME: Name = Name {
         cn: DirectoryString::PrintableString(b"DPE Leaf"),
-        serial: DirectoryString::PrintableString(&[0x00; DPE_PROFILE.get_hash_size() * 2]),
+        serial: DirectoryString::PrintableString(&[0x00; DPE_PROFILE.hash_size() * 2]),
     };
 
-    const ECC_INT_SIZE: usize = DPE_PROFILE.get_ecc_int_size();
+    const ECC_INT_SIZE: usize = DPE_PROFILE.ecc_int_size();
 
     const DEFAULT_OTHER_NAME_OID: &[u8] = &[0, 0, 0];
     const DEFAULT_OTHER_NAME_VALUE: &str = "default-other-name";
@@ -2929,7 +2929,7 @@ pub(crate) mod tests {
             other_name,
         });
         let measurements = MeasurementData {
-            label: &[0; DPE_PROFILE.get_hash_size()],
+            label: &[0; DPE_PROFILE.hash_size()],
             tci_nodes: &[node],
             is_ca,
             supports_recursive: true,

--- a/tools/src/sample_dpe_cert.rs
+++ b/tools/src/sample_dpe_cert.rs
@@ -30,7 +30,7 @@ impl DpeTypes for TestTypes {
 fn add_tcb_info(
     dpe: &mut DpeInstance,
     env: &mut DpeEnv<TestTypes>,
-    data: &[u8; DPE_PROFILE.get_hash_size()],
+    data: &[u8; DPE_PROFILE.hash_size()],
     tci_type: u32,
 ) {
     let cmd = DeriveContextCmd {
@@ -61,7 +61,7 @@ fn certify_key(dpe: &mut DpeInstance, env: &mut DpeEnv<TestTypes>, format: u32) 
     let certify_key_cmd: CertifyKeyCmd = commands::CertifyKeyCmd {
         handle: ContextHandle::default(),
         flags: CertifyKeyFlags::empty(),
-        label: [0; DPE_PROFILE.get_hash_size()],
+        label: [0; DPE_PROFILE.hash_size()],
         format,
     };
     let cmd_body = certify_key_cmd.as_bytes().to_vec();
@@ -113,7 +113,7 @@ fn main() {
     add_tcb_info(
         &mut dpe,
         &mut env,
-        &[0; DPE_PROFILE.get_hash_size()],
+        &[0; DPE_PROFILE.hash_size()],
         u32::from_be_bytes(*b"TEST"),
     );
     let cert = certify_key(&mut dpe, &mut env, format);


### PR DESCRIPTION
The `get_*` doesn't follow Rust conventions and takes up unnecessary horizontal space.