### PR TITLE
Remove DeriveContextFlags::INPUT_ALLOW_X509

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -69,9 +69,6 @@ impl CommandExecution for CertifyKeyCmd {
             if !env.state.support.x509() {
                 return Err(DpeErrorCode::ArgumentNotSupported);
             }
-            if !context.allow_x509() {
-                return Err(DpeErrorCode::InvalidArgument);
-            }
         } else if self.format == Self::FORMAT_CSR && !env.state.support.csr() {
             return Err(DpeErrorCode::ArgumentNotSupported);
         }
@@ -84,7 +81,6 @@ impl CommandExecution for CertifyKeyCmd {
         cfg_if! {
             if #[cfg(not(feature = "no-cfi"))] {
                 cfi_assert!(self.format != Self::FORMAT_X509 || env.state.support.x509());
-                cfi_assert!(self.format != Self::FORMAT_X509 || context.allow_x509());
                 cfi_assert!(self.format != Self::FORMAT_CSR || env.state.support.csr());
                 cfi_assert_eq(context.locality, locality);
             }
@@ -524,7 +520,7 @@ mod tests {
         let derive_cmd = DeriveContextCmd {
             handle: ContextHandle::default(),
             data: [1; DPE_PROFILE.tci_size()],
-            flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INPUT_ALLOW_X509,
+            flags: DeriveContextFlags::MAKE_DEFAULT,
             tci_type: 1,
             target_locality: 0,
             svn: 0,

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -38,7 +38,6 @@ bitflags! {
         const MAKE_DEFAULT = 1u32 << 28;
         const CHANGE_LOCALITY = 1u32 << 27;
         const ALLOW_NEW_CONTEXT_TO_EXPORT = 1u32 << 26;
-        const INPUT_ALLOW_X509 = 1u32 << 25;
         const RECURSIVE = 1u32 << 24;
         const EXPORT_CDI = 1u32 << 23;
         const CREATE_CERTIFICATE = 1u32 << 22;
@@ -84,10 +83,6 @@ impl DeriveContextCmd {
 
     pub const fn changes_locality(&self) -> bool {
         self.flags.contains(DeriveContextFlags::CHANGE_LOCALITY)
-    }
-
-    const fn allows_x509(&self) -> bool {
-        self.flags.contains(DeriveContextFlags::INPUT_ALLOW_X509)
     }
 
     pub const fn is_recursive(&self) -> bool {
@@ -212,7 +207,6 @@ impl CommandExecution for DeriveContextCmd {
         if (!support.internal_info() && self.uses_internal_info_input())
             || (!support.internal_dice() && self.uses_internal_dice_input())
             || (!support.retain_parent_context() && self.retains_parent())
-            || (!support.x509() && self.allows_x509())
             || (!support.cdi_export() && (self.creates_certificate() || self.exports_cdi()))
             || (!support.recursive() && self.is_recursive())
         {
@@ -220,8 +214,7 @@ impl CommandExecution for DeriveContextCmd {
         }
 
         let parent_idx = env.state.get_active_context_pos(&self.handle, locality)?;
-        if (!env.state.contexts[parent_idx].allow_x509() && self.allows_x509())
-            || (self.exports_cdi() && !self.creates_certificate())
+        if (self.exports_cdi() && !self.creates_certificate())
             || (self.exports_cdi() && self.is_recursive())
             || (self.exports_cdi() && self.changes_locality())
             || (self.exports_cdi()
@@ -247,8 +240,6 @@ impl CommandExecution for DeriveContextCmd {
                 cfi_assert!(support.internal_info() || !self.uses_internal_info_input());
                 cfi_assert!(support.internal_dice() || !self.uses_internal_dice_input());
                 cfi_assert!(support.retain_parent_context() || !self.retains_parent());
-                cfi_assert!(support.x509() || !self.allows_x509());
-                cfi_assert!(env.state.contexts[parent_idx].allow_x509() || !self.allows_x509());
                 cfi_assert!(!self.is_recursive() || !self.retains_parent());
             }
         }
@@ -382,7 +373,6 @@ impl CommandExecution for DeriveContextCmd {
             dpe.generate_new_handle(env)?
         };
 
-        let allow_x509 = self.allows_x509();
         let uses_internal_input_info = self.uses_internal_info_input();
         let uses_internal_input_dice = self.uses_internal_dice_input();
 
@@ -394,7 +384,6 @@ impl CommandExecution for DeriveContextCmd {
             handle: &child_handle,
             tci_type: self.tci_type,
             parent_idx: parent_idx as u8,
-            allow_x509,
             uses_internal_input_info,
             uses_internal_input_dice,
             allow_export_cdi: self.allows_new_context_to_export()
@@ -1070,7 +1059,6 @@ mod tests {
             .get_active_context_pos(&ContextHandle::default(), 0)
             .unwrap();
         // ensure flags are unchanged
-        assert!(env.state.contexts[child_idx].allow_x509());
         assert!(!env.state.contexts[child_idx].uses_internal_input_info());
         assert!(!env.state.contexts[child_idx].uses_internal_input_dice());
         // Still using the same context.

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -97,7 +97,6 @@ impl CommandExecution for InitCtxCmd {
             handle: &handle,
             tci_type: 0,
             parent_idx: Context::ROOT_INDEX,
-            allow_x509: true,
             uses_internal_input_info: false,
             uses_internal_input_dice: false,
             allow_export_cdi: true,

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -226,7 +226,7 @@ mod tests {
             DeriveContextCmd {
                 handle: ContextHandle::default(),
                 data: [i; DPE_PROFILE.hash_size()],
-                flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INPUT_ALLOW_X509,
+                flags: DeriveContextFlags::MAKE_DEFAULT,
                 tci_type: i as u32,
                 target_locality: 0,
                 svn: 0,

--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -30,11 +30,9 @@ pub struct Context {
     pub uses_internal_input_info: U8Bool,
     /// Whether we should hash internal dice info consisting of the certificate chain when deriving the CDI
     pub uses_internal_input_dice: U8Bool,
-    /// Whether this context can emit certificates in X.509 format
-    pub allow_x509: U8Bool,
     /// Whether this context can use the `EXPORT_CDI` feature.
     pub allow_export_cdi: U8Bool,
-    pub reserved: [u8; 1],
+    pub reserved: [u8; 2],
 }
 
 #[cfg(test)]
@@ -70,11 +68,10 @@ impl Context {
             locality: 0,
             uses_internal_input_info: U8Bool::new(false),
             uses_internal_input_dice: U8Bool::new(false),
-            allow_x509: U8Bool::new(false),
             // The root context needs to
             // allow_export_cdi or it is never enabled.
             allow_export_cdi: U8Bool::new(true),
-            reserved: [0; 1],
+            reserved: [0; 2],
         }
     }
 
@@ -83,9 +80,6 @@ impl Context {
     }
     pub fn uses_internal_input_dice(&self) -> bool {
         self.uses_internal_input_dice.get()
-    }
-    pub fn allow_x509(&self) -> bool {
-        self.allow_x509.get()
     }
     pub fn allow_export_cdi(&self) -> bool {
         self.allow_export_cdi.get()
@@ -103,7 +97,6 @@ impl Context {
         self.context_type = args.context_type;
         self.state = ContextState::Active;
         self.locality = args.locality;
-        self.allow_x509 = args.allow_x509.into();
         self.uses_internal_input_info = args.uses_internal_input_info.into();
         self.uses_internal_input_dice = args.uses_internal_input_dice.into();
         self.allow_export_cdi = args.allow_export_cdi.into();
@@ -116,7 +109,6 @@ impl Context {
         self.state = ContextState::Inactive;
         self.uses_internal_input_info = false.into();
         self.uses_internal_input_dice = false.into();
-        self.allow_x509 = false.into();
         self.parent_idx = Self::ROOT_INDEX;
         self.locality = 0;
         self.children = 0;
@@ -202,7 +194,6 @@ pub struct ActiveContextArgs<'a> {
     pub handle: &'a ContextHandle,
     pub tci_type: u32,
     pub parent_idx: u8,
-    pub allow_x509: bool,
     pub uses_internal_input_info: bool,
     pub uses_internal_input_dice: bool,
     pub allow_export_cdi: bool,

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -329,9 +329,6 @@ impl DpeInstance {
                 uses_internal_input_info || context.uses_internal_input_info();
             uses_internal_input_dice =
                 uses_internal_input_dice || context.uses_internal_input_dice();
-
-            // Add allow x509 to hash
-            hasher.update(context.allow_x509().as_bytes())?;
         }
 
         // Add internal input info to hash
@@ -592,9 +589,6 @@ pub mod tests {
         for result in ChildToRootIter::new(leaf_idx, &env.state.contexts) {
             let context = result.unwrap();
             hasher.update(context.tci.as_bytes()).unwrap();
-            hasher
-                .update(/*allow_x509=*/ context.allow_x509().as_bytes())
-                .unwrap();
         }
 
         let digest = hasher.finish().unwrap();
@@ -640,9 +634,7 @@ pub mod tests {
         let mut hasher = env.crypto.hash_initialize().unwrap();
 
         hasher.update(child_context.tci.as_bytes()).unwrap();
-        hasher.update(/*allow_x509=*/ false.as_bytes()).unwrap();
         hasher.update(parent_context.tci.as_bytes()).unwrap();
-        hasher.update(/*allow_x509=*/ true.as_bytes()).unwrap();
         let mut internal_input_info = [0u8; INTERNAL_INPUT_INFO_SIZE];
         dpe.serialize_internal_input_info(
             &mut env.platform,
@@ -698,9 +690,7 @@ pub mod tests {
         let mut hasher = env.crypto.hash_initialize().unwrap();
 
         hasher.update(child_context.tci.as_bytes()).unwrap();
-        hasher.update(/*allow_x509=*/ false.as_bytes()).unwrap();
         hasher.update(parent_context.tci.as_bytes()).unwrap();
-        hasher.update(/*allow_x509=*/ true.as_bytes()).unwrap();
         let cert_chain = env.platform.0.cert_chain();
         hasher.update(&cert_chain).unwrap();
 

--- a/dpe/src/validation.rs
+++ b/dpe/src/validation.rs
@@ -34,7 +34,6 @@ pub enum ValidationError {
     ChildWithMultipleParents = 0x12,
     ParentChildLinksCorrupted = 0x13,
     AllowCaNotSupported = 0x14,
-    AllowX509NotSupported = 0x15,
     InactiveParent = 0x16,
     InactiveChild = 0x17,
     DpeNotMarkedInitialized = 0x18,
@@ -120,14 +119,6 @@ impl DpeValidator<'_> {
         if !self.dpe.support.internal_info() && context.uses_internal_input_info() {
             return Err(ValidationError::InternalInfoNotSupported);
         }
-        // initialized contexts will always have parent = Context::ROOT_INDEX and then the allow_x509
-        // field will always be true regardless of support.
-        if context.parent_idx != Context::ROOT_INDEX
-            && !self.dpe.support.x509()
-            && context.allow_x509()
-        {
-            return Err(ValidationError::AllowX509NotSupported);
-        }
         Ok(())
     }
 
@@ -139,10 +130,7 @@ impl DpeValidator<'_> {
             Err(ValidationError::InactiveContextWithChildren)
         } else if context.tci != TciNodeData::default() {
             Err(ValidationError::InactiveContextWithMeasurement)
-        } else if context.uses_internal_input_dice()
-            || context.allow_x509()
-            || context.uses_internal_input_info()
-        {
+        } else if context.uses_internal_input_dice() || context.uses_internal_input_info() {
             Err(ValidationError::InactiveContextWithFlagSet)
         } else {
             Ok(())
@@ -382,15 +370,6 @@ pub mod tests {
             dpe_validator.validate_dpe_state(),
             Err(ValidationError::InternalInfoNotSupported)
         );
-
-        // test x509
-        dpe_validator.dpe.contexts[0].parent_idx = 1;
-        dpe_validator.dpe.contexts[0].uses_internal_input_info = U8Bool::new(false);
-        dpe_validator.dpe.contexts[0].allow_x509 = U8Bool::new(true);
-        assert_eq!(
-            dpe_validator.validate_dpe_state(),
-            Err(ValidationError::AllowX509NotSupported)
-        );
     }
 
     #[test]
@@ -425,7 +404,7 @@ pub mod tests {
         );
 
         dpe_validator.dpe.contexts[0].tci.tci_current = TciMeasurement::default();
-        dpe_validator.dpe.contexts[0].allow_x509 = U8Bool::new(true);
+        dpe_validator.dpe.contexts[0].uses_internal_input_info = U8Bool::new(true);
         assert_eq!(
             dpe_validator.validate_dpe_state(),
             Err(ValidationError::InactiveContextWithFlagSet)

--- a/tools/src/sample_dpe_cert.rs
+++ b/tools/src/sample_dpe_cert.rs
@@ -46,7 +46,7 @@ fn add_tcb_info(
     let cmd = DeriveContextCmd {
         handle: ContextHandle::default(),
         data: *data,
-        flags: DeriveContextFlags::INPUT_ALLOW_X509 | DeriveContextFlags::MAKE_DEFAULT,
+        flags: DeriveContextFlags::MAKE_DEFAULT,
         tci_type,
         target_locality: 0, // Unused since flag isn't set
         svn,

--- a/verification/testing/deriveContext.go
+++ b/verification/testing/deriveContext.go
@@ -314,8 +314,7 @@ func TestPrivilegesEscalation(d client.TestDPEInstance, c client.DPEClient, t *t
 	// Create a child TCI node with no special privileges
 	resp, err := c.DeriveContext(handle,
 		make([]byte, digestLen),
-		client.DeriveContextFlags(0),
-		0, 0)
+		0, 0, 0)
 	if err != nil {
 		t.Fatalf("[FATAL]: Error encountered in getting child context: %v", err)
 	}
@@ -324,17 +323,9 @@ func TestPrivilegesEscalation(d client.TestDPEInstance, c client.DPEClient, t *t
 	// Adding new privileges to child that parent does NOT possess will cause failure
 	_, err = c.DeriveContext(handle,
 		make([]byte, digestLen),
-		client.DeriveContextFlags(client.InputAllowX509),
+		client.DeriveContextFlags(client.AllowNewContextToExport|client.CdiExport|client.CreateCertificate),
 		0, 0)
 	if err == nil {
-		t.Errorf("[ERROR]: Should return %q, but returned no error", client.StatusInvalidArgument)
-	} else if !errors.Is(err, client.StatusInvalidArgument) {
-		t.Errorf("[ERROR]: Incorrect error type. Should return %q, but returned %q", client.StatusInvalidArgument, err)
-	}
-
-	// Similarly, when commands like CertifyKey try to make use of features/flags that are unsupported
-	// by child context, it will fail.
-	if _, err = c.CertifyKey(handle, make([]byte, digestLen), client.CertifyKeyX509, 0); err == nil {
 		t.Errorf("[ERROR]: Should return %q, but returned no error", client.StatusInvalidArgument)
 	} else if !errors.Is(err, client.StatusInvalidArgument) {
 		t.Errorf("[ERROR]: Incorrect error type. Should return %q, but returned %q", client.StatusInvalidArgument, err)
@@ -360,7 +351,7 @@ func TestMaxTCIs(d client.TestDPEInstance, c client.DPEClient, t *testing.T) {
 	maxTciCount := int(d.GetMaxTciNodes())
 	allowedTciCount := maxTciCount - 1 // since, a TCI node is already auto-initialized
 	for i := 0; i < allowedTciCount; i++ {
-		resp, err = c.DeriveContext(handle, make([]byte, digestSize), client.InputAllowX509, 0, 0)
+		resp, err = c.DeriveContext(handle, make([]byte, digestSize), 0, 0, 0)
 		if err != nil {
 			t.Fatalf("[FATAL]: Error encountered in executing derive child: %v", err)
 		}
@@ -556,7 +547,7 @@ func TestDeriveContextRecursiveOnDerivedContexts(d client.TestDPEInstance, c cli
 	}()
 
 	// DeriveContext with input data, tag it and check TCI_CUMULATIVE
-	childCtx, err := c.DeriveContext(parentHandle, tciValue, client.DeriveContextFlags(client.RetainParentContext|client.InputAllowX509), 0, 0)
+	childCtx, err := c.DeriveContext(parentHandle, tciValue, client.DeriveContextFlags(client.RetainParentContext), 0, 0)
 	if err != nil {
 		t.Fatalf("[FATAL]: Error while creating default child handle in default context: %s", err)
 	}

--- a/verification/testing/negativeCases.go
+++ b/verification/testing/negativeCases.go
@@ -190,11 +190,4 @@ func TestUnsupportedCommandFlag(d client.TestDPEInstance, c client.DPEClient, t 
 	} else if !errors.Is(err, client.StatusArgumentNotSupported) {
 		t.Errorf("[ERROR]: Incorrect error type. InternalDice is not supported by DPE, DeriveContext should return %q, but returned %q", client.StatusArgumentNotSupported, err)
 	}
-
-	// Check whether error is returned since InternalDice usage is unsupported by DPE profile
-	if _, err := c.DeriveContext(handle, make([]byte, digestLen), client.DeriveContextFlags(client.InputAllowX509), 0, 0); err == nil {
-		t.Errorf("[ERROR]:X509 is not supported by DPE, DeriveContext should return %q, but returned no error", client.StatusArgumentNotSupported)
-	} else if !errors.Is(err, client.StatusArgumentNotSupported) {
-		t.Errorf("[ERROR]: Incorrect error type. X509 is not supported by DPE, DeriveContext should return %q, but returned %q", client.StatusArgumentNotSupported, err)
-	}
 }

--- a/verification/testing/simulator.go
+++ b/verification/testing/simulator.go
@@ -122,7 +122,7 @@ func GetSimulatorTargets() []TestTarget {
 		},
 		{
 			"DeriveContext",
-			getTestTarget([]string{"AutoInit", "X509", "RetainParentContext"}),
+			getTestTarget([]string{"AutoInit", "RetainParentContext"}),
 			[]TestCase{DeriveContextTestCase},
 		},
 		{
@@ -147,12 +147,12 @@ func GetSimulatorTargets() []TestTarget {
 		},
 		{
 			"DeriveContext_Simulation",
-			getTestTarget([]string{"AutoInit", "Simulation", "X509", "RetainParentContext"}),
+			getTestTarget([]string{"AutoInit", "Simulation", "RetainParentContext"}),
 			[]TestCase{DeriveContextSimulationTestCase},
 		},
 		{
 			"DeriveContext_PrivilegeEscalation",
-			getTestTarget([]string{"AutoInit", "X509"}),
+			getTestTarget([]string{"AutoInit", "CdiExport"}),
 			[]TestCase{DeriveContextPrivilegeEscalationTestCase},
 		},
 		{

--- a/verification/testing/verification.go
+++ b/verification/testing/verification.go
@@ -129,7 +129,7 @@ var TestDeriveContextAllowedChildCdiExportTestCase = TestCase{
 
 // DeriveContextSimulationTestCase tests DeriveContext with Simulation contexts
 var DeriveContextSimulationTestCase = TestCase{
-	"DeriveContextSimulation", TestDeriveContextSimulation, []string{"AutoInit", "Simulation", "X509", "InternalDice", "InternalInfo", "RetainParentContext"},
+	"DeriveContextSimulation", TestDeriveContextSimulation, []string{"AutoInit", "Simulation", "InternalDice", "InternalInfo", "RetainParentContext"},
 }
 
 // DeriveContextMaxTCIsTestCase checks whether the number of derived contexts is limited by MAX_TCI_NODES attribute of the profile
@@ -144,7 +144,7 @@ var DeriveContextLocalityTestCase = TestCase{
 
 // DeriveContextPrivilegeEscalationTestCase tests that commands trying to use features that are unsupported by child context fail.
 var DeriveContextPrivilegeEscalationTestCase = TestCase{
-	"DeriveContext_PrivilegeEscalation", TestPrivilegesEscalation, []string{"AutoInit", "X509"},
+	"DeriveContext_PrivilegeEscalation", TestPrivilegesEscalation, []string{"AutoInit", "CdiExport"},
 }
 
 // DeriveContextInputFlagsTestCase tests DeriveContext with the input flags InternalDiceInfo and InternalInputInfo.
@@ -154,12 +154,12 @@ var DeriveContextInputFlagsTestCase = TestCase{
 
 // DeriveContextRecursiveTestCase tests DeriveContext with the Recursive input flag
 var DeriveContextRecursiveTestCase = TestCase{
-	"DeriveContext_Recursive", TestDeriveContextRecursive, []string{"AutoInit", "Recursive", "X509"},
+	"DeriveContext_Recursive", TestDeriveContextRecursive, []string{"AutoInit", "Recursive"},
 }
 
 // DeriveContextRecursiveOnDerivedContextsTestCase tests DeriveContext with the Recursive input flag on derived contexts
 var DeriveContextRecursiveOnDerivedContextsTestCase = TestCase{
-	"DeriveContext_RecursiveOnDerivedContexts", TestDeriveContextRecursiveOnDerivedContexts, []string{"AutoInit", "Recursive", "RetainParentContext", "X509", "RotateContext"},
+	"DeriveContext_RecursiveOnDerivedContexts", TestDeriveContextRecursiveOnDerivedContexts, []string{"AutoInit", "Recursive", "RetainParentContext", "RotateContext"},
 }
 
 // AllTestCases contains all DPE test cases


### PR DESCRIPTION
This is a clean up item leftover from
chipsalliance#400.

Since DeriveContext using ExportedCDI replaced this feature, this code is no longer necessary.

This change saves ~464 bytes.