### PR TITLE
Move DPE state into the environment.

### DIFF
--- a/dpe/fuzz/src/fuzz_target_1.rs
+++ b/dpe/fuzz/src/fuzz_target_1.rs
@@ -5,7 +5,7 @@
 #[cfg(all(not(feature = "libfuzzer-sys"), not(feature = "afl")))]
 compile_error!("Either feature \"libfuzzer-sys\" or \"afl\" must be enabled!");
 
-use dpe::{dpe_instance::DpeInstanceFlags, response::DpeErrorCode};
+use dpe::{response::DpeErrorCode, DpeFlags};
 #[cfg(feature = "libfuzzer-sys")]
 use libfuzzer_sys::fuzz_target;
 
@@ -53,7 +53,7 @@ fn harness(data: &[u8]) {
     let mut env = DpeEnv::<SimTypes> {
         crypto: RustCryptoImpl::new(),
         platform: DefaultPlatform(DefaultPlatformProfile::P256),
-        state: &mut dpe::State::new(SUPPORT, DpeInstanceFlags::empty()),
+        state: &mut dpe::State::new(SUPPORT, DpeFlags::empty()),
     };
     let mut dpe = DpeInstance::new(&mut env).unwrap();
     trace!("----------------------------------");

--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -2,10 +2,10 @@
 use super::CommandExecution;
 use crate::{
     context::ContextHandle,
-    dpe_instance::{DpeEnv, DpeInstance, DpeInstanceFlags, DpeTypes},
+    dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
     response::{CertifyKeyResp, DpeErrorCode, Response},
     x509::{create_dpe_cert, create_dpe_csr, CreateDpeCertArgs, CreateDpeCertResult},
-    DPE_PROFILE, MAX_CERT_SIZE,
+    DpeFlags, DPE_PROFILE, MAX_CERT_SIZE,
 };
 use bitflags::bitflags;
 #[cfg(not(feature = "no-cfi"))]
@@ -98,7 +98,7 @@ impl CommandExecution for CertifyKeyCmd {
             dice_extensions_are_critical: env
                 .state
                 .flags
-                .contains(DpeInstanceFlags::MARK_DICE_EXTENSIONS_CRITICAL),
+                .contains(DpeFlags::MARK_DICE_EXTENSIONS_CRITICAL),
         };
         let mut cert = [0; MAX_CERT_SIZE];
 
@@ -216,9 +216,9 @@ mod tests {
         for mark_dice_extensions_critical in [true, false] {
             CfiCounter::reset_for_test();
             let flags = {
-                let mut flags = DpeInstanceFlags::empty();
+                let mut flags = DpeFlags::empty();
                 flags.set(
-                    DpeInstanceFlags::MARK_DICE_EXTENSIONS_CRITICAL,
+                    DpeFlags::MARK_DICE_EXTENSIONS_CRITICAL,
                     mark_dice_extensions_critical,
                 );
                 flags
@@ -271,9 +271,9 @@ mod tests {
         for mark_dice_extensions_critical in [true, false] {
             CfiCounter::reset_for_test();
             let flags = {
-                let mut flags = DpeInstanceFlags::empty();
+                let mut flags = DpeFlags::empty();
                 flags.set(
-                    DpeInstanceFlags::MARK_DICE_EXTENSIONS_CRITICAL,
+                    DpeFlags::MARK_DICE_EXTENSIONS_CRITICAL,
                     mark_dice_extensions_critical,
                 );
                 flags
@@ -501,10 +501,7 @@ mod tests {
     #[test]
     fn test_certify_key_order() {
         CfiCounter::reset_for_test();
-        let mut state = State::new(
-            Support::X509 | Support::AUTO_INIT,
-            DpeInstanceFlags::empty(),
-        );
+        let mut state = State::new(Support::X509 | Support::AUTO_INIT, DpeFlags::empty());
         let mut env = test_env(&mut state);
         let mut dpe = DpeInstance::new(&mut env).unwrap();
 

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -7,7 +7,7 @@ use crate::{
     response::{DeriveContextExportedCdiResp, DeriveContextResp, DpeErrorCode, Response},
     tci::TciMeasurement,
     x509::{create_exported_dpe_cert, CreateDpeCertArgs, CreateDpeCertResult},
-    DPE_PROFILE, MAX_CERT_SIZE,
+    State, DPE_PROFILE, MAX_CERT_SIZE,
 };
 use bitflags::bitflags;
 #[cfg(not(feature = "no-cfi"))]
@@ -177,16 +177,16 @@ impl DeriveContextCmd {
     /// * `target_locality` - Intended locality of the new child.
     fn safe_to_make_child(
         &self,
-        dpe: &mut DpeInstance,
+        state: &State,
         parent_idx: usize,
         target_locality: u32,
     ) -> Result<bool, DpeErrorCode> {
-        let default_context_idx = dpe
+        let default_context_idx = state
             .get_active_context_pos(&ContextHandle::default(), target_locality)
             .ok();
 
         // count active contexts in target_locality
-        let num_contexts_in_locality = dpe.count_contexts(|c: &Context| {
+        let num_contexts_in_locality = state.count_contexts(|c: &Context| {
             c.state == ContextState::Active && c.locality == target_locality
         })?;
 
@@ -206,25 +206,26 @@ impl CommandExecution for DeriveContextCmd {
         env: &mut DpeEnv<impl DpeTypes>,
         locality: u32,
     ) -> Result<Response, DpeErrorCode> {
+        let support = env.state.support;
         // Make sure the operation is supported.
-        if (!dpe.support.internal_info() && self.uses_internal_info_input())
-            || (!dpe.support.internal_dice() && self.uses_internal_dice_input())
-            || (!dpe.support.retain_parent_context() && self.retains_parent())
-            || (!dpe.support.x509() && self.allows_x509())
-            || (!dpe.support.cdi_export() && (self.creates_certificate() || self.exports_cdi()))
-            || (!dpe.support.recursive() && self.is_recursive())
+        if (!support.internal_info() && self.uses_internal_info_input())
+            || (!support.internal_dice() && self.uses_internal_dice_input())
+            || (!support.retain_parent_context() && self.retains_parent())
+            || (!support.x509() && self.allows_x509())
+            || (!support.cdi_export() && (self.creates_certificate() || self.exports_cdi()))
+            || (!support.recursive() && self.is_recursive())
         {
             return Err(DpeErrorCode::ArgumentNotSupported);
         }
 
-        let parent_idx = dpe.get_active_context_pos(&self.handle, locality)?;
-        if (!dpe.contexts[parent_idx].allow_x509() && self.allows_x509())
+        let parent_idx = env.state.get_active_context_pos(&self.handle, locality)?;
+        if (!env.state.contexts[parent_idx].allow_x509() && self.allows_x509())
             || (self.exports_cdi() && !self.creates_certificate())
             || (self.exports_cdi() && self.is_recursive())
             || (self.exports_cdi() && self.changes_locality())
             || (self.exports_cdi()
-                && dpe.contexts[parent_idx].context_type == ContextType::Simulation)
-            || (self.exports_cdi() && !dpe.contexts[parent_idx].allow_export_cdi())
+                && env.state.contexts[parent_idx].context_type == ContextType::Simulation)
+            || (self.exports_cdi() && !env.state.contexts[parent_idx].allow_export_cdi())
             || (self.is_recursive() && self.retains_parent())
         {
             return Err(DpeErrorCode::InvalidArgument);
@@ -242,11 +243,11 @@ impl CommandExecution for DeriveContextCmd {
 
         cfg_if! {
             if #[cfg(not(feature = "no-cfi"))] {
-                cfi_assert!(dpe.support.internal_info() || !self.uses_internal_info_input());
-                cfi_assert!(dpe.support.internal_dice() || !self.uses_internal_dice_input());
-                cfi_assert!(dpe.support.retain_parent_context() || !self.retains_parent());
-                cfi_assert!(dpe.support.x509() || !self.allows_x509());
-                cfi_assert!(dpe.contexts[parent_idx].allow_x509() || !self.allows_x509());
+                cfi_assert!(support.internal_info() || !self.uses_internal_info_input());
+                cfi_assert!(support.internal_dice() || !self.uses_internal_dice_input());
+                cfi_assert!(support.retain_parent_context() || !self.retains_parent());
+                cfi_assert!(support.x509() || !self.allows_x509());
+                cfi_assert!(env.state.contexts[parent_idx].allow_x509() || !self.allows_x509());
                 cfi_assert!(!self.is_recursive() || !self.retains_parent());
             }
         }
@@ -254,7 +255,7 @@ impl CommandExecution for DeriveContextCmd {
         if self.is_recursive() {
             cfg_if! {
                 if #[cfg(not(feature = "disable_recursive"))] {
-                    let mut tmp_context = dpe.contexts[parent_idx];
+                    let mut tmp_context = env.state.contexts[parent_idx];
                     if tmp_context.tci.tci_type != self.tci_type {
                         return Err(DpeErrorCode::InvalidArgument);
                     } else {
@@ -271,14 +272,14 @@ impl CommandExecution for DeriveContextCmd {
                     // Rotate the handle if it isn't the default context.
                     dpe.roll_onetime_use_handle(env, parent_idx)?;
 
-                    dpe.contexts[parent_idx] = Context {
-                        handle: dpe.contexts[parent_idx].handle,
+                    env.state.contexts[parent_idx] = Context {
+                        handle: env.state.contexts[parent_idx].handle,
                         ..tmp_context
                     };
 
                     // Return new handle in new_context_handle
                     return Ok(Response::DeriveContext(DeriveContextResp {
-                        handle: dpe.contexts[parent_idx].handle,
+                        handle: env.state.contexts[parent_idx].handle,
                         // Should be ignored since retain_parent cannot be true
                         parent_handle: ContextHandle::default(),
                         resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
@@ -290,7 +291,7 @@ impl CommandExecution for DeriveContextCmd {
         }
 
         // Copy the parent context to mutate so that we avoid mutating internal state upon an error.
-        let mut tmp_parent_context = dpe.contexts[parent_idx];
+        let mut tmp_parent_context = env.state.contexts[parent_idx];
         if self.retains_parent() {
             if !tmp_parent_context.handle.is_default() {
                 tmp_parent_context.handle = dpe.generate_new_handle(env)?;
@@ -321,7 +322,7 @@ impl CommandExecution for DeriveContextCmd {
                         key_label: b"Exported ECC",
                         context: b"Exported ECC",
                         ueid,
-                        dice_extensions_are_critical: dpe.flags.contains(DpeInstanceFlags::MARK_DICE_EXTENSIONS_CRITICAL),
+                        dice_extensions_are_critical: env.state.flags.contains(DpeInstanceFlags::MARK_DICE_EXTENSIONS_CRITICAL),
                     };
                     let mut cert = [0; MAX_CERT_SIZE];
                     let CreateDpeCertResult { cert_size, exported_cdi_handle, .. } = create_exported_dpe_cert(
@@ -331,21 +332,21 @@ impl CommandExecution for DeriveContextCmd {
                         &mut cert,
                     )?;
 
-                    if !self.retains_parent() && !dpe.contexts[parent_idx].has_children() {
+                    if !self.retains_parent() && !env.state.contexts[parent_idx].has_children() {
                         // When the parent is not retained and there are no other children,
                         // destroy it.
-                        destroy_context::destroy_context(&self.handle, dpe, locality)?;
+                        destroy_context::destroy_context(&self.handle, env.state, locality)?;
                     } else {
                         // We either retained the parent or it has other children, so retire it and
                         // make it's handle invalid.
                         // At this point we cannot error out anymore, so it is safe to set the parent context.
-                        dpe.contexts[parent_idx] = tmp_parent_context;
+                        env.state.contexts[parent_idx] = tmp_parent_context;
                     }
 
 
                     return Ok(Response::DeriveContextExportedCdi(DeriveContextExportedCdiResp {
                         handle: ContextHandle::new_invalid(),
-                        parent_handle: dpe.contexts[parent_idx].handle,
+                        parent_handle: env.state.contexts[parent_idx].handle,
                         resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
                         exported_cdi: exported_cdi_handle,
                         certificate_size: cert_size,
@@ -357,11 +358,12 @@ impl CommandExecution for DeriveContextCmd {
             }
         }
 
-        let child_idx = dpe
+        let child_idx = env
+            .state
             .get_next_inactive_context_pos()
             .ok_or(DpeErrorCode::MaxTcis)?;
 
-        let safe_to_make_child = self.safe_to_make_child(dpe, parent_idx, target_locality)?;
+        let safe_to_make_child = self.safe_to_make_child(env.state, parent_idx, target_locality)?;
         if !safe_to_make_child {
             return Err(DpeErrorCode::InvalidArgument);
         } else {
@@ -386,7 +388,7 @@ impl CommandExecution for DeriveContextCmd {
         // Create a temporary context to mutate so that we avoid mutating internal state upon an error.
         let mut tmp_child_context = Context::new();
         tmp_child_context.activate(&ActiveContextArgs {
-            context_type: dpe.contexts[parent_idx].context_type,
+            context_type: env.state.contexts[parent_idx].context_type,
             locality: target_locality,
             handle: &child_handle,
             tci_type: self.tci_type,
@@ -410,12 +412,12 @@ impl CommandExecution for DeriveContextCmd {
         tmp_parent_context.children = children_with_child_idx;
 
         // At this point we cannot error out anymore, so it is safe to set the updated child and parent contexts.
-        dpe.contexts[child_idx] = tmp_child_context;
-        dpe.contexts[parent_idx] = tmp_parent_context;
+        env.state.contexts[child_idx] = tmp_child_context;
+        env.state.contexts[parent_idx] = tmp_parent_context;
 
         Ok(Response::DeriveContext(DeriveContextResp {
             handle: child_handle,
-            parent_handle: dpe.contexts[parent_idx].handle,
+            parent_handle: env.state.contexts[parent_idx].handle,
             resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
         }))
     }
@@ -427,18 +429,20 @@ mod tests {
     use crate::{
         commands::{
             rotate_context::{RotateCtxCmd, RotateCtxFlags},
-            tests::{DEFAULT_PLATFORM, PROFILES, TEST_DIGEST, TEST_LABEL},
+            tests::{PROFILES, TEST_DIGEST, TEST_LABEL},
             CertifyKeyCmd, CertifyKeyFlags, Command, CommandHdr, InitCtxCmd, SignCmd, SignFlags,
         },
         context::ContextType,
-        dpe_instance::tests::{TestTypes, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_LOCALITIES},
+        dpe_instance::tests::{
+            test_env, TestTypes, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_LOCALITIES,
+        },
         response::NewHandleResp,
         support::Support,
         validation::DpeValidator,
         DpeProfile, MAX_EXPORTED_CDI_SIZE, MAX_HANDLES,
     };
     use caliptra_cfi_lib_git::CfiCounter;
-    use crypto::{Crypto, Hasher, RustCryptoImpl};
+    use crypto::{Crypto, Hasher};
     use openssl::{
         bn::BigNum,
         ecdsa::EcdsaSig,
@@ -475,16 +479,12 @@ mod tests {
     #[test]
     fn test_support() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe = DpeInstance::new(
-            &mut env,
+        let mut state = State::new(
             Support::AUTO_INIT | Support::INTERNAL_INFO | Support::RETAIN_PARENT_CONTEXT,
             DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        );
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         assert_eq!(
             Err(DpeErrorCode::ArgumentNotSupported),
@@ -498,12 +498,11 @@ mod tests {
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
 
-        dpe = DpeInstance::new(
-            &mut env,
+        *env.state = State::new(
             Support::AUTO_INIT | Support::INTERNAL_DICE | Support::RETAIN_PARENT_CONTEXT,
             DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        );
+        dpe = DpeInstance::new(&mut env).unwrap();
 
         assert_eq!(
             Err(DpeErrorCode::ArgumentNotSupported),
@@ -517,12 +516,11 @@ mod tests {
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
 
-        let mut dpe = DpeInstance::new(
-            &mut env,
+        *env.state = State::new(
             Support::AUTO_INIT | Support::INTERNAL_INFO | Support::INTERNAL_DICE,
             DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        );
+        dpe = DpeInstance::new(&mut env).unwrap();
 
         assert_eq!(
             Err(DpeErrorCode::ArgumentNotSupported),
@@ -540,12 +538,9 @@ mod tests {
     #[test]
     fn test_initial_conditions() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe =
-            DpeInstance::new(&mut env, Support::default(), DpeInstanceFlags::empty()).unwrap();
+        let mut state = State::default();
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         InitCtxCmd::new_use_default()
             .execute(&mut dpe, &mut env, 0)
@@ -568,12 +563,9 @@ mod tests {
     #[test]
     fn test_max_tcis() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe =
-            DpeInstance::new(&mut env, Support::AUTO_INIT, DpeInstanceFlags::empty()).unwrap();
+        let mut state = State::new(Support::AUTO_INIT, DpeInstanceFlags::empty());
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         // Fill all contexts with children (minus the auto-init context).
         for _ in 0..MAX_HANDLES - 1 {
@@ -605,14 +597,12 @@ mod tests {
     #[test]
     fn test_set_child_parent_relationship() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe =
-            DpeInstance::new(&mut env, Support::AUTO_INIT, DpeInstanceFlags::empty()).unwrap();
+        let mut state = State::new(Support::AUTO_INIT, DpeInstanceFlags::empty());
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
-        let parent_idx = dpe
+        let parent_idx = env
+            .state
             .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[0])
             .unwrap();
         DeriveContextCmd {
@@ -624,15 +614,16 @@ mod tests {
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         .unwrap();
-        let child_idx = dpe
+        let child_idx = env
+            .state
             .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[1])
             .unwrap();
-        let child = &dpe.contexts[child_idx];
+        let child = &env.state.contexts[child_idx];
 
         assert_eq!(parent_idx, child.parent_idx as usize);
         assert_eq!(
             child_idx,
-            dpe.contexts[parent_idx].children.trailing_zeros() as usize
+            env.state.contexts[parent_idx].children.trailing_zeros() as usize
         );
         assert_eq!(7, child.tci.tci_type);
         assert_eq!(TEST_LOCALITIES[1], child.locality);
@@ -641,12 +632,9 @@ mod tests {
     #[test]
     fn test_set_other_values() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe =
-            DpeInstance::new(&mut env, Support::AUTO_INIT, DpeInstanceFlags::empty()).unwrap();
+        let mut state = State::new(Support::AUTO_INIT, DpeInstanceFlags::empty());
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         DeriveContextCmd {
             handle: ContextHandle::default(),
@@ -658,7 +646,8 @@ mod tests {
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         .unwrap();
 
-        let child = &dpe.contexts[dpe
+        let child = &env.state.contexts[env
+            .state
             .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[1])
             .unwrap()];
 
@@ -670,12 +659,9 @@ mod tests {
     #[test]
     fn test_correct_child_handle() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe =
-            DpeInstance::new(&mut env, Support::AUTO_INIT, DpeInstanceFlags::empty()).unwrap();
+        let mut state = State::new(Support::AUTO_INIT, DpeInstanceFlags::empty());
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         // Make sure child handle is default when creating default child.
         assert_eq!(
@@ -715,20 +701,16 @@ mod tests {
     #[test]
     fn test_full_attestation_flow() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe = DpeInstance::new(
-            &mut env,
+        let mut state = State::new(
             Support::INTERNAL_INFO
                 | Support::X509
                 | Support::AUTO_INIT
                 | Support::ROTATE_CONTEXT
                 | Support::RETAIN_PARENT_CONTEXT,
             DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        );
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         let handle = match (RotateCtxCmd {
             handle: ContextHandle::default(),
@@ -813,16 +795,12 @@ mod tests {
     #[test]
     fn test_correct_parent_handle() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe = DpeInstance::new(
-            &mut env,
+        let mut state = State::new(
             Support::AUTO_INIT | Support::RETAIN_PARENT_CONTEXT,
             DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        );
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         // Make sure the parent handle is non-sense when not retaining.
         assert_eq!(
@@ -863,10 +841,11 @@ mod tests {
         // The next test case is to make sure the parent handle rotates when not the default and
         // parent is retained. Right now both localities have a default. We need to mutate one of them so
         // we can create a new child as the default in the locality.
-        let old_default_idx = dpe
+        let old_default_idx = env
+            .state
             .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[0])
             .unwrap();
-        dpe.contexts[old_default_idx].handle = ContextHandle([0x1; ContextHandle::SIZE]);
+        env.state.contexts[old_default_idx].handle = ContextHandle([0x1; ContextHandle::SIZE]);
 
         // Make sure neither the parent nor the child handles are default.
         let Response::DeriveContext(DeriveContextResp {
@@ -875,7 +854,7 @@ mod tests {
             resp_hdr,
             ..
         }) = DeriveContextCmd {
-            handle: dpe.contexts[old_default_idx].handle,
+            handle: env.state.contexts[old_default_idx].handle,
             data: [0; DPE_PROFILE.tci_size()],
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
             tci_type: 0,
@@ -960,16 +939,12 @@ mod tests {
     #[test]
     fn test_default_context_cannot_be_retained() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe = DpeInstance::new(
-            &mut env,
+        let mut state = State::new(
             Support::AUTO_INIT | Support::RETAIN_PARENT_CONTEXT,
             DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        );
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         assert_eq!(
             DeriveContextCmd {
@@ -987,16 +962,12 @@ mod tests {
     #[test]
     fn test_make_default_in_other_locality_that_has_non_default() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe = DpeInstance::new(
-            &mut env,
+        let mut state = State::new(
             Support::AUTO_INIT | Support::RETAIN_PARENT_CONTEXT,
             DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        );
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         DeriveContextCmd {
             handle: ContextHandle::default(),
@@ -1027,19 +998,15 @@ mod tests {
     #[test]
     fn test_recursive() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe = DpeInstance::new(
-            &mut env,
+        let mut state = State::new(
             Support::AUTO_INIT
                 | Support::RECURSIVE
                 | Support::INTERNAL_DICE
                 | Support::INTERNAL_INFO,
             DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        );
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         assert_eq!(
             Ok(Response::DeriveContext(DeriveContextResp {
@@ -1073,15 +1040,16 @@ mod tests {
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         .unwrap();
 
-        let child_idx = dpe
+        let child_idx = env
+            .state
             .get_active_context_pos(&ContextHandle::default(), 0)
             .unwrap();
         // ensure flags are unchanged
-        assert!(dpe.contexts[child_idx].allow_x509());
-        assert!(!dpe.contexts[child_idx].uses_internal_input_info());
-        assert!(!dpe.contexts[child_idx].uses_internal_input_dice());
+        assert!(env.state.contexts[child_idx].allow_x509());
+        assert!(!env.state.contexts[child_idx].uses_internal_input_info());
+        assert!(!env.state.contexts[child_idx].uses_internal_input_dice());
         // Still using the same context.
-        assert!(dpe.contexts[child_idx].allow_export_cdi());
+        assert!(env.state.contexts[child_idx].allow_export_cdi());
 
         // check tci_cumulative correctly computed
         let mut hasher = env.crypto.hash_initialize(DPE_PROFILE.alg_len()).unwrap();
@@ -1092,18 +1060,16 @@ mod tests {
         hasher_2.update(temp_digest.bytes()).unwrap();
         hasher_2.update(&[2u8; DPE_PROFILE.hash_size()]).unwrap();
         let digest = hasher_2.finish().unwrap();
-        assert_eq!(digest.bytes(), dpe.contexts[child_idx].tci.tci_cumulative.0);
+        assert_eq!(
+            digest.bytes(),
+            env.state.contexts[child_idx].tci.tci_cumulative.0
+        );
     }
 
     #[test]
     fn test_cdi_export_flags() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe = DpeInstance::new(
-            &mut env,
+        let mut state = State::new(
             Support::AUTO_INIT
                 | Support::CDI_EXPORT
                 | Support::X509
@@ -1111,8 +1077,9 @@ mod tests {
                 | Support::SIMULATION
                 | Support::RETAIN_PARENT_CONTEXT,
             DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        );
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         // When `DeriveContextFlags::EXPORT_CDI` is set, `DeriveContextFlags::CREATE_CERTIFICATE` MUST
         // also be set, or `DpeErrorCode::InvalidArgument` is raised.
@@ -1187,12 +1154,11 @@ mod tests {
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
 
-        dpe = DpeInstance::new(
-            &mut env,
+        *env.state = State::new(
             Support::AUTO_INIT | Support::CDI_EXPORT | Support::X509,
             DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        );
+        dpe = DpeInstance::new(&mut env).unwrap();
 
         // Happy case!
         let res = DeriveContextCmd {
@@ -1214,12 +1180,11 @@ mod tests {
         assert_ne!(res.new_certificate, [0; MAX_CERT_SIZE]);
         assert_ne!(res.exported_cdi, [0; MAX_EXPORTED_CDI_SIZE]);
 
-        let mut dpe = DpeInstance::new(
-            &mut env,
+        *env.state = State::new(
             Support::AUTO_INIT | Support::INTERNAL_INFO | Support::INTERNAL_DICE | Support::X509,
             DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        );
+        dpe = DpeInstance::new(&mut env).unwrap();
 
         // `DpeInstance` needs `Support::EXPORT_CDI` to use `DeriveContextFlags::EXPORT_CDI`.
         assert_eq!(
@@ -1261,19 +1226,15 @@ mod tests {
         );
 
         // New ENV so the exported-cdi slot is clear.
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        dpe = DpeInstance::new(
-            &mut env,
+        let mut state = State::new(
             Support::AUTO_INIT
                 | Support::CDI_EXPORT
                 | Support::X509
                 | Support::RETAIN_PARENT_CONTEXT,
             DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        );
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         let Ok(Response::DeriveContext(DeriveContextResp { handle, .. })) = DeriveContextCmd {
             handle: ContextHandle::default(),
@@ -1311,19 +1272,15 @@ mod tests {
         assert_ne!(res.exported_cdi, [0; MAX_EXPORTED_CDI_SIZE]);
 
         // New ENV so the exported-cdi slot is clear.
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        dpe = DpeInstance::new(
-            &mut env,
+        let mut state = State::new(
             Support::AUTO_INIT
                 | Support::CDI_EXPORT
                 | Support::X509
                 | Support::RETAIN_PARENT_CONTEXT,
             DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        );
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         // When `DeriveContextFlags::RETAIN_PARENT_CONTEXT` a new handle to the parent should be
         // returned. If the default handle was used, it should be the default handle.
@@ -1350,12 +1307,11 @@ mod tests {
 
         // Children that did not have `DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT` should not
         // be able to use `DeriveContextFlags::EXPORT_CDI`.
-        dpe = DpeInstance::new(
-            &mut env,
+        *env.state = State::new(
             Support::AUTO_INIT | Support::CDI_EXPORT | Support::X509,
             DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        );
+        dpe = DpeInstance::new(&mut env).unwrap();
 
         let Ok(Response::DeriveContext(res)) = DeriveContextCmd {
             handle: ContextHandle::default(),
@@ -1368,8 +1324,8 @@ mod tests {
             panic!("Unexpected result!");
         };
 
-        let child_idx = dpe.get_active_context_pos(&res.handle, 0).unwrap();
-        assert!(!dpe.contexts[child_idx].allow_export_cdi());
+        let child_idx = env.state.get_active_context_pos(&res.handle, 0).unwrap();
+        assert!(!env.state.contexts[child_idx].allow_export_cdi());
 
         let res = DeriveContextCmd {
             handle: res.handle,
@@ -1384,12 +1340,11 @@ mod tests {
         // Children that did not have `DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT` should not
         // be able to use `DeriveContextFlags::EXPORT_CDI` even if `DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT`
         // was included.
-        dpe = DpeInstance::new(
-            &mut env,
+        *env.state = State::new(
             Support::AUTO_INIT | Support::CDI_EXPORT | Support::X509,
             DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        );
+        dpe = DpeInstance::new(&mut env).unwrap();
 
         let Ok(Response::DeriveContext(res)) = DeriveContextCmd {
             handle: ContextHandle::default(),
@@ -1401,8 +1356,8 @@ mod tests {
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]) else {
             panic!("Unexpected result!");
         };
-        let child_idx = dpe.get_active_context_pos(&res.handle, 0).unwrap();
-        assert!(!dpe.contexts[child_idx].allow_export_cdi());
+        let child_idx = env.state.get_active_context_pos(&res.handle, 0).unwrap();
+        assert!(!env.state.contexts[child_idx].allow_export_cdi());
 
         let res = DeriveContextCmd {
             handle: res.handle,
@@ -1420,16 +1375,12 @@ mod tests {
         // use `DeriveContextFlags::EXPORT_CDI`.
 
         // Create a new env to clear cached exported CDIs
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        dpe = DpeInstance::new(
-            &mut env,
+        let mut state = State::new(
             Support::AUTO_INIT | Support::CDI_EXPORT | Support::X509,
             DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        );
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         let res = DeriveContextCmd {
             handle: ContextHandle::default(),
@@ -1440,10 +1391,11 @@ mod tests {
             target_locality: TEST_LOCALITIES[0],
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]);
-        let child_idx = dpe
+        let child_idx = env
+            .state
             .get_active_context_pos(&ContextHandle::default(), 0)
             .unwrap();
-        assert!(dpe.contexts[child_idx].allow_export_cdi());
+        assert!(env.state.contexts[child_idx].allow_export_cdi());
 
         let res = match res {
             Ok(Response::DeriveContext(res)) => res,
@@ -1474,16 +1426,12 @@ mod tests {
     #[test]
     fn export_cdi_parent_without_children() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe = DpeInstance::new(
-            &mut env,
+        let mut state = State::new(
             Support::AUTO_INIT | Support::CDI_EXPORT | Support::X509,
             DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        );
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         let res = DeriveContextCmd {
             handle: ContextHandle::default(),
@@ -1500,32 +1448,31 @@ mod tests {
 
         // Make sure we did not leak a context.
         assert_eq!(
-            dpe.contexts
+            env.state
+                .contexts
                 .iter()
                 .filter(|&c| c.state == ContextState::Inactive)
                 .count(),
-            dpe.contexts.len()
+            env.state.contexts.len()
         );
-        let validator = DpeValidator { dpe: &mut dpe };
+        let validator = DpeValidator {
+            dpe: &mut env.state,
+        };
         assert!(validator.validate_dpe().is_ok());
     }
 
     #[test]
     fn export_cdi_parent_retained() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe = DpeInstance::new(
-            &mut env,
+        let mut state = State::new(
             Support::AUTO_INIT
                 | Support::CDI_EXPORT
                 | Support::X509
                 | Support::RETAIN_PARENT_CONTEXT,
             DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        );
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         let res = DeriveContextCmd {
             handle: ContextHandle::default(),
@@ -1542,12 +1489,15 @@ mod tests {
             panic!("expected to get a valid DeriveContextExportedCdi response.");
         };
 
-        let validator = DpeValidator { dpe: &mut dpe };
+        let validator = DpeValidator {
+            dpe: &mut env.state,
+        };
         assert!(validator.validate_dpe().is_ok());
 
         // Parent is still valid.
         assert_eq!(
-            dpe.contexts
+            env.state
+                .contexts
                 .iter()
                 .filter(|&c| c.state == ContextState::Active)
                 .count(),
@@ -1564,20 +1514,16 @@ mod tests {
         // * Active siblings are not destroyed.
         // * The grand-parent remains active.
 
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe = DpeInstance::new(
-            &mut env,
+        let mut state = State::new(
             Support::AUTO_INIT
                 | Support::CDI_EXPORT
                 | Support::X509
                 | Support::RETAIN_PARENT_CONTEXT
                 | Support::ROTATE_CONTEXT,
             DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        );
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         // We want to use multiple contexts, so rotate out the default handle for a new handle.
         let Ok(Response::RotateCtx(NewHandleResp {
@@ -1614,10 +1560,12 @@ mod tests {
             );
         }
 
-        let root_idx = dpe
+        let root_idx = env
+            .state
             .get_active_context_pos(&parent_handle, TEST_LOCALITIES[0])
             .unwrap();
-        let exported_idx = dpe
+        let exported_idx = env
+            .state
             .get_active_context_pos(&handle, TEST_LOCALITIES[0])
             .unwrap();
 
@@ -1639,17 +1587,22 @@ mod tests {
         );
 
         // The parent of the exported CDI is destroyed.
-        assert_eq!(dpe.contexts[exported_idx].state, ContextState::Inactive);
         assert_eq!(
-            dpe.contexts[exported_idx].handle,
+            env.state.contexts[exported_idx].state,
+            ContextState::Inactive
+        );
+        assert_eq!(
+            env.state.contexts[exported_idx].handle,
             ContextHandle::new_invalid()
         );
 
         // The root node should not have been destroyed since it has other children.
-        assert_eq!(dpe.contexts[root_idx].state, ContextState::Active);
-        assert_eq!(dpe.contexts[root_idx].handle, parent_handle);
+        assert_eq!(env.state.contexts[root_idx].state, ContextState::Active);
+        assert_eq!(env.state.contexts[root_idx].handle, parent_handle);
 
-        let validator = DpeValidator { dpe: &mut dpe };
+        let validator = DpeValidator {
+            dpe: &mut env.state,
+        };
         assert!(validator.validate_dpe().is_ok());
     }
 
@@ -1662,20 +1615,16 @@ mod tests {
         // * Active siblings are not destroyed.
         // * The parent is retired, instead of destroyed, since it has active children.
 
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe = DpeInstance::new(
-            &mut env,
+        let mut state = State::new(
             Support::AUTO_INIT
                 | Support::CDI_EXPORT
                 | Support::X509
                 | Support::RETAIN_PARENT_CONTEXT
                 | Support::ROTATE_CONTEXT,
             DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        );
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         // We want to use multiple contexts, so rotate out the default handle for a new handle.
         let Ok(Response::RotateCtx(NewHandleResp {
@@ -1710,7 +1659,8 @@ mod tests {
             );
         }
 
-        let parent_idx = dpe
+        let parent_idx = env
+            .state
             .get_active_context_pos(&parent_handle, TEST_LOCALITIES[0])
             .unwrap();
 
@@ -1731,13 +1681,15 @@ mod tests {
             expected_active_contexts,
         );
 
-        assert_eq!(dpe.contexts[parent_idx].state, ContextState::Retired);
+        assert_eq!(env.state.contexts[parent_idx].state, ContextState::Retired);
         assert_eq!(
-            dpe.contexts[parent_idx].handle,
+            env.state.contexts[parent_idx].handle,
             ContextHandle::new_invalid()
         );
 
-        let validator = DpeValidator { dpe: &mut dpe };
+        let validator = DpeValidator {
+            dpe: &mut env.state,
+        };
         assert!(validator.validate_dpe().is_ok());
     }
 
@@ -1745,10 +1697,6 @@ mod tests {
     fn test_create_ca() {
         for mark_dice_extensions_critical in [true, false] {
             CfiCounter::reset_for_test();
-            let mut env = DpeEnv::<TestTypes> {
-                crypto: RustCryptoImpl::new(),
-                platform: DEFAULT_PLATFORM,
-            };
             let flags = {
                 let mut flags = DpeInstanceFlags::empty();
                 flags.set(
@@ -1757,8 +1705,10 @@ mod tests {
                 );
                 flags
             };
-            let mut dpe =
-                DpeInstance::new(&mut env, Support::X509 | Support::CDI_EXPORT, flags).unwrap();
+            let mut state = State::new(Support::X509 | Support::CDI_EXPORT, flags);
+            let mut env = test_env(&mut state);
+            let mut dpe = DpeInstance::new(&mut env).unwrap();
+
             let init_resp = match InitCtxCmd::new_use_default()
                 .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
                 .unwrap()
@@ -1871,7 +1821,8 @@ mod tests {
                 ..
             })) => {
                 assert_eq!(
-                    dpe.count_contexts(|context: &Context| context.state == ContextState::Active),
+                    env.state
+                        .count_contexts(|context: &Context| context.state == ContextState::Active),
                     Ok(expected_active_child_count)
                 );
                 (handle, parent_handle)

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -3,11 +3,11 @@ use super::CommandExecution;
 use crate::{
     commands::destroy_context,
     context::{ActiveContextArgs, Context, ContextHandle, ContextState, ContextType},
-    dpe_instance::{DpeEnv, DpeInstance, DpeInstanceFlags, DpeTypes},
+    dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
     response::{DeriveContextExportedCdiResp, DeriveContextResp, DpeErrorCode, Response},
     tci::TciMeasurement,
     x509::{create_exported_dpe_cert, CreateDpeCertArgs, CreateDpeCertResult},
-    State, DPE_PROFILE, MAX_CERT_SIZE,
+    DpeFlags, State, DPE_PROFILE, MAX_CERT_SIZE,
 };
 use bitflags::bitflags;
 #[cfg(not(feature = "no-cfi"))]
@@ -322,7 +322,7 @@ impl CommandExecution for DeriveContextCmd {
                         key_label: b"Exported ECC",
                         context: b"Exported ECC",
                         ueid,
-                        dice_extensions_are_critical: env.state.flags.contains(DpeInstanceFlags::MARK_DICE_EXTENSIONS_CRITICAL),
+                        dice_extensions_are_critical: env.state.flags.contains(DpeFlags::MARK_DICE_EXTENSIONS_CRITICAL),
                     };
                     let mut cert = [0; MAX_CERT_SIZE];
                     let CreateDpeCertResult { cert_size, exported_cdi_handle, .. } = create_exported_dpe_cert(
@@ -481,7 +481,7 @@ mod tests {
         CfiCounter::reset_for_test();
         let mut state = State::new(
             Support::AUTO_INIT | Support::INTERNAL_INFO | Support::RETAIN_PARENT_CONTEXT,
-            DpeInstanceFlags::empty(),
+            DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
         let mut dpe = DpeInstance::new(&mut env).unwrap();
@@ -500,7 +500,7 @@ mod tests {
 
         *env.state = State::new(
             Support::AUTO_INIT | Support::INTERNAL_DICE | Support::RETAIN_PARENT_CONTEXT,
-            DpeInstanceFlags::empty(),
+            DpeFlags::empty(),
         );
         dpe = DpeInstance::new(&mut env).unwrap();
 
@@ -518,7 +518,7 @@ mod tests {
 
         *env.state = State::new(
             Support::AUTO_INIT | Support::INTERNAL_INFO | Support::INTERNAL_DICE,
-            DpeInstanceFlags::empty(),
+            DpeFlags::empty(),
         );
         dpe = DpeInstance::new(&mut env).unwrap();
 
@@ -563,7 +563,7 @@ mod tests {
     #[test]
     fn test_max_tcis() {
         CfiCounter::reset_for_test();
-        let mut state = State::new(Support::AUTO_INIT, DpeInstanceFlags::empty());
+        let mut state = State::new(Support::AUTO_INIT, DpeFlags::empty());
         let mut env = test_env(&mut state);
         let mut dpe = DpeInstance::new(&mut env).unwrap();
 
@@ -597,7 +597,7 @@ mod tests {
     #[test]
     fn test_set_child_parent_relationship() {
         CfiCounter::reset_for_test();
-        let mut state = State::new(Support::AUTO_INIT, DpeInstanceFlags::empty());
+        let mut state = State::new(Support::AUTO_INIT, DpeFlags::empty());
         let mut env = test_env(&mut state);
         let mut dpe = DpeInstance::new(&mut env).unwrap();
 
@@ -632,7 +632,7 @@ mod tests {
     #[test]
     fn test_set_other_values() {
         CfiCounter::reset_for_test();
-        let mut state = State::new(Support::AUTO_INIT, DpeInstanceFlags::empty());
+        let mut state = State::new(Support::AUTO_INIT, DpeFlags::empty());
         let mut env = test_env(&mut state);
         let mut dpe = DpeInstance::new(&mut env).unwrap();
 
@@ -659,7 +659,7 @@ mod tests {
     #[test]
     fn test_correct_child_handle() {
         CfiCounter::reset_for_test();
-        let mut state = State::new(Support::AUTO_INIT, DpeInstanceFlags::empty());
+        let mut state = State::new(Support::AUTO_INIT, DpeFlags::empty());
         let mut env = test_env(&mut state);
         let mut dpe = DpeInstance::new(&mut env).unwrap();
 
@@ -707,7 +707,7 @@ mod tests {
                 | Support::AUTO_INIT
                 | Support::ROTATE_CONTEXT
                 | Support::RETAIN_PARENT_CONTEXT,
-            DpeInstanceFlags::empty(),
+            DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
         let mut dpe = DpeInstance::new(&mut env).unwrap();
@@ -797,7 +797,7 @@ mod tests {
         CfiCounter::reset_for_test();
         let mut state = State::new(
             Support::AUTO_INIT | Support::RETAIN_PARENT_CONTEXT,
-            DpeInstanceFlags::empty(),
+            DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
         let mut dpe = DpeInstance::new(&mut env).unwrap();
@@ -941,7 +941,7 @@ mod tests {
         CfiCounter::reset_for_test();
         let mut state = State::new(
             Support::AUTO_INIT | Support::RETAIN_PARENT_CONTEXT,
-            DpeInstanceFlags::empty(),
+            DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
         let mut dpe = DpeInstance::new(&mut env).unwrap();
@@ -964,7 +964,7 @@ mod tests {
         CfiCounter::reset_for_test();
         let mut state = State::new(
             Support::AUTO_INIT | Support::RETAIN_PARENT_CONTEXT,
-            DpeInstanceFlags::empty(),
+            DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
         let mut dpe = DpeInstance::new(&mut env).unwrap();
@@ -1003,7 +1003,7 @@ mod tests {
                 | Support::RECURSIVE
                 | Support::INTERNAL_DICE
                 | Support::INTERNAL_INFO,
-            DpeInstanceFlags::empty(),
+            DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
         let mut dpe = DpeInstance::new(&mut env).unwrap();
@@ -1076,7 +1076,7 @@ mod tests {
                 | Support::RECURSIVE
                 | Support::SIMULATION
                 | Support::RETAIN_PARENT_CONTEXT,
-            DpeInstanceFlags::empty(),
+            DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
         let mut dpe = DpeInstance::new(&mut env).unwrap();
@@ -1156,7 +1156,7 @@ mod tests {
 
         *env.state = State::new(
             Support::AUTO_INIT | Support::CDI_EXPORT | Support::X509,
-            DpeInstanceFlags::empty(),
+            DpeFlags::empty(),
         );
         dpe = DpeInstance::new(&mut env).unwrap();
 
@@ -1182,7 +1182,7 @@ mod tests {
 
         *env.state = State::new(
             Support::AUTO_INIT | Support::INTERNAL_INFO | Support::INTERNAL_DICE | Support::X509,
-            DpeInstanceFlags::empty(),
+            DpeFlags::empty(),
         );
         dpe = DpeInstance::new(&mut env).unwrap();
 
@@ -1231,7 +1231,7 @@ mod tests {
                 | Support::CDI_EXPORT
                 | Support::X509
                 | Support::RETAIN_PARENT_CONTEXT,
-            DpeInstanceFlags::empty(),
+            DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
         let mut dpe = DpeInstance::new(&mut env).unwrap();
@@ -1277,7 +1277,7 @@ mod tests {
                 | Support::CDI_EXPORT
                 | Support::X509
                 | Support::RETAIN_PARENT_CONTEXT,
-            DpeInstanceFlags::empty(),
+            DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
         let mut dpe = DpeInstance::new(&mut env).unwrap();
@@ -1309,7 +1309,7 @@ mod tests {
         // be able to use `DeriveContextFlags::EXPORT_CDI`.
         *env.state = State::new(
             Support::AUTO_INIT | Support::CDI_EXPORT | Support::X509,
-            DpeInstanceFlags::empty(),
+            DpeFlags::empty(),
         );
         dpe = DpeInstance::new(&mut env).unwrap();
 
@@ -1342,7 +1342,7 @@ mod tests {
         // was included.
         *env.state = State::new(
             Support::AUTO_INIT | Support::CDI_EXPORT | Support::X509,
-            DpeInstanceFlags::empty(),
+            DpeFlags::empty(),
         );
         dpe = DpeInstance::new(&mut env).unwrap();
 
@@ -1377,7 +1377,7 @@ mod tests {
         // Create a new env to clear cached exported CDIs
         let mut state = State::new(
             Support::AUTO_INIT | Support::CDI_EXPORT | Support::X509,
-            DpeInstanceFlags::empty(),
+            DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
         let mut dpe = DpeInstance::new(&mut env).unwrap();
@@ -1428,7 +1428,7 @@ mod tests {
         CfiCounter::reset_for_test();
         let mut state = State::new(
             Support::AUTO_INIT | Support::CDI_EXPORT | Support::X509,
-            DpeInstanceFlags::empty(),
+            DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
         let mut dpe = DpeInstance::new(&mut env).unwrap();
@@ -1469,7 +1469,7 @@ mod tests {
                 | Support::CDI_EXPORT
                 | Support::X509
                 | Support::RETAIN_PARENT_CONTEXT,
-            DpeInstanceFlags::empty(),
+            DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
         let mut dpe = DpeInstance::new(&mut env).unwrap();
@@ -1520,7 +1520,7 @@ mod tests {
                 | Support::X509
                 | Support::RETAIN_PARENT_CONTEXT
                 | Support::ROTATE_CONTEXT,
-            DpeInstanceFlags::empty(),
+            DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
         let mut dpe = DpeInstance::new(&mut env).unwrap();
@@ -1621,7 +1621,7 @@ mod tests {
                 | Support::X509
                 | Support::RETAIN_PARENT_CONTEXT
                 | Support::ROTATE_CONTEXT,
-            DpeInstanceFlags::empty(),
+            DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
         let mut dpe = DpeInstance::new(&mut env).unwrap();
@@ -1698,9 +1698,9 @@ mod tests {
         for mark_dice_extensions_critical in [true, false] {
             CfiCounter::reset_for_test();
             let flags = {
-                let mut flags = DpeInstanceFlags::empty();
+                let mut flags = DpeFlags::empty();
                 flags.set(
-                    DpeInstanceFlags::MARK_DICE_EXTENSIONS_CRITICAL,
+                    DpeFlags::MARK_DICE_EXTENSIONS_CRITICAL,
                     mark_dice_extensions_critical,
                 );
                 flags

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -104,11 +104,9 @@ mod tests {
             tests::PROFILES, Command, CommandHdr, DeriveContextCmd, DeriveContextFlags, InitCtxCmd,
         },
         context::{Context, ContextState},
-        dpe_instance::{
-            tests::{test_env, test_state, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES},
-            DpeInstanceFlags,
+        dpe_instance::tests::{
+            test_env, test_state, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES,
         },
-        support::Support,
         DPE_PROFILE,
     };
     use caliptra_cfi_lib_git::CfiCounter;

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -4,7 +4,7 @@ use crate::{
     context::{Context, ContextHandle, ContextState},
     dpe_instance::{flags_iter, DpeEnv, DpeInstance, DpeTypes},
     response::{DpeErrorCode, Response},
-    MAX_HANDLES,
+    State, MAX_HANDLES,
 };
 #[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_derive_git::cfi_impl_fn;
@@ -28,11 +28,11 @@ pub struct DestroyCtxCmd {
 
 pub(crate) fn destroy_context(
     context_handle: &ContextHandle,
-    dpe: &mut DpeInstance,
+    state: &mut State,
     locality: u32,
 ) -> Result<(), DpeErrorCode> {
-    let idx = dpe.get_active_context_pos(context_handle, locality)?;
-    let context = &dpe.contexts[idx];
+    let idx = state.get_active_context_pos(context_handle, locality)?;
+    let context = &state.contexts[idx];
     // Make sure the command is coming from the right locality.
     if context.locality != locality {
         return Err(DpeErrorCode::InvalidLocality);
@@ -47,10 +47,10 @@ pub(crate) fn destroy_context(
     loop {
         if parent_idx == Context::ROOT_INDEX as usize {
             break;
-        } else if parent_idx >= dpe.contexts.len() {
+        } else if parent_idx >= state.contexts.len() {
             return Err(DpeErrorCode::InternalError);
         }
-        let parent_context = &dpe.contexts[parent_idx];
+        let parent_context = &state.contexts[parent_idx];
         // make sure the retired context does not have other active child contexts
         let child_context_count = flags_iter(parent_context.children, MAX_HANDLES).count();
         if parent_context.state == ContextState::Retired && cfi_launder(child_context_count) == 1 {
@@ -66,9 +66,9 @@ pub(crate) fn destroy_context(
 
     // create a bitmask indicating that the current context, all its descendants, and its consecutive
     // retired parent contexts should be destroyed
-    let to_destroy = (1 << idx) | dpe.get_descendants(context)? | retired_contexts;
+    let to_destroy = (1 << idx) | state.get_descendants(context)? | retired_contexts;
 
-    for (idx, c) in dpe.contexts.iter_mut().enumerate() {
+    for (idx, c) in state.contexts.iter_mut().enumerate() {
         // Clears all the to_destroy bits in the children of every context
         c.children &= !cfi_launder(to_destroy);
         if to_destroy & (1 << idx) != 0 {
@@ -86,10 +86,10 @@ impl CommandExecution for DestroyCtxCmd {
     fn execute(
         &self,
         dpe: &mut DpeInstance,
-        _env: &mut DpeEnv<impl DpeTypes>,
+        env: &mut DpeEnv<impl DpeTypes>,
         locality: u32,
     ) -> Result<Response, DpeErrorCode> {
-        destroy_context(&self.handle, dpe, locality)?;
+        destroy_context(&self.handle, env.state, locality)?;
         Ok(Response::DestroyCtx(
             dpe.response_hdr(DpeErrorCode::NoError),
         ))
@@ -101,19 +101,17 @@ mod tests {
     use super::*;
     use crate::{
         commands::{
-            tests::{DEFAULT_PLATFORM, PROFILES},
-            Command, CommandHdr, DeriveContextCmd, DeriveContextFlags, InitCtxCmd,
+            tests::PROFILES, Command, CommandHdr, DeriveContextCmd, DeriveContextFlags, InitCtxCmd,
         },
         context::{Context, ContextState},
         dpe_instance::{
-            tests::{TestTypes, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES},
+            tests::{test_env, test_state, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES},
             DpeInstanceFlags,
         },
-        support::{test::SUPPORT, Support},
+        support::Support,
         DPE_PROFILE,
     };
     use caliptra_cfi_lib_git::CfiCounter;
-    use crypto::RustCryptoImpl;
     use zerocopy::IntoBytes;
 
     const TEST_DESTROY_CTX_CMD: DestroyCtxCmd = DestroyCtxCmd {
@@ -138,12 +136,9 @@ mod tests {
     #[test]
     fn test_destroy_context() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe =
-            DpeInstance::new(&mut env, Support::default(), DpeInstanceFlags::empty()).unwrap();
+        let mut state = State::default();
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         InitCtxCmd::new_use_default()
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -159,8 +154,8 @@ mod tests {
         );
 
         // create two dummy contexts at indices 0 and 1, with 1 being the child of 0
-        activate_dummy_context(&mut dpe, 0, Context::ROOT_INDEX, &TEST_HANDLE, &[1]);
-        activate_dummy_context(&mut dpe, 1, 0, &ContextHandle::default(), &[]);
+        activate_dummy_context(&mut env.state, 0, Context::ROOT_INDEX, &TEST_HANDLE, &[1]);
+        activate_dummy_context(&mut env.state, 1, 0, &ContextHandle::default(), &[]);
         // destroy context[1]
         assert_eq!(
             Ok(Response::DestroyCtx(
@@ -171,8 +166,8 @@ mod tests {
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
-        assert_eq!(dpe.contexts[1].state, ContextState::Inactive);
-        assert_eq!(dpe.contexts[0].children, 0);
+        assert_eq!(env.state.contexts[1].state, ContextState::Inactive);
+        assert_eq!(env.state.contexts[0].children, 0);
         // destroy context[0]
         assert_eq!(
             Ok(Response::DestroyCtx(
@@ -183,52 +178,52 @@ mod tests {
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
-        assert_eq!(dpe.contexts[0].state, ContextState::Inactive);
+        assert_eq!(env.state.contexts[0].state, ContextState::Inactive);
 
         activate_dummy_context(
-            &mut dpe,
+            &mut env.state,
             0,
             Context::ROOT_INDEX,
             &ContextHandle::default(),
             &[1, 2],
         );
         activate_dummy_context(
-            &mut dpe,
+            &mut env.state,
             1,
             0,
             &ContextHandle([1; ContextHandle::SIZE]),
             &[3, 4],
         );
         activate_dummy_context(
-            &mut dpe,
+            &mut env.state,
             2,
             0,
             &ContextHandle([2; ContextHandle::SIZE]),
             &[5, 6],
         );
         activate_dummy_context(
-            &mut dpe,
+            &mut env.state,
             3,
             1,
             &ContextHandle([3; ContextHandle::SIZE]),
             &[],
         );
         activate_dummy_context(
-            &mut dpe,
+            &mut env.state,
             4,
             1,
             &ContextHandle([4; ContextHandle::SIZE]),
             &[],
         );
         activate_dummy_context(
-            &mut dpe,
+            &mut env.state,
             5,
             2,
             &ContextHandle([5; ContextHandle::SIZE]),
             &[],
         );
         activate_dummy_context(
-            &mut dpe,
+            &mut env.state,
             6,
             2,
             &ContextHandle([6; ContextHandle::SIZE]),
@@ -245,34 +240,34 @@ mod tests {
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
-        assert_eq!(dpe.contexts[0].state, ContextState::Inactive);
-        assert_eq!(dpe.contexts[1].state, ContextState::Inactive);
-        assert_eq!(dpe.contexts[2].state, ContextState::Inactive);
-        assert_eq!(dpe.contexts[3].state, ContextState::Inactive);
-        assert_eq!(dpe.contexts[4].state, ContextState::Inactive);
-        assert_eq!(dpe.contexts[5].state, ContextState::Inactive);
-        assert_eq!(dpe.contexts[6].state, ContextState::Inactive);
-        assert_eq!(dpe.contexts[0].children, 0);
-        assert_eq!(dpe.contexts[1].children, 0);
-        assert_eq!(dpe.contexts[2].children, 0);
-        assert_eq!(dpe.contexts[3].children, 0);
+        assert_eq!(env.state.contexts[0].state, ContextState::Inactive);
+        assert_eq!(env.state.contexts[1].state, ContextState::Inactive);
+        assert_eq!(env.state.contexts[2].state, ContextState::Inactive);
+        assert_eq!(env.state.contexts[3].state, ContextState::Inactive);
+        assert_eq!(env.state.contexts[4].state, ContextState::Inactive);
+        assert_eq!(env.state.contexts[5].state, ContextState::Inactive);
+        assert_eq!(env.state.contexts[6].state, ContextState::Inactive);
+        assert_eq!(env.state.contexts[0].children, 0);
+        assert_eq!(env.state.contexts[1].children, 0);
+        assert_eq!(env.state.contexts[2].children, 0);
+        assert_eq!(env.state.contexts[3].children, 0);
 
         activate_dummy_context(
-            &mut dpe,
+            &mut env.state,
             0,
             Context::ROOT_INDEX,
             &ContextHandle::default(),
             &[1, 2],
         );
         activate_dummy_context(
-            &mut dpe,
+            &mut env.state,
             1,
             0,
             &ContextHandle([1; ContextHandle::SIZE]),
             &[],
         );
         activate_dummy_context(
-            &mut dpe,
+            &mut env.state,
             2,
             0,
             &ContextHandle([2; ContextHandle::SIZE]),
@@ -288,19 +283,17 @@ mod tests {
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
-        assert_eq!(dpe.contexts[1].state, ContextState::Inactive);
+        assert_eq!(env.state.contexts[1].state, ContextState::Inactive);
         // check that context[2] is still a child of context[0]
-        assert_eq!(dpe.contexts[0].children, 1 << 2);
+        assert_eq!(env.state.contexts[0].children, 1 << 2);
     }
 
     #[test]
     fn test_retired_parent_contexts_destroyed() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe = DpeInstance::new(&mut env, SUPPORT, DpeInstanceFlags::empty()).unwrap();
+        let mut state = test_state();
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         // create new context while preserving auto-initialized context
         let handle_1 = match (DeriveContextCmd {
@@ -355,21 +348,20 @@ mod tests {
         // destroyed since they are in the chain of consecutive retired parents of the destroyed
         // context.
         assert_eq!(
-            dpe.count_contexts(|ctx| ctx.state != ContextState::Inactive)
+            env.state
+                .count_contexts(|ctx| ctx.state != ContextState::Inactive)
                 .unwrap(),
             1
         );
-        assert_eq!(dpe.contexts[2].state, ContextState::Inactive);
+        assert_eq!(env.state.contexts[2].state, ContextState::Inactive);
     }
 
     #[test]
     fn test_retired_parent_context_not_destroyed_if_it_has_other_active_children() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe = DpeInstance::new(&mut env, SUPPORT, DpeInstanceFlags::empty()).unwrap();
+        let mut state = test_state();
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         // create new context while preserving auto-initialized context
         let parent_handle = match (DeriveContextCmd {
@@ -423,26 +415,27 @@ mod tests {
         // Since the retired handle has another active context apart from handle_b, it
         // shouldn't be destroyed.
         assert_eq!(
-            dpe.count_contexts(|ctx| ctx.state != ContextState::Inactive)
+            env.state
+                .count_contexts(|ctx| ctx.state != ContextState::Inactive)
                 .unwrap(),
             3
         );
-        assert_eq!(dpe.contexts[1].state, ContextState::Retired);
+        assert_eq!(env.state.contexts[1].state, ContextState::Retired);
     }
 
     fn activate_dummy_context(
-        dpe: &mut DpeInstance,
+        state: &mut State,
         idx: usize,
         parent_idx: u8,
         handle: &ContextHandle,
         children: &[u8],
     ) {
-        dpe.contexts[idx].state = ContextState::Active;
-        dpe.contexts[idx].handle = *handle;
-        dpe.contexts[idx].parent_idx = parent_idx;
+        state.contexts[idx].state = ContextState::Active;
+        state.contexts[idx].handle = *handle;
+        state.contexts[idx].parent_idx = parent_idx;
         for i in children {
-            let children = dpe.contexts[idx].add_child(*i as usize).unwrap();
-            dpe.contexts[idx].children = children;
+            let children = state.contexts[idx].add_child(*i as usize).unwrap();
+            state.contexts[idx].children = children;
         }
     }
 }

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -52,18 +52,10 @@ impl CommandExecution for GetCertificateChainCmd {
 mod tests {
     use super::*;
     use crate::{
-        commands::{
-            tests::{DEFAULT_PLATFORM, PROFILES},
-            Command, CommandHdr,
-        },
-        dpe_instance::{
-            tests::{TestTypes, TEST_LOCALITIES},
-            DpeInstanceFlags,
-        },
-        support::test::SUPPORT,
+        commands::{tests::PROFILES, Command, CommandHdr},
+        dpe_instance::tests::{test_env, test_state, TEST_LOCALITIES},
     };
     use caliptra_cfi_lib_git::CfiCounter;
-    use crypto::RustCryptoImpl;
     use zerocopy::IntoBytes;
 
     const TEST_GET_CERTIFICATE_CHAIN_CMD: GetCertificateChainCmd = GetCertificateChainCmd {
@@ -91,11 +83,9 @@ mod tests {
     #[test]
     fn test_fails_if_size_greater_than_max_chunk_size() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe = DpeInstance::new(&mut env, SUPPORT, DpeInstanceFlags::empty()).unwrap();
+        let mut state = test_state();
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         assert_eq!(
             Err(DpeErrorCode::InvalidArgument),

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -115,12 +115,9 @@ mod tests {
     use crate::{
         commands::{tests::PROFILES, Command, CommandHdr},
         context::ContextState,
-        dpe_instance::{
-            tests::{test_env, TEST_LOCALITIES},
-            DpeInstanceFlags,
-        },
+        dpe_instance::tests::{test_env, TEST_LOCALITIES},
         support::Support,
-        State,
+        DpeFlags, State,
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use zerocopy::IntoBytes;
@@ -178,7 +175,7 @@ mod tests {
         );
 
         // Change to support simulation.
-        *env.state = State::new(Support::SIMULATION, DpeInstanceFlags::empty());
+        *env.state = State::new(Support::SIMULATION, DpeFlags::empty());
         let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         // Try setting both flags.

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -58,8 +58,8 @@ impl CommandExecution for InitCtxCmd {
         locality: u32,
     ) -> Result<Response, DpeErrorCode> {
         // This function can only be called once for non-simulation contexts.
-        if (self.flag_is_default() && dpe.has_initialized())
-            || (self.flag_is_simulation() && !dpe.support.simulation())
+        if (self.flag_is_default() && env.state.has_initialized())
+            || (self.flag_is_simulation() && !env.state.support.simulation())
         {
             return Err(DpeErrorCode::ArgumentNotSupported);
         }
@@ -73,24 +73,25 @@ impl CommandExecution for InitCtxCmd {
 
         cfg_if! {
             if #[cfg(not(feature = "no-cfi"))] {
-                cfi_assert!(!self.flag_is_default() || !dpe.has_initialized());
-                cfi_assert!(!self.flag_is_simulation() || dpe.support.simulation());
+                cfi_assert!(!self.flag_is_default() || !env.state.has_initialized());
+                cfi_assert!(!self.flag_is_simulation() || env.state.support.simulation());
                 cfi_assert!(self.flag_is_default() ^ self.flag_is_simulation());
             }
         }
 
-        let idx = dpe
+        let idx = env
+            .state
             .get_next_inactive_context_pos()
             .ok_or(DpeErrorCode::MaxTcis)?;
         let (context_type, handle) = if self.flag_is_default() {
-            dpe.has_initialized = true.into();
+            env.state.has_initialized = true.into();
             (ContextType::Normal, ContextHandle::default())
         } else {
             // Simulation.
             (ContextType::Simulation, dpe.generate_new_handle(env)?)
         };
 
-        dpe.contexts[idx].activate(&ActiveContextArgs {
+        env.state.contexts[idx].activate(&ActiveContextArgs {
             context_type,
             locality,
             handle: &handle,
@@ -112,19 +113,16 @@ impl CommandExecution for InitCtxCmd {
 mod tests {
     use super::*;
     use crate::{
-        commands::{
-            tests::{DEFAULT_PLATFORM, PROFILES},
-            Command, CommandHdr,
-        },
+        commands::{tests::PROFILES, Command, CommandHdr},
         context::ContextState,
         dpe_instance::{
-            tests::{TestTypes, TEST_LOCALITIES},
+            tests::{test_env, TEST_LOCALITIES},
             DpeInstanceFlags,
         },
         support::Support,
+        State,
     };
     use caliptra_cfi_lib_git::CfiCounter;
-    use crypto::RustCryptoImpl;
     use zerocopy::IntoBytes;
 
     const TEST_INIT_CTX_CMD: InitCtxCmd = InitCtxCmd(0x1234_5678);
@@ -147,12 +145,9 @@ mod tests {
     #[test]
     fn test_initialize_context() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe =
-            DpeInstance::new(&mut env, Support::default(), DpeInstanceFlags::empty()).unwrap();
+        let mut state = State::default();
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         let handle = match InitCtxCmd::new_use_default()
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -183,8 +178,8 @@ mod tests {
         );
 
         // Change to support simulation.
-        let mut dpe =
-            DpeInstance::new(&mut env, Support::SIMULATION, DpeInstanceFlags::empty()).unwrap();
+        *env.state = State::new(Support::SIMULATION, DpeInstanceFlags::empty());
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         // Try setting both flags.
         assert_eq!(
@@ -197,7 +192,7 @@ mod tests {
         );
 
         // Set all handles as active.
-        for context in dpe.contexts.iter_mut() {
+        for context in env.state.contexts.iter_mut() {
             context.state = ContextState::Active;
         }
 

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -130,11 +130,11 @@ mod tests {
     use super::*;
     use crate::{
         commands::{tests::PROFILES, Command, CommandHdr, InitCtxCmd},
-        dpe_instance::{
-            tests::{test_env, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES},
-            DpeInstanceFlags,
+        dpe_instance::tests::{
+            test_env, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES,
         },
         support::Support,
+        DpeFlags,
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use zerocopy::IntoBytes;
@@ -176,7 +176,7 @@ mod tests {
         );
 
         // Make a new instance that supports RotateContext.
-        *env.state = State::new(Support::ROTATE_CONTEXT, DpeInstanceFlags::empty());
+        *env.state = State::new(Support::ROTATE_CONTEXT, DpeFlags::empty());
         let mut dpe = DpeInstance::new(&mut env).unwrap();
         InitCtxCmd::new_use_default()
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -11,8 +11,8 @@ use crate::{
     context::{ChildToRootIter, Context, ContextHandle, ContextState},
     response::{DpeErrorCode, GetProfileResp, Response, ResponseHdr},
     support::Support,
-    tci::{TciMeasurement, TciNodeData},
-    DpeProfile, U8Bool, DPE_PROFILE, MAX_HANDLES,
+    tci::TciMeasurement,
+    DpeProfile, State, DPE_PROFILE, MAX_HANDLES,
 };
 use bitflags::bitflags;
 #[cfg(not(feature = "no-cfi"))]
@@ -21,12 +21,11 @@ use caliptra_cfi_lib_git::cfi_launder;
 #[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
 use cfg_if::cfg_if;
-use core::mem::align_of;
 use crypto::{Crypto, Digest, Hasher};
 use platform::Platform;
 #[cfg(not(feature = "disable_internal_dice"))]
 use platform::MAX_CHUNK_SIZE;
-use zerocopy::{Immutable, IntoBytes, KnownLayout, TryFromBytes};
+use zerocopy::IntoBytes;
 use zeroize::Zeroize;
 
 pub trait DpeTypes {
@@ -41,6 +40,7 @@ pub trait DpeTypes {
 pub struct DpeEnv<'a, T: DpeTypes + 'a> {
     pub crypto: T::Crypto<'a>,
     pub platform: T::Platform<'a>,
+    pub state: &'a mut State,
 }
 
 #[repr(C)]
@@ -63,26 +63,11 @@ bitflags! {
     }
 }
 
-#[repr(C, align(4))]
-#[derive(IntoBytes, TryFromBytes, KnownLayout, Immutable, Zeroize)]
 pub struct DpeInstance {
-    /// Layout version of this structure. If the layout of this structure changes, Self::VERSION
-    /// must be updated.
-    pub version: u32,
     pub profile: DpeProfile,
-    pub contexts: [Context; MAX_HANDLES],
-    pub support: Support,
-    pub flags: DpeInstanceFlags,
-    /// Can only successfully execute the initialize context command for non-simulation (i.e.
-    /// `InitializeContext(simulation=false)`) once per reset cycle.
-    pub has_initialized: U8Bool,
-    // unused buffer added to make DpeInstance word aligned and remove padding
-    pub reserved: [u8; 1],
 }
-const _: () = assert!(align_of::<DpeInstance>() == 4);
 
 impl DpeInstance {
-    pub const VERSION: u32 = 1;
     const MAX_NEW_HANDLE_ATTEMPTS: usize = 8;
 
     /// Create a new DPE instance.
@@ -93,29 +78,17 @@ impl DpeInstance {
     /// * `support` - optional functionality the instance supports
     /// * `flags` - configures `Self` behaviors.
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
-    pub fn new(
-        env: &mut DpeEnv<impl DpeTypes>,
-        support: Support,
-        flags: DpeInstanceFlags,
-    ) -> Result<DpeInstance, DpeErrorCode> {
-        let updated_support = support.preprocess_support();
-        const CONTEXT_INITIALIZER: Context = Context::new();
-        let mut dpe = DpeInstance {
-            version: Self::VERSION,
+    pub fn new(env: &mut DpeEnv<impl DpeTypes>) -> Result<Self, DpeErrorCode> {
+        let mut dpe = Self {
             profile: DPE_PROFILE,
-            contexts: [CONTEXT_INITIALIZER; MAX_HANDLES],
-            support: updated_support,
-            flags,
-            has_initialized: false.into(),
-            reserved: [0; 1],
         };
 
-        if dpe.support.auto_init() {
+        if env.state.support.auto_init() {
             let locality = env.platform.get_auto_init_locality()?;
             InitCtxCmd::new_use_default().execute(&mut dpe, env, locality)?;
         } else {
             #[cfg(not(feature = "no-cfi"))]
-            cfi_assert!(!dpe.support.auto_init());
+            cfi_assert!(!env.state.support.auto_init());
         }
         Ok(dpe)
     }
@@ -133,24 +106,23 @@ impl DpeInstance {
     #[cfg(not(feature = "disable_auto_init"))]
     pub fn new_auto_init(
         env: &mut DpeEnv<impl DpeTypes>,
-        support: Support,
         tci_type: u32,
         auto_init_measurement: [u8; DPE_PROFILE.hash_size()],
-        flags: DpeInstanceFlags,
-    ) -> Result<DpeInstance, DpeErrorCode> {
-        let updated_support = support.preprocess_support();
+    ) -> Result<Self, DpeErrorCode> {
         // auto-init must be supported to add an auto init measurement
-        if !updated_support.auto_init() {
+        if !env.state.support.auto_init() {
             return Err(DpeErrorCode::ArgumentNotSupported);
         } else {
             #[cfg(not(feature = "no-cfi"))]
-            cfi_assert!(updated_support.auto_init());
+            cfi_assert!(env.state.support.auto_init());
         }
-        let mut dpe = Self::new(env, updated_support, flags)?;
+        let dpe = Self::new(env)?;
 
         let locality = env.platform.get_auto_init_locality()?;
-        let idx = dpe.get_active_context_pos(&ContextHandle::default(), locality)?;
-        let mut tmp_context = dpe.contexts[idx];
+        let idx = env
+            .state
+            .get_active_context_pos(&ContextHandle::default(), locality)?;
+        let mut tmp_context = env.state.contexts[idx];
         // add measurement to auto-initialized context
         dpe.add_tci_measurement(
             env,
@@ -158,24 +130,21 @@ impl DpeInstance {
             &TciMeasurement(auto_init_measurement),
             locality,
         )?;
-        dpe.contexts[idx] = tmp_context;
-        dpe.contexts[idx].tci.tci_type = tci_type;
+        env.state.contexts[idx] = tmp_context;
+        env.state.contexts[idx].tci.tci_type = tci_type;
         Ok(dpe)
-    }
-
-    pub fn has_initialized(&self) -> bool {
-        self.has_initialized.get()
     }
 
     pub fn get_profile(
         &self,
         platform: &mut impl Platform,
+        support: Support,
     ) -> Result<GetProfileResp, DpeErrorCode> {
         let vendor_id = platform.get_vendor_id()?;
         let vendor_sku = platform.get_vendor_sku()?;
         Ok(GetProfileResp::new(
             self.profile,
-            self.support.bits(),
+            support.bits(),
             vendor_id,
             vendor_sku,
         ))
@@ -197,7 +166,9 @@ impl DpeInstance {
     ) -> Result<Response, DpeErrorCode> {
         let command = self.deserialize_command(cmd)?;
         let resp = match cfi_launder(command) {
-            Command::GetProfile => Ok(Response::GetProfile(self.get_profile(&mut env.platform)?)),
+            Command::GetProfile => Ok(Response::GetProfile(
+                self.get_profile(&mut env.platform, env.state.support)?,
+            )),
             Command::InitCtx(cmd) => cmd.execute(self, env, locality),
             Command::DeriveContext(cmd) => cmd.execute(self, env, locality),
             Command::CertifyKey(cmd) => cmd.execute(self, env, locality),
@@ -226,91 +197,6 @@ impl DpeInstance {
         Command::deserialize(self.profile, cmd)
     }
 
-    /// Finds the index of the context having `handle` in `locality`
-    /// Inlined so the callsite optimizer knows that idx < self.contexts.len()
-    /// and won't insert possible call to panic.
-    ///
-    /// # Arguments
-    ///
-    /// * `handle` - handle to search
-    /// * `locality` - locality to search
-    #[inline(always)]
-    pub fn get_active_context_pos(
-        &self,
-        handle: &ContextHandle,
-        locality: u32,
-    ) -> Result<usize, DpeErrorCode> {
-        let idx = self.get_active_context_pos_internal(handle, locality)?;
-        if idx >= self.contexts.len() {
-            return Err(DpeErrorCode::InternalError);
-        }
-        Ok(idx)
-    }
-
-    fn get_active_context_pos_internal(
-        &self,
-        handle: &ContextHandle,
-        locality: u32,
-    ) -> Result<usize, DpeErrorCode> {
-        // find all active contexts whose localities match the locality parameter
-        let mut valid_localities = self
-            .contexts
-            .iter()
-            .enumerate()
-            .filter(|(_, context)| {
-                context.state == ContextState::Active && context.locality == locality
-            })
-            .peekable();
-        if valid_localities.peek().is_none() {
-            return Err(DpeErrorCode::InvalidLocality);
-        }
-
-        // filter down the contexts with valid localities based on their context handle matching the input context handle
-        // the locality and handle filters are separated so that we can return InvalidHandle or InvalidLocality upon getting no valid contexts accordingly
-        let mut valid_handles_and_localities = valid_localities
-            .filter(|(_, context)| context.handle.equals(handle))
-            .peekable();
-        if valid_handles_and_localities.peek().is_none() {
-            return Err(DpeErrorCode::InvalidHandle);
-        }
-        let (i, _) = valid_handles_and_localities
-            .find(|(_, context)| {
-                context.state == ContextState::Active
-                    && context.handle.equals(handle)
-                    && context.locality == locality
-            })
-            .ok_or(DpeErrorCode::InternalError)?;
-        Ok(i)
-    }
-
-    pub(crate) fn get_next_inactive_context_pos(&self) -> Option<usize> {
-        self.contexts
-            .iter()
-            .position(|context| context.state == ContextState::Inactive)
-    }
-
-    /// Recursive function that will return all of `context`'s descendants
-    ///
-    /// # Arguments
-    ///
-    /// * `context` - context to get descendants for
-    ///
-    /// Returns a u32 representing a bitmap of the node indices.
-    pub(crate) fn get_descendants(&self, context: &Context) -> Result<u32, DpeErrorCode> {
-        if context.state == ContextState::Inactive {
-            return Err(DpeErrorCode::InvalidHandle);
-        }
-
-        let mut descendants = context.children;
-        for idx in flags_iter(context.children, MAX_HANDLES) {
-            if idx >= self.contexts.len() {
-                return Err(DpeErrorCode::InternalError);
-            }
-            descendants |= cfi_launder(self.get_descendants(&self.contexts[idx])?);
-        }
-        Ok(descendants)
-    }
-
     /// Generates a random context handle that is unique from all other context handles
     ///
     /// # Arguments
@@ -323,7 +209,8 @@ impl DpeInstance {
         for _ in 0..Self::MAX_NEW_HANDLE_ATTEMPTS {
             let mut handle = ContextHandle::default();
             env.crypto.rand_bytes(&mut handle.0)?;
-            if !handle.is_default() && !self.contexts.iter().any(|c| c.handle.equals(&handle)) {
+            if !handle.is_default() && !env.state.contexts.iter().any(|c| c.handle.equals(&handle))
+            {
                 return Ok(handle);
             }
         }
@@ -344,49 +231,13 @@ impl DpeInstance {
         if idx >= MAX_HANDLES {
             return Err(DpeErrorCode::MaxTcis);
         }
-        if !self.contexts[idx].handle.is_default() {
-            self.contexts[idx].handle = self.generate_new_handle(env)?;
+        if !env.state.contexts[idx].handle.is_default() {
+            env.state.contexts[idx].handle = self.generate_new_handle(env)?;
         } else {
             #[cfg(not(feature = "no-cfi"))]
-            cfi_assert!(self.contexts[idx].handle.is_default());
+            cfi_assert!(env.state.contexts[idx].handle.is_default());
         }
         Ok(())
-    }
-
-    /// Get the TCI nodes from the context at `start_idx` to the root node following parent
-    /// links. These are the nodes that should contribute to CDI and key
-    /// derivation for the context at `start_idx`.
-    ///
-    /// # Arguments
-    ///
-    /// * `start_idx` - Index into context array
-    /// * `nodes` - Array to write TCI nodes to
-    ///
-    /// Returns the number of TCIs written to `nodes`
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
-    pub(crate) fn get_tcb_nodes(
-        &self,
-        start_idx: usize,
-        nodes: &mut [TciNodeData],
-    ) -> Result<usize, DpeErrorCode> {
-        let mut out_idx = 0;
-
-        for status in ChildToRootIter::new(start_idx, &self.contexts) {
-            let curr = status?;
-            if out_idx >= nodes.len() {
-                return Err(DpeErrorCode::InternalError);
-            }
-
-            nodes[out_idx] = curr.tci;
-            out_idx += 1;
-        }
-
-        if out_idx > nodes.len() {
-            return Err(DpeErrorCode::InternalError);
-        }
-        nodes[..out_idx].reverse();
-
-        Ok(out_idx)
     }
 
     /// Adds `measurement` to `context`. The current TCI is the measurement and
@@ -446,10 +297,11 @@ impl DpeInstance {
     fn serialize_internal_input_info(
         &self,
         platform: &mut impl Platform,
+        support: Support,
         internal_input_info: &mut [u8; INTERNAL_INPUT_INFO_SIZE],
     ) -> Result<(), DpeErrorCode> {
         // Internal DPE Info contains get profile response fields as well as the DPE_PROFILE
-        let profile = self.get_profile(platform)?;
+        let profile = self.get_profile(platform, support)?;
         let profile_bytes = profile.as_bytes();
         internal_input_info
             .get_mut(..profile_bytes.len())
@@ -484,7 +336,7 @@ impl DpeInstance {
         let mut uses_internal_input_dice = false;
 
         // Hash each node.
-        for status in ChildToRootIter::new(start_idx, &self.contexts) {
+        for status in ChildToRootIter::new(start_idx, &env.state.contexts) {
             let context = status?;
 
             hasher.update(context.tci.as_bytes())?;
@@ -503,7 +355,11 @@ impl DpeInstance {
         #[cfg(not(feature = "disable_internal_info"))]
         if cfi_launder(uses_internal_input_info) {
             let mut internal_input_info = [0u8; INTERNAL_INPUT_INFO_SIZE];
-            self.serialize_internal_input_info(&mut env.platform, &mut internal_input_info)?;
+            self.serialize_internal_input_info(
+                &mut env.platform,
+                env.state.support,
+                &mut internal_input_info,
+            )?;
             hasher.update(&internal_input_info[..INTERNAL_INPUT_INFO_SIZE])?;
         }
 
@@ -522,15 +378,6 @@ impl DpeInstance {
         }
 
         Ok(hasher.finish()?)
-    }
-
-    /// Count number of contexts satisfying some predicate
-    ///
-    /// # Arguments
-    ///
-    /// * `context_pred` - A predicate on a context used to determine contexts to count
-    pub fn count_contexts(&self, f: impl Fn(&Context) -> bool) -> Result<usize, DpeErrorCode> {
-        Ok(self.contexts.iter().filter(|context| f(context)).count())
     }
 }
 
@@ -594,14 +441,24 @@ pub mod tests {
 
     pub const TEST_LOCALITIES: [u32; 2] = [AUTO_INIT_LOCALITY, u32::from_be_bytes(*b"OTHR")];
 
+    pub fn test_env(state: &mut State) -> DpeEnv<TestTypes> {
+        DpeEnv::<TestTypes> {
+            crypto: RustCryptoImpl::new(),
+            platform: DEFAULT_PLATFORM,
+            state,
+        }
+    }
+
+    pub fn test_state() -> State {
+        State::new(SUPPORT, DpeInstanceFlags::empty())
+    }
+
     #[test]
     fn test_execute_serialized_command() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe = DpeInstance::new(&mut env, SUPPORT, DpeInstanceFlags::empty()).unwrap();
+        let mut state = test_state();
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         assert_eq!(
             Response::GetProfile(GetProfileResp::new(
@@ -638,68 +495,25 @@ pub mod tests {
     #[test]
     fn test_get_profile() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let dpe = DpeInstance::new(&mut env, SUPPORT, DpeInstanceFlags::empty()).unwrap();
-        let profile = dpe.get_profile(&mut env.platform).unwrap();
+        let mut state = test_state();
+        let mut env = test_env(&mut state);
+        let dpe = DpeInstance::new(&mut env).unwrap();
+        let profile = dpe
+            .get_profile(&mut env.platform, env.state.support)
+            .unwrap();
         assert_eq!(profile.major_version, CURRENT_PROFILE_MAJOR_VERSION);
         assert_eq!(profile.flags, SUPPORT.bits());
     }
 
     #[test]
-    fn test_get_active_context_index() {
-        CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe =
-            DpeInstance::new(&mut env, Support::default(), DpeInstanceFlags::empty()).unwrap();
-        let expected_index = 7;
-        dpe.contexts[expected_index].handle = SIMULATION_HANDLE;
-
-        let locality = AUTO_INIT_LOCALITY;
-        // Has not been activated.
-        assert!(dpe
-            .get_active_context_pos(&SIMULATION_HANDLE, locality)
-            .is_err());
-
-        // Shouldn't be able to find it if it is retired either.
-        dpe.contexts[expected_index].state = ContextState::Retired;
-        assert!(dpe
-            .get_active_context_pos(&SIMULATION_HANDLE, locality)
-            .is_err());
-
-        // Mark it active, but check the wrong locality.
-        let locality = 2;
-        dpe.contexts[expected_index].state = ContextState::Active;
-        assert!(dpe
-            .get_active_context_pos(&SIMULATION_HANDLE, locality)
-            .is_err());
-
-        // Should find it now.
-        dpe.contexts[expected_index].locality = locality;
-        let idx = dpe
-            .get_active_context_pos(&SIMULATION_HANDLE, locality)
-            .unwrap();
-        assert_eq!(expected_index, idx);
-    }
-
-    #[test]
     fn test_add_tci_measurement() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-
-        let mut dpe =
-            DpeInstance::new(&mut env, Support::AUTO_INIT, DpeInstanceFlags::empty()).unwrap();
+        let mut state = State::new(Support::AUTO_INIT, DpeInstanceFlags::empty());
+        let mut env = test_env(&mut state);
+        let dpe = DpeInstance::new(&mut env).unwrap();
 
         let data = [1; DPE_PROFILE.hash_size()];
-        let mut context = dpe.contexts[0];
+        let mut context = env.state.contexts[0];
         dpe.add_tci_measurement(
             &mut env,
             &mut context,
@@ -707,7 +521,7 @@ pub mod tests {
             TEST_LOCALITIES[0],
         )
         .unwrap();
-        dpe.contexts[0] = context;
+        env.state.contexts[0] = context;
         assert_eq!(data, context.tci.tci_current.0);
 
         // Compute cumulative.
@@ -728,7 +542,7 @@ pub mod tests {
         )
         .unwrap();
         // Make sure the current TCI was updated correctly.
-        dpe.contexts[0] = context;
+        env.state.contexts[0] = context;
         assert_eq!(data, context.tci.tci_current.0);
 
         let mut hasher = env.crypto.hash_initialize(DPE_PROFILE.alg_len()).unwrap();
@@ -741,70 +555,11 @@ pub mod tests {
     }
 
     #[test]
-    fn test_get_descendants() {
-        CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe =
-            DpeInstance::new(&mut env, Support::default(), DpeInstanceFlags::empty()).unwrap();
-        let root = 7;
-        let child_1 = 3;
-        let child_1_1 = 0;
-        let child_1_2 = MAX_HANDLES - 1;
-        let child_1_2_1 = 1;
-        let child_1_3 = MAX_HANDLES - 2;
-
-        // Root isn't active.
-        assert_eq!(
-            dpe.get_descendants(&dpe.contexts[root]),
-            Err(DpeErrorCode::InvalidHandle)
-        );
-
-        // No children.
-        dpe.contexts[root].state = ContextState::Active;
-        assert_eq!(dpe.get_descendants(&dpe.contexts[root]).unwrap(), 0);
-
-        // Child not active.
-        dpe.contexts[root].children = 1 << child_1;
-        assert_eq!(
-            dpe.get_descendants(&dpe.contexts[root]),
-            Err(DpeErrorCode::InvalidHandle)
-        );
-
-        // One child.
-        dpe.contexts[child_1].state = ContextState::Active;
-        let mut children = dpe.contexts[root].children;
-        assert_eq!(children, dpe.get_descendants(&dpe.contexts[root]).unwrap());
-
-        // Add grandchildren.
-        dpe.contexts[child_1_1].state = ContextState::Active;
-        dpe.contexts[child_1_2].state = ContextState::Active;
-        dpe.contexts[child_1_3].state = ContextState::Active;
-        dpe.contexts[child_1].children = (1 << child_1_1) | (1 << child_1_2) | (1 << child_1_3);
-        children |= dpe.contexts[child_1].children;
-        assert_eq!(children, dpe.get_descendants(&dpe.contexts[root]).unwrap());
-
-        // Add great-grandchildren.
-        dpe.contexts[child_1_2_1].state = ContextState::Active;
-        dpe.contexts[child_1_2].children = 1 << child_1_2_1;
-        children |= dpe.contexts[child_1_2].children;
-        assert_eq!(
-            dpe.contexts[child_1_2].children,
-            dpe.get_descendants(&dpe.contexts[child_1_2]).unwrap()
-        );
-        assert_eq!(children, dpe.get_descendants(&dpe.contexts[root]).unwrap());
-    }
-
-    #[test]
     fn test_derive_cdi() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe = DpeInstance::new(&mut env, SUPPORT, DpeInstanceFlags::empty()).unwrap();
+        let mut state = test_state();
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
         let mut last_cdi = vec![];
 
@@ -820,7 +575,8 @@ pub mod tests {
             .unwrap();
 
             // Check the CDI changes each time.
-            let leaf_context_idx = dpe
+            let leaf_context_idx = env
+                .state
                 .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[0])
                 .unwrap();
             let digest = dpe
@@ -836,11 +592,12 @@ pub mod tests {
         }
 
         let mut hasher = env.crypto.hash_initialize(DPE_PROFILE.alg_len()).unwrap();
-        let leaf_idx = dpe
+        let leaf_idx = env
+            .state
             .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[0])
             .unwrap();
 
-        for result in ChildToRootIter::new(leaf_idx, &dpe.contexts) {
+        for result in ChildToRootIter::new(leaf_idx, &env.state.contexts) {
             let context = result.unwrap();
             hasher.update(context.tci.as_bytes()).unwrap();
             hasher
@@ -859,18 +616,12 @@ pub mod tests {
     #[test]
     fn test_hash_internal_input_info() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe = DpeInstance::new(
-            &mut env,
-            SUPPORT | Support::INTERNAL_INFO,
-            DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        let mut state = State::new(SUPPORT | Support::INTERNAL_INFO, DpeInstanceFlags::empty());
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
-        let parent_context_idx = dpe
+        let parent_context_idx = env
+            .state
             .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[0])
             .unwrap();
         DeriveContextCmd {
@@ -883,7 +634,8 @@ pub mod tests {
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         .unwrap();
 
-        let child_context_idx = dpe
+        let child_context_idx = env
+            .state
             .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[0])
             .unwrap();
         let digest = dpe
@@ -893,8 +645,8 @@ pub mod tests {
             .crypto
             .derive_cdi(DPE_PROFILE.alg_len(), &digest, b"DPE")
             .unwrap();
-        let parent_context = &dpe.contexts[parent_context_idx];
-        let child_context = &dpe.contexts[child_context_idx];
+        let parent_context = &env.state.contexts[parent_context_idx];
+        let child_context = &env.state.contexts[child_context_idx];
         assert!(child_context.uses_internal_input_info());
         assert!(!parent_context.uses_internal_input_info());
 
@@ -905,8 +657,12 @@ pub mod tests {
         hasher.update(parent_context.tci.as_bytes()).unwrap();
         hasher.update(/*allow_x509=*/ true.as_bytes()).unwrap();
         let mut internal_input_info = [0u8; INTERNAL_INPUT_INFO_SIZE];
-        dpe.serialize_internal_input_info(&mut env.platform, &mut internal_input_info)
-            .unwrap();
+        dpe.serialize_internal_input_info(
+            &mut env.platform,
+            env.state.support,
+            &mut internal_input_info,
+        )
+        .unwrap();
 
         hasher
             .update(&internal_input_info[..INTERNAL_INPUT_INFO_SIZE])
@@ -923,18 +679,12 @@ pub mod tests {
     #[test]
     fn test_hash_internal_input_dice() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
-        let mut dpe = DpeInstance::new(
-            &mut env,
-            SUPPORT | Support::INTERNAL_DICE,
-            DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        let mut state = State::new(SUPPORT | Support::INTERNAL_DICE, DpeInstanceFlags::empty());
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env).unwrap();
 
-        let parent_context_idx = dpe
+        let parent_context_idx = env
+            .state
             .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[0])
             .unwrap();
         DeriveContextCmd {
@@ -947,7 +697,8 @@ pub mod tests {
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         .unwrap();
 
-        let child_context_idx = dpe
+        let child_context_idx = env
+            .state
             .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[0])
             .unwrap();
         let digest = dpe
@@ -957,8 +708,8 @@ pub mod tests {
             .crypto
             .derive_cdi(DPE_PROFILE.alg_len(), &digest, b"DPE")
             .unwrap();
-        let parent_context = &dpe.contexts[parent_context_idx];
-        let child_context = &dpe.contexts[child_context_idx];
+        let parent_context = &env.state.contexts[parent_context_idx];
+        let child_context = &env.state.contexts[child_context_idx];
         assert!(child_context.uses_internal_input_dice());
         assert!(!parent_context.uses_internal_input_dice());
 
@@ -982,33 +733,29 @@ pub mod tests {
     #[test]
     fn test_new_auto_init() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
+        let mut state = test_state();
+        let mut env = test_env(&mut state);
         let tci_type = 0xdeadbeef_u32;
         let auto_init_measurement = [0x1; DPE_PROFILE.hash_size()];
         let auto_init_locality = env.platform.get_auto_init_locality().unwrap();
-        let mut dpe = DpeInstance::new_auto_init(
-            &mut env,
-            SUPPORT,
-            tci_type,
-            auto_init_measurement,
-            DpeInstanceFlags::empty(),
-        )
-        .unwrap();
+        let mut dpe =
+            DpeInstance::new_auto_init(&mut env, tci_type, auto_init_measurement).unwrap();
 
-        let idx = dpe
+        let idx = env
+            .state
             .get_active_context_pos(&ContextHandle::default(), auto_init_locality)
             .unwrap();
-        assert_eq!(dpe.contexts[idx].tci.tci_type, tci_type);
-        assert_eq!(dpe.contexts[idx].tci.locality, auto_init_locality);
-        assert_eq!(dpe.contexts[idx].tci.tci_current.0, auto_init_measurement);
-        assert_eq!(dpe.contexts[idx].parent_idx, Context::ROOT_INDEX);
-        assert_eq!(dpe.contexts[idx].children, 0);
-        assert_eq!(dpe.contexts[idx].state, ContextState::Active);
-        assert_eq!(dpe.contexts[idx].handle, ContextHandle::default());
-        assert!(dpe.has_initialized());
+        assert_eq!(env.state.contexts[idx].tci.tci_type, tci_type);
+        assert_eq!(env.state.contexts[idx].tci.locality, auto_init_locality);
+        assert_eq!(
+            env.state.contexts[idx].tci.tci_current.0,
+            auto_init_measurement
+        );
+        assert_eq!(env.state.contexts[idx].parent_idx, Context::ROOT_INDEX);
+        assert_eq!(env.state.contexts[idx].children, 0);
+        assert_eq!(env.state.contexts[idx].state, ContextState::Active);
+        assert_eq!(env.state.contexts[idx].handle, ContextHandle::default());
+        assert!(env.state.has_initialized());
 
         // check that initialize context fails if new_auto_init was used
         assert_eq!(

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -7,12 +7,15 @@ Abstract:
 #![cfg_attr(not(test), no_std)]
 
 pub use dpe_instance::DpeInstance;
+pub use state::State;
+
 use zeroize::Zeroize;
 
 pub mod commands;
 pub mod context;
 pub mod dpe_instance;
 pub mod response;
+mod state;
 pub mod support;
 pub mod validation;
 

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -7,7 +7,7 @@ Abstract:
 #![cfg_attr(not(test), no_std)]
 
 pub use dpe_instance::DpeInstance;
-pub use state::State;
+pub use state::{DpeFlags, State};
 
 use zeroize::Zeroize;
 

--- a/dpe/src/state.rs
+++ b/dpe/src/state.rs
@@ -1,0 +1,302 @@
+// Licensed under the Apache-2.0 license.
+use crate::{
+    context::{ChildToRootIter, Context, ContextHandle, ContextState},
+    dpe_instance::{flags_iter, DpeInstanceFlags},
+    response::DpeErrorCode,
+    support::Support,
+    tci::TciNodeData,
+    U8Bool, MAX_HANDLES,
+};
+use caliptra_cfi_lib_git::cfi_launder;
+use zerocopy::{Immutable, IntoBytes, KnownLayout, TryFromBytes};
+use zeroize::Zeroize;
+
+#[cfg(not(feature = "no-cfi"))]
+use caliptra_cfi_derive_git::cfi_impl_fn;
+
+#[repr(C, align(4))]
+#[derive(IntoBytes, TryFromBytes, KnownLayout, Immutable, Zeroize)]
+pub struct State {
+    /// Layout version of this structure. If the layout of this structure changes, Self::VERSION
+    /// must be updated.
+    pub version: u32,
+    pub contexts: [Context; MAX_HANDLES],
+    pub support: Support,
+    pub flags: DpeInstanceFlags,
+    /// Can only successfully execute the initialize context command for non-simulation (i.e.
+    /// `InitializeContext(simulation=false)`) once per reset cycle.
+    pub has_initialized: U8Bool,
+    // unused buffer added to make DpeInstance word aligned and remove padding
+    pub reserved: [u8; 1],
+}
+const _: () = assert!(align_of::<State>() == 4);
+
+impl Default for State {
+    fn default() -> Self {
+        const CONTEXT_INITIALIZER: Context = Context::new();
+        State {
+            version: Self::VERSION,
+            contexts: [CONTEXT_INITIALIZER; MAX_HANDLES],
+            support: Support::default(),
+            flags: DpeInstanceFlags::empty(),
+            has_initialized: false.into(),
+            reserved: [0; 1],
+        }
+    }
+}
+
+impl State {
+    pub const VERSION: u32 = 1;
+
+    pub fn new(support: Support, flags: DpeInstanceFlags) -> Self {
+        let updated_support = support.preprocess_support();
+        const CONTEXT_INITIALIZER: Context = Context::new();
+        State {
+            version: Self::VERSION,
+            contexts: [CONTEXT_INITIALIZER; MAX_HANDLES],
+            support: updated_support,
+            flags,
+            has_initialized: false.into(),
+            reserved: [0; 1],
+        }
+    }
+
+    pub fn has_initialized(&self) -> bool {
+        self.has_initialized.get()
+    }
+
+    /// Finds the index of the context having `handle` in `locality`
+    /// Inlined so the callsite optimizer knows that idx < self.contexts.len()
+    /// and won't insert possible call to panic.
+    ///
+    /// # Arguments
+    ///
+    /// * `handle` - handle to search
+    /// * `locality` - locality to search
+    #[inline(always)]
+    pub fn get_active_context_pos(
+        &self,
+        handle: &ContextHandle,
+        locality: u32,
+    ) -> Result<usize, DpeErrorCode> {
+        let idx = self.get_active_context_pos_internal(handle, locality)?;
+        if idx >= self.contexts.len() {
+            return Err(DpeErrorCode::InternalError);
+        }
+        Ok(idx)
+    }
+
+    fn get_active_context_pos_internal(
+        &self,
+        handle: &ContextHandle,
+        locality: u32,
+    ) -> Result<usize, DpeErrorCode> {
+        // find all active contexts whose localities match the locality parameter
+        let mut valid_localities = self
+            .contexts
+            .iter()
+            .enumerate()
+            .filter(|(_, context)| {
+                context.state == ContextState::Active && context.locality == locality
+            })
+            .peekable();
+        if valid_localities.peek().is_none() {
+            return Err(DpeErrorCode::InvalidLocality);
+        }
+
+        // filter down the contexts with valid localities based on their context handle matching the input context handle
+        // the locality and handle filters are separated so that we can return InvalidHandle or InvalidLocality upon getting no valid contexts accordingly
+        let mut valid_handles_and_localities = valid_localities
+            .filter(|(_, context)| context.handle.equals(handle))
+            .peekable();
+        if valid_handles_and_localities.peek().is_none() {
+            return Err(DpeErrorCode::InvalidHandle);
+        }
+        let (i, _) = valid_handles_and_localities
+            .find(|(_, context)| {
+                context.state == ContextState::Active
+                    && context.handle.equals(handle)
+                    && context.locality == locality
+            })
+            .ok_or(DpeErrorCode::InternalError)?;
+        Ok(i)
+    }
+
+    pub(crate) fn get_next_inactive_context_pos(&self) -> Option<usize> {
+        self.contexts
+            .iter()
+            .position(|context| context.state == ContextState::Inactive)
+    }
+
+    /// Recursive function that will return all of `context`'s descendants
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - context to get descendants for
+    ///
+    /// Returns a u32 representing a bitmap of the node indices.
+    pub(crate) fn get_descendants(&self, context: &Context) -> Result<u32, DpeErrorCode> {
+        if context.state == ContextState::Inactive {
+            return Err(DpeErrorCode::InvalidHandle);
+        }
+
+        let mut descendants = context.children;
+        for idx in flags_iter(context.children, MAX_HANDLES) {
+            if idx >= self.contexts.len() {
+                return Err(DpeErrorCode::InternalError);
+            }
+            descendants |= cfi_launder(self.get_descendants(&self.contexts[idx])?);
+        }
+        Ok(descendants)
+    }
+
+    /// Get the TCI nodes from the context at `start_idx` to the root node following parent
+    /// links. These are the nodes that should contribute to CDI and key
+    /// derivation for the context at `start_idx`.
+    ///
+    /// # Arguments
+    ///
+    /// * `start_idx` - Index into context array
+    /// * `nodes` - Array to write TCI nodes to
+    ///
+    /// Returns the number of TCIs written to `nodes`
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    pub(crate) fn get_tcb_nodes(
+        &self,
+        start_idx: usize,
+        nodes: &mut [TciNodeData],
+    ) -> Result<usize, DpeErrorCode> {
+        let mut out_idx = 0;
+
+        for status in ChildToRootIter::new(start_idx, &self.contexts) {
+            let curr = status?;
+            if out_idx >= nodes.len() {
+                return Err(DpeErrorCode::InternalError);
+            }
+
+            nodes[out_idx] = curr.tci;
+            out_idx += 1;
+        }
+
+        if out_idx > nodes.len() {
+            return Err(DpeErrorCode::InternalError);
+        }
+        nodes[..out_idx].reverse();
+
+        Ok(out_idx)
+    }
+
+    /// Count number of contexts satisfying some predicate
+    ///
+    /// # Arguments
+    ///
+    /// * `context_pred` - A predicate on a context used to determine contexts to count
+    pub fn count_contexts(&self, f: impl Fn(&Context) -> bool) -> Result<usize, DpeErrorCode> {
+        Ok(self.contexts.iter().filter(|context| f(context)).count())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use caliptra_cfi_lib_git::CfiCounter;
+    use platform::default::AUTO_INIT_LOCALITY;
+
+    use crate::dpe_instance::tests::SIMULATION_HANDLE;
+
+    use super::*;
+
+    #[test]
+    fn test_get_active_context_index() {
+        CfiCounter::reset_for_test();
+        let mut state = State::default();
+        let expected_index = 7;
+        state.contexts[expected_index].handle = SIMULATION_HANDLE;
+
+        let locality = AUTO_INIT_LOCALITY;
+        // Has not been activated.
+        assert!(state
+            .get_active_context_pos(&SIMULATION_HANDLE, locality)
+            .is_err());
+
+        // Shouldn't be able to find it if it is retired either.
+        state.contexts[expected_index].state = ContextState::Retired;
+        assert!(state
+            .get_active_context_pos(&SIMULATION_HANDLE, locality)
+            .is_err());
+
+        // Mark it active, but check the wrong locality.
+        let locality = 2;
+        state.contexts[expected_index].state = ContextState::Active;
+        assert!(state
+            .get_active_context_pos(&SIMULATION_HANDLE, locality)
+            .is_err());
+
+        // Should find it now.
+        state.contexts[expected_index].locality = locality;
+        let idx = state
+            .get_active_context_pos(&SIMULATION_HANDLE, locality)
+            .unwrap();
+        assert_eq!(expected_index, idx);
+    }
+
+    #[test]
+    fn test_get_descendants() {
+        CfiCounter::reset_for_test();
+        let mut state = State::default();
+        let root = 7;
+        let child_1 = 3;
+        let child_1_1 = 0;
+        let child_1_2 = MAX_HANDLES - 1;
+        let child_1_2_1 = 1;
+        let child_1_3 = MAX_HANDLES - 2;
+
+        // Root isn't active.
+        assert_eq!(
+            state.get_descendants(&state.contexts[root]),
+            Err(DpeErrorCode::InvalidHandle)
+        );
+
+        // No children.
+        state.contexts[root].state = ContextState::Active;
+        assert_eq!(state.get_descendants(&state.contexts[root]).unwrap(), 0);
+
+        // Child not active.
+        state.contexts[root].children = 1 << child_1;
+        assert_eq!(
+            state.get_descendants(&state.contexts[root]),
+            Err(DpeErrorCode::InvalidHandle)
+        );
+
+        // One child.
+        state.contexts[child_1].state = ContextState::Active;
+        let mut children = state.contexts[root].children;
+        assert_eq!(
+            children,
+            state.get_descendants(&state.contexts[root]).unwrap()
+        );
+
+        // Add grandchildren.
+        state.contexts[child_1_1].state = ContextState::Active;
+        state.contexts[child_1_2].state = ContextState::Active;
+        state.contexts[child_1_3].state = ContextState::Active;
+        state.contexts[child_1].children = (1 << child_1_1) | (1 << child_1_2) | (1 << child_1_3);
+        children |= state.contexts[child_1].children;
+        assert_eq!(
+            children,
+            state.get_descendants(&state.contexts[root]).unwrap()
+        );
+
+        // Add great-grandchildren.
+        state.contexts[child_1_2_1].state = ContextState::Active;
+        state.contexts[child_1_2].children = 1 << child_1_2_1;
+        children |= state.contexts[child_1_2].children;
+        assert_eq!(
+            state.contexts[child_1_2].children,
+            state.get_descendants(&state.contexts[child_1_2]).unwrap()
+        );
+        assert_eq!(
+            children,
+            state.get_descendants(&state.contexts[root]).unwrap()
+        );
+    }
+}

--- a/dpe/src/validation.rs
+++ b/dpe/src/validation.rs
@@ -451,11 +451,11 @@ impl DpeValidator<'_> {
 pub mod tests {
     use crate::{
         context::{Context, ContextHandle, ContextState, ContextType},
-        dpe_instance::{tests::test_state, DpeInstanceFlags},
+        dpe_instance::tests::test_state,
         support::Support,
         tci::TciMeasurement,
         validation::{DpeValidator, ValidationError},
-        State, U8Bool, DPE_PROFILE,
+        DpeFlags, State, U8Bool, DPE_PROFILE,
     };
     use caliptra_cfi_lib_git::CfiCounter;
 
@@ -564,7 +564,7 @@ pub mod tests {
         let dpe_validator = DpeValidator {
             dpe: &mut State::new(
                 Support::all().difference(Support::AUTO_INIT),
-                DpeInstanceFlags::empty(),
+                DpeFlags::empty(),
             ),
         };
 

--- a/dpe/src/validation.rs
+++ b/dpe/src/validation.rs
@@ -5,7 +5,7 @@ use crate::{
     dpe_instance::flags_iter,
     response::DpeErrorCode,
     tci::TciNodeData,
-    DpeInstance, MAX_HANDLES,
+    State, MAX_HANDLES,
 };
 
 #[cfg(not(feature = "no-cfi"))]
@@ -57,7 +57,7 @@ impl ValidationError {
 }
 
 pub struct DpeValidator<'a> {
-    pub dpe: &'a mut DpeInstance,
+    pub dpe: &'a mut State,
 }
 
 impl DpeValidator<'_> {
@@ -92,12 +92,12 @@ impl DpeValidator<'_> {
     /// present within the DPE instance.
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     fn validate_dpe_state(&self) -> Result<(), ValidationError> {
-        if cfi_launder(self.dpe.version == DpeInstance::VERSION) {
+        if cfi_launder(self.dpe.version == State::VERSION) {
             #[cfg(not(feature = "no-cfi"))]
-            cfi_assert!(self.dpe.version == DpeInstance::VERSION);
+            cfi_assert!(self.dpe.version == State::VERSION);
         } else {
             #[cfg(not(feature = "no-cfi"))]
-            cfi_assert!(self.dpe.version != DpeInstance::VERSION);
+            cfi_assert!(self.dpe.version != State::VERSION);
             return Err(ValidationError::VersionMismatch);
         }
         for i in 0..MAX_HANDLES {
@@ -449,28 +449,21 @@ impl DpeValidator<'_> {
 
 #[cfg(test)]
 pub mod tests {
-    use caliptra_cfi_lib_git::CfiCounter;
-    use crypto::RustCryptoImpl;
-
     use crate::{
-        commands::tests::DEFAULT_PLATFORM,
         context::{Context, ContextHandle, ContextState, ContextType},
-        dpe_instance::{tests::TestTypes, DpeEnv, DpeInstanceFlags},
-        support::{test::SUPPORT, Support},
+        dpe_instance::{tests::test_state, DpeInstanceFlags},
+        support::Support,
         tci::TciMeasurement,
         validation::{DpeValidator, ValidationError},
-        DpeInstance, U8Bool, DPE_PROFILE,
+        State, U8Bool, DPE_PROFILE,
     };
+    use caliptra_cfi_lib_git::CfiCounter;
 
     #[test]
     fn test_validate_context_forest() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
         let dpe_validator = DpeValidator {
-            dpe: &mut DpeInstance::new(&mut env, SUPPORT, DpeInstanceFlags::empty()).unwrap(),
+            dpe: &mut test_state(),
         };
 
         // validation fails on graph where child has multiple parents
@@ -528,13 +521,8 @@ pub mod tests {
     #[test]
     fn test_support_validation() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
         let dpe_validator = DpeValidator {
-            dpe: &mut DpeInstance::new(&mut env, Support::empty(), DpeInstanceFlags::empty())
-                .unwrap(),
+            dpe: &mut State::default(),
         };
 
         // test simulation support
@@ -573,17 +561,11 @@ pub mod tests {
     #[test]
     fn test_context_specific_validation() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
         let dpe_validator = DpeValidator {
-            dpe: &mut DpeInstance::new(
-                &mut env,
+            dpe: &mut State::new(
                 Support::all().difference(Support::AUTO_INIT),
                 DpeInstanceFlags::empty(),
-            )
-            .unwrap(),
+            ),
         };
 
         // inactive context validation
@@ -687,13 +669,8 @@ pub mod tests {
     #[test]
     fn test_contexts_within_same_locality_validation() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
         let dpe_validator = DpeValidator {
-            dpe: &mut DpeInstance::new(&mut env, Support::empty(), DpeInstanceFlags::empty())
-                .unwrap(),
+            dpe: &mut State::default(),
         };
         dpe_validator.dpe.has_initialized = U8Bool::new(true);
 
@@ -720,13 +697,8 @@ pub mod tests {
     #[test]
     fn test_version_mismatch() {
         CfiCounter::reset_for_test();
-        let mut env = DpeEnv::<TestTypes> {
-            crypto: RustCryptoImpl::new(),
-            platform: DEFAULT_PLATFORM,
-        };
         let dpe_validator = DpeValidator {
-            dpe: &mut DpeInstance::new(&mut env, Support::empty(), DpeInstanceFlags::empty())
-                .unwrap(),
+            dpe: &mut State::default(),
         };
         assert_eq!(Ok(()), dpe_validator.validate_dpe_state());
 

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -10,7 +10,7 @@ use crate::{
     dpe_instance::{DpeEnv, DpeTypes},
     response::DpeErrorCode,
     tci::{TciMeasurement, TciNodeData},
-    DpeInstance, DpeProfile, DPE_PROFILE, MAX_CERT_SIZE, MAX_HANDLES,
+    DpeInstance, DpeProfile, State, DPE_PROFILE, MAX_CERT_SIZE, MAX_HANDLES,
 };
 use bitflags::bitflags;
 use caliptra_cfi_lib_git::cfi_launder;
@@ -2301,7 +2301,7 @@ fn get_dpe_measurement_digest(
     handle: &ContextHandle,
     locality: u32,
 ) -> Result<Digest, DpeErrorCode> {
-    let parent_idx = dpe.get_active_context_pos(handle, locality)?;
+    let parent_idx = env.state.get_active_context_pos(handle, locality)?;
     let digest = dpe.compute_measurement_hash(env, parent_idx)?;
     Ok(digest)
 }
@@ -2325,13 +2325,13 @@ fn get_subject_name<'a>(
 }
 
 fn get_tci_nodes<'a>(
-    dpe: &mut DpeInstance,
+    state: &State,
     handle: &ContextHandle,
     locality: u32,
     nodes: &'a mut [TciNodeData],
 ) -> Result<&'a mut [TciNodeData], DpeErrorCode> {
-    let parent_idx = dpe.get_active_context_pos(handle, locality)?;
-    let tcb_count = dpe.get_tcb_nodes(parent_idx, nodes)?;
+    let parent_idx = state.get_active_context_pos(handle, locality)?;
+    let tcb_count = state.get_tcb_nodes(parent_idx, nodes)?;
     if tcb_count > MAX_HANDLES {
         return Err(DpeErrorCode::InternalError);
     }
@@ -2451,7 +2451,7 @@ fn create_dpe_cert_or_csr(
 
     const INITIALIZER: TciNodeData = TciNodeData::new();
     let mut nodes = [INITIALIZER; MAX_HANDLES];
-    let tci_nodes = get_tci_nodes(dpe, args.handle, args.locality, &mut nodes)?;
+    let tci_nodes = get_tci_nodes(env.state, args.handle, args.locality, &mut nodes)?;
 
     let mut subject_key_identifier = [0u8; MAX_KEY_IDENTIFIER_SIZE];
     get_subject_key_identifier(env, &pub_key, &mut subject_key_identifier)?;
@@ -2472,7 +2472,7 @@ fn create_dpe_cert_or_csr(
     };
 
     let supports_recursive = match cert_type {
-        CertificateType::Leaf => dpe.support.recursive(),
+        CertificateType::Leaf => env.state.support.recursive(),
         CertificateType::Exported => false,
     };
 

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -4,7 +4,7 @@
 compile_error!("must provide a crypto implementation");
 
 use clap::Parser;
-use dpe::dpe_instance::DpeInstanceFlags;
+use dpe::DpeFlags;
 use log::{error, info, trace, warn};
 use platform::default::{DefaultPlatform, DefaultPlatformProfile};
 use std::fs;
@@ -160,9 +160,9 @@ fn main() -> std::io::Result<()> {
     );
     support.set(Support::CDI_EXPORT, args.supports_cdi_export);
 
-    let mut flags = DpeInstanceFlags::empty();
+    let mut flags = DpeFlags::empty();
     flags.set(
-        DpeInstanceFlags::MARK_DICE_EXTENSIONS_CRITICAL,
+        DpeFlags::MARK_DICE_EXTENSIONS_CRITICAL,
         args.mark_dice_extensions_critical,
     );
 

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -160,6 +160,12 @@ fn main() -> std::io::Result<()> {
     );
     support.set(Support::CDI_EXPORT, args.supports_cdi_export);
 
+    let mut flags = DpeInstanceFlags::empty();
+    flags.set(
+        DpeInstanceFlags::MARK_DICE_EXTENSIONS_CRITICAL,
+        args.mark_dice_extensions_critical,
+    );
+
     #[cfg(feature = "dpe_profile_p256_sha256")]
     let p = DefaultPlatformProfile::P256;
     #[cfg(feature = "dpe_profile_p384_sha384")]
@@ -167,14 +173,9 @@ fn main() -> std::io::Result<()> {
     let mut env = DpeEnv::<SimTypes> {
         crypto: <SimTypes as DpeTypes>::Crypto::new(),
         platform: DefaultPlatform(p),
+        state: &mut dpe::State::new(support, flags),
     };
-
-    let mut flags = DpeInstanceFlags::empty();
-    flags.set(
-        DpeInstanceFlags::MARK_DICE_EXTENSIONS_CRITICAL,
-        args.mark_dice_extensions_critical,
-    );
-    let mut dpe = DpeInstance::new(&mut env, support, flags).map_err(|err| {
+    let mut dpe = DpeInstance::new(&mut env).map_err(|err| {
         Error::new(
             ErrorKind::Other,
             format!("{err:?} while creating new DPE instance"),

--- a/tools/src/sample_dpe_cert.rs
+++ b/tools/src/sample_dpe_cert.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use dpe::dpe_instance::DpeInstanceFlags;
+use dpe::DpeFlags;
 use platform::default::DefaultPlatformProfile;
 use std::env;
 
@@ -106,7 +106,7 @@ fn main() {
     let mut env = DpeEnv::<TestTypes> {
         crypto: RustCryptoImpl::new(),
         platform: DefaultPlatform(p),
-        state: &mut dpe::State::new(support, DpeInstanceFlags::empty()),
+        state: &mut dpe::State::new(support, DpeFlags::empty()),
     };
 
     let mut dpe = DpeInstance::new(&mut env).unwrap();

--- a/tools/src/sample_dpe_cert.rs
+++ b/tools/src/sample_dpe_cert.rs
@@ -106,9 +106,10 @@ fn main() {
     let mut env = DpeEnv::<TestTypes> {
         crypto: RustCryptoImpl::new(),
         platform: DefaultPlatform(p),
+        state: &mut dpe::State::new(support, DpeInstanceFlags::empty()),
     };
 
-    let mut dpe = DpeInstance::new(&mut env, support, DpeInstanceFlags::empty()).unwrap();
+    let mut dpe = DpeInstance::new(&mut env).unwrap();
 
     add_tcb_info(
         &mut dpe,


### PR DESCRIPTION
This commit moves the DPE state out of the DPE instance and into a separate struct. This allows for more flexibility in how the DPE is used.

More specifically this will help in Caliptra 2.x to support both an ECDSA and an ML-DSA DPE instance that share the same DPE state.