### PR TITLE
Simplify command dispatch.

### DIFF
--- a/dpe/fuzz/src/fuzz_target_1.rs
+++ b/dpe/fuzz/src/fuzz_target_1.rs
@@ -57,7 +57,7 @@ fn harness(data: &[u8]) {
     };
     let mut dpe = DpeInstance::new(&mut env).unwrap();
     trace!("----------------------------------");
-    if let Ok(command) = dpe.deserialize_command(data) {
+    if let Ok(command) = dpe.deserialize_command::<SimTypes>(data) {
         trace!("| Fuzzer's locality requested {command:x?}");
         trace!("|");
     } else {

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -199,12 +199,12 @@ impl DeriveContextCmd {
     }
 }
 
-impl CommandExecution for DeriveContextCmd {
+impl<T: DpeTypes> CommandExecution<T> for DeriveContextCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     fn execute(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv<impl DpeTypes>,
+        env: &mut DpeEnv<T>,
         locality: u32,
     ) -> Result<Response, DpeErrorCode> {
         let support = env.state.support;
@@ -430,9 +430,10 @@ mod tests {
     use super::*;
     use crate::{
         commands::{
+            self,
             rotate_context::{RotateCtxCmd, RotateCtxFlags},
             tests::{PROFILES, TEST_DIGEST, TEST_LABEL},
-            CertifyKeyCmd, CertifyKeyFlags, Command, CommandHdr, InitCtxCmd, SignCmd, SignFlags,
+            CertifyKeyCmd, CertifyKeyFlags, CommandHdr, InitCtxCmd, SignCmd, SignFlags,
         },
         context::ContextType,
         dpe_instance::tests::{
@@ -468,14 +469,11 @@ mod tests {
     fn test_deserialize_derive_context() {
         CfiCounter::reset_for_test();
         for p in PROFILES {
-            let mut command = CommandHdr::new(p, Command::DERIVE_CONTEXT)
+            let mut command = CommandHdr::new(p, commands::DERIVE_CONTEXT)
                 .as_bytes()
                 .to_vec();
             command.extend(TEST_DERIVE_CONTEXT_CMD.as_bytes());
-            assert_eq!(
-                Ok(Command::DeriveContext(&TEST_DERIVE_CONTEXT_CMD)),
-                Command::deserialize(p, &command)
-            );
+            assert!(commands::deserialize::<TestTypes>(p, &command).is_ok());
         }
     }
 

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -23,12 +23,12 @@ pub struct GetCertificateChainCmd {
     pub size: u32,
 }
 
-impl CommandExecution for GetCertificateChainCmd {
+impl<T: DpeTypes> CommandExecution<T> for GetCertificateChainCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     fn execute(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv<impl DpeTypes>,
+        env: &mut DpeEnv<T>,
         _locality: u32,
     ) -> Result<Response, DpeErrorCode> {
         // Make sure the operation is supported.
@@ -52,8 +52,8 @@ impl CommandExecution for GetCertificateChainCmd {
 mod tests {
     use super::*;
     use crate::{
-        commands::{tests::PROFILES, Command, CommandHdr},
-        dpe_instance::tests::{test_env, test_state, TEST_LOCALITIES},
+        commands::{self, tests::PROFILES, CommandHdr},
+        dpe_instance::tests::{test_env, test_state, TestTypes, TEST_LOCALITIES},
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use zerocopy::IntoBytes;
@@ -67,16 +67,11 @@ mod tests {
     fn test_deserialize_get_certificate_chain() {
         CfiCounter::reset_for_test();
         for p in PROFILES {
-            let mut command = CommandHdr::new(p, Command::GET_CERTIFICATE_CHAIN)
+            let mut command = CommandHdr::new(p, commands::GET_CERTIFICATE_CHAIN)
                 .as_bytes()
                 .to_vec();
             command.extend(TEST_GET_CERTIFICATE_CHAIN_CMD.as_bytes());
-            assert_eq!(
-                Ok(Command::GetCertificateChain(
-                    &TEST_GET_CERTIFICATE_CHAIN_CMD
-                )),
-                Command::deserialize(p, &command)
-            );
+            assert!(commands::deserialize::<TestTypes>(p, &command).is_ok());
         }
     }
 

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -49,12 +49,12 @@ impl InitCtxCmd {
     }
 }
 
-impl CommandExecution for InitCtxCmd {
+impl<T: DpeTypes> CommandExecution<T> for InitCtxCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     fn execute(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv<impl DpeTypes>,
+        env: &mut DpeEnv<T>,
         locality: u32,
     ) -> Result<Response, DpeErrorCode> {
         // This function can only be called once for non-simulation contexts.
@@ -114,9 +114,9 @@ impl CommandExecution for InitCtxCmd {
 mod tests {
     use super::*;
     use crate::{
-        commands::{tests::PROFILES, Command, CommandHdr},
+        commands::{self, tests::PROFILES, CommandHdr},
         context::ContextState,
-        dpe_instance::tests::{test_env, TEST_LOCALITIES},
+        dpe_instance::tests::{test_env, TestTypes, TEST_LOCALITIES},
         support::Support,
         DpeFlags, State,
     };
@@ -129,14 +129,11 @@ mod tests {
     fn test_deserialize_init_ctx() {
         CfiCounter::reset_for_test();
         for p in PROFILES {
-            let mut command = CommandHdr::new(p, Command::INITIALIZE_CONTEXT)
+            let mut command = CommandHdr::new(p, commands::INITIALIZE_CONTEXT)
                 .as_bytes()
                 .to_vec();
             command.extend(TEST_INIT_CTX_CMD.as_bytes());
-            assert_eq!(
-                Ok(Command::InitCtx(&TEST_INIT_CTX_CMD)),
-                Command::deserialize(p, &command)
-            );
+            assert!(commands::deserialize::<TestTypes>(p, &command).is_ok());
         }
     }
 

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -77,12 +77,12 @@ impl RotateCtxCmd {
     }
 }
 
-impl CommandExecution for RotateCtxCmd {
+impl<T: DpeTypes> CommandExecution<T> for RotateCtxCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     fn execute(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv<impl DpeTypes>,
+        env: &mut DpeEnv<T>,
         locality: u32,
     ) -> Result<Response, DpeErrorCode> {
         if !env.state.support.rotate_context() {
@@ -129,9 +129,9 @@ impl CommandExecution for RotateCtxCmd {
 mod tests {
     use super::*;
     use crate::{
-        commands::{tests::PROFILES, Command, CommandHdr, InitCtxCmd},
+        commands::{self, tests::PROFILES, CommandHdr, InitCtxCmd},
         dpe_instance::tests::{
-            test_env, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES,
+            test_env, TestTypes, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES,
         },
         support::Support,
         DpeFlags,
@@ -148,14 +148,11 @@ mod tests {
     fn test_deserialize_rotate_context() {
         CfiCounter::reset_for_test();
         for p in PROFILES {
-            let mut command = CommandHdr::new(p, Command::ROTATE_CONTEXT_HANDLE)
+            let mut command = CommandHdr::new(p, commands::ROTATE_CONTEXT_HANDLE)
                 .as_bytes()
                 .to_vec();
             command.extend(TEST_ROTATE_CTX_CMD.as_bytes());
-            assert_eq!(
-                Ok(Command::RotateCtx(&TEST_ROTATE_CTX_CMD)),
-                Command::deserialize(p, &command)
-            );
+            assert!(commands::deserialize::<TestTypes>(p, &command).is_ok());
         }
     }
 

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -36,7 +36,7 @@ fn handle_request(dpe: &mut DpeInstance, env: &mut DpeEnv<impl DpeTypes>, stream
     };
 
     trace!("----------------------------------");
-    if let Ok(command) = dpe.deserialize_command(cmd) {
+    if let Ok(command) = dpe.deserialize_command::<SimTypes>(cmd) {
         trace!("| Locality `{locality:#x}` requested {command:x?}",);
     } else {
         trace!("| Locality `{locality:#010x}` requested invalid command. {cmd:02x?}")

--- a/tools/src/sample_dpe_cert.rs
+++ b/tools/src/sample_dpe_cert.rs
@@ -42,7 +42,7 @@ fn add_tcb_info(
     };
     let cmd_body = cmd.as_bytes().to_vec();
     let cmd_hdr = dpe
-        .command_hdr(dpe::commands::Command::DERIVE_CONTEXT)
+        .command_hdr(dpe::commands::DERIVE_CONTEXT)
         .as_bytes()
         .to_vec();
     let mut command = cmd_hdr;
@@ -67,7 +67,7 @@ fn certify_key(dpe: &mut DpeInstance, env: &mut DpeEnv<TestTypes>, format: u32) 
     };
     let cmd_body = certify_key_cmd.as_bytes().to_vec();
     let cmd_hdr = dpe
-        .command_hdr(dpe::commands::Command::CERTIFY_KEY)
+        .command_hdr(dpe::commands::CERTIFY_KEY)
         .as_bytes()
         .to_vec();
     let mut command = cmd_hdr;


### PR DESCRIPTION
This removes the `Command` enum completely `deserialize_command` instead returns a `dyn` reference to the `CommandExecution` trait.

This uses a `dyn` reference instead of an `impl` because `dyn` can take a performance hit but saves on code size because it is dynamically dispatched. We are low on memory in Caliptra RT firmware and we are not concerned with performance.

Dyn references can't have `impl` types in any of the function parameters so this also switches the `impl DpeTypes` for `DpeEnv` to be a generic.

Also because we can't check equality anymore because the compiler doesn't know what kind of object it is, the deserialization tests just check for OK now.