### PR TITLE
Build Sign command with multiple profiles.

### DIFF
--- a/dpe/fuzz/src/fuzz_target_1.rs
+++ b/dpe/fuzz/src/fuzz_target_1.rs
@@ -81,7 +81,7 @@ fn harness(data: &[u8]) {
         Response::DeriveContextExportedCdi(ref res) => res.resp_hdr.status,
         Response::RotateCtx(ref res) => res.resp_hdr.status,
         Response::CertifyKey(ref res) => res.resp_hdr.status,
-        Response::Sign(ref res) => res.resp_hdr.status,
+        Response::Sign(ref res) => res.resp_hdr().status,
         Response::DestroyCtx(ref resp_hdr) => resp_hdr.status,
         Response::GetCertificateChain(ref res) => res.resp_hdr.status,
         Response::Error(ref resp_hdr) => resp_hdr.status,

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -428,17 +428,21 @@ impl CommandExecution for DeriveContextCmd {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "dpe_profile_p256_sha256")]
+    use crate::commands::sign::SignP256Cmd as SignCmd;
+    #[cfg(feature = "dpe_profile_p384_sha384")]
+    use crate::commands::sign::SignP384Cmd as SignCmd;
     use crate::{
         commands::{
             rotate_context::{RotateCtxCmd, RotateCtxFlags},
             tests::{PROFILES, TEST_DIGEST, TEST_LABEL},
-            CertifyKeyCmd, CertifyKeyFlags, Command, CommandHdr, InitCtxCmd, SignCmd, SignFlags,
+            CertifyKeyCmd, CertifyKeyFlags, Command, CommandHdr, InitCtxCmd, SignFlags,
         },
         context::ContextType,
         dpe_instance::tests::{
             test_env, TestTypes, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_LOCALITIES,
         },
-        response::NewHandleResp,
+        response::{NewHandleResp, SignResp},
         support::Support,
         validation::DpeValidator,
         DpeProfile, MAX_EXPORTED_CDI_SIZE, MAX_HANDLES,
@@ -759,7 +763,17 @@ mod tests {
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         {
-            Ok(Response::Sign(resp)) => (
+            #[cfg(feature = "dpe_profile_p256_sha256")]
+            Ok(Response::Sign(SignResp::P256(resp))) => (
+                resp.new_context_handle,
+                EcdsaSig::from_private_components(
+                    BigNum::from_slice(&resp.sig_r).unwrap(),
+                    BigNum::from_slice(&resp.sig_s).unwrap(),
+                )
+                .unwrap(),
+            ),
+            #[cfg(feature = "dpe_profile_p384_sha384")]
+            Ok(Response::Sign(SignResp::P384(resp))) => (
                 resp.new_context_handle,
                 EcdsaSig::from_private_components(
                     BigNum::from_slice(&resp.sig_r).unwrap(),

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -12,7 +12,7 @@ pub use self::initialize_context::InitCtxCmd;
 pub use self::certify_key::{CertifyKeyCmd, CertifyKeyFlags};
 #[cfg(not(feature = "disable_rotate_context"))]
 pub use self::rotate_context::{RotateCtxCmd, RotateCtxFlags};
-pub use self::sign::{SignCmd, SignFlags};
+pub use self::sign::{SignCommand, SignFlags};
 
 use crate::{
     dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
@@ -37,7 +37,7 @@ pub enum Command<'a> {
     InitCtx(&'a InitCtxCmd),
     DeriveContext(&'a DeriveContextCmd),
     CertifyKey(&'a CertifyKeyCmd),
-    Sign(&'a SignCmd),
+    Sign(SignCommand<'a>),
     #[cfg(not(feature = "disable_rotate_context"))]
     RotateCtx(&'a RotateCtxCmd),
     DestroyCtx(&'a DestroyCtxCmd),
@@ -69,7 +69,7 @@ impl Command<'_> {
             Command::INITIALIZE_CONTEXT => Self::parse_command(Command::InitCtx, bytes),
             Command::DERIVE_CONTEXT => Self::parse_command(Command::DeriveContext, bytes),
             Command::CERTIFY_KEY => Self::parse_command(Command::CertifyKey, bytes),
-            Command::SIGN => Self::parse_command(Command::Sign, bytes),
+            Command::SIGN => Ok(Command::Sign(SignCommand::deserialize(profile, bytes)?)),
             #[cfg(not(feature = "disable_rotate_context"))]
             Command::ROTATE_CONTEXT_HANDLE => Self::parse_command(Command::RotateCtx, bytes),
             Command::DESTROY_CONTEXT => Self::parse_command(Command::DestroyCtx, bytes),

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -4,7 +4,7 @@ use crate::{
     context::{ContextHandle, ContextType},
     dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
     response::{DpeErrorCode, Response, SignResp},
-    DPE_PROFILE,
+    DpeProfile,
 };
 use bitflags::bitflags;
 #[cfg(not(feature = "no-cfi"))]
@@ -13,7 +13,8 @@ use caliptra_cfi_lib_git::cfi_launder;
 #[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_assert_ne};
 use cfg_if::cfg_if;
-use crypto::{ecdsa::EcdsaSignature, Crypto, Digest, Signature};
+use crypto::ecdsa::EcdsaSignature;
+use crypto::{Crypto, Digest, Signature};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 #[repr(C)]
@@ -24,49 +25,35 @@ bitflags! {
     impl SignFlags: u32 {}
 }
 
-#[repr(C)]
-#[derive(Debug, PartialEq, Eq, IntoBytes, FromBytes, Immutable, KnownLayout)]
-pub struct SignCmd {
-    pub handle: ContextHandle,
-    pub label: [u8; DPE_PROFILE.hash_size()],
-    pub flags: SignFlags,
-    pub digest: [u8; DPE_PROFILE.hash_size()],
+#[derive(Debug, PartialEq, Eq)]
+pub enum SignCommand<'a> {
+    #[cfg(feature = "dpe_profile_p256_sha256")]
+    P256(&'a SignP256Cmd),
+    #[cfg(feature = "dpe_profile_p384_sha384")]
+    P384(&'a SignP384Cmd),
 }
 
-impl SignCmd {
-    /// Signs `digest` using ECDSA
-    ///
-    /// # Arguments
-    ///
-    /// * `dpe` - DPE instance
-    /// * `env` - DPE environment containing Crypto and Platform implementations
-    /// * `idx` - The index of the context where the measurement hash is computed from
-    /// * `digest` - The data to be signed
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
-    fn sign(
-        &self,
-        dpe: &mut DpeInstance,
-        env: &mut DpeEnv<impl DpeTypes>,
-        idx: usize,
-        digest: &Digest,
-    ) -> Result<Signature, DpeErrorCode> {
-        let cdi_digest = dpe.compute_measurement_hash(env, idx)?;
-        let cdi = env.crypto.derive_cdi(&cdi_digest, b"DPE")?;
-        let key_pair = env.crypto.derive_key_pair(&cdi, &self.label, b"ECC");
-        if cfi_launder(key_pair.is_ok()) {
-            #[cfg(not(feature = "no-cfi"))]
-            cfi_assert!(key_pair.is_ok());
-        } else {
-            #[cfg(not(feature = "no-cfi"))]
-            cfi_assert!(key_pair.is_err());
+impl SignCommand<'_> {
+    pub fn deserialize(profile: DpeProfile, bytes: &[u8]) -> Result<SignCommand, DpeErrorCode> {
+        match profile {
+            #[cfg(feature = "dpe_profile_p256_sha256")]
+            DpeProfile::P256Sha256 => SignCommand::parse_command(SignCommand::P256, bytes),
+            #[cfg(feature = "dpe_profile_p384_sha384")]
+            DpeProfile::P384Sha384 => SignCommand::parse_command(SignCommand::P384, bytes),
+            _ => Err(DpeErrorCode::InvalidArgument)?,
         }
-        let (priv_key, pub_key) = key_pair?;
-
-        Ok(env.crypto.sign_with_derived(digest, &priv_key, &pub_key)?)
+    }
+    pub fn parse_command<'a, T: FromBytes + KnownLayout + Immutable + 'a>(
+        build: impl FnOnce(&'a T) -> SignCommand<'a>,
+        bytes: &'a [u8],
+    ) -> Result<SignCommand<'a>, DpeErrorCode> {
+        let (prefix, _remaining_bytes) =
+            T::ref_from_prefix(bytes).map_err(|_| DpeErrorCode::InvalidArgument)?;
+        Ok(build(prefix))
     }
 }
 
-impl CommandExecution for SignCmd {
+impl CommandExecution for SignCommand<'_> {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     fn execute(
         &self,
@@ -74,66 +61,173 @@ impl CommandExecution for SignCmd {
         env: &mut DpeEnv<impl DpeTypes>,
         locality: u32,
     ) -> Result<Response, DpeErrorCode> {
-        let idx = env.state.get_active_context_pos(&self.handle, locality)?;
-        let context = &env.state.contexts[idx];
-
-        if context.context_type == ContextType::Simulation {
-            return Err(DpeErrorCode::InvalidArgument);
-        }
-
-        cfg_if! {
-            if #[cfg(not(feature = "no-cfi"))] {
-                cfi_assert_ne(context.context_type, ContextType::Simulation);
-            }
-        }
-
-        #[cfg(feature = "dpe_profile_p256_sha256")]
-        let digest = Digest::Sha256(
-            crypto::Sha256::read_from_bytes(&self.digest)
-                .map_err(|_| DpeErrorCode::Crypto(crypto::CryptoError::Size))?,
-        );
-
-        #[cfg(feature = "dpe_profile_p384_sha384")]
-        let digest = Digest::Sha384(
-            crypto::Sha384::read_from_bytes(&self.digest)
-                .map_err(|_| DpeErrorCode::Crypto(crypto::CryptoError::Size))?,
-        );
-
-        let sig = match self.sign(dpe, env, idx, &digest)? {
+        match self {
             #[cfg(feature = "dpe_profile_p256_sha256")]
-            Signature::Ecdsa(EcdsaSignature::Ecdsa256(sig)) => sig,
+            SignCommand::P256(cmd) => cmd.execute(dpe, env, locality),
             #[cfg(feature = "dpe_profile_p384_sha384")]
-            Signature::Ecdsa(EcdsaSignature::Ecdsa384(sig)) => sig,
-            _ => Err(DpeErrorCode::InvalidArgument)?,
-        };
+            SignCommand::P384(cmd) => cmd.execute(dpe, env, locality),
+        }
+    }
+}
 
-        let (&sig_r, &sig_s) = sig.as_slice()?;
+/// Signs `digest` using ECDSA
+///
+/// # Arguments
+///
+/// * `dpe` - DPE instance
+/// * `env` - DPE environment containing Crypto and Platform implementations
+/// * `idx` - The index of the context where the measurement hash is computed from
+/// * `digest` - The data to be signed
+fn sign(
+    dpe: &mut DpeInstance,
+    env: &mut DpeEnv<impl DpeTypes>,
+    idx: usize,
+    label: &[u8],
+    digest: &Digest,
+) -> Result<Signature, DpeErrorCode> {
+    let cdi_digest = dpe.compute_measurement_hash(env, idx)?;
+    let cdi = env.crypto.derive_cdi(&cdi_digest, b"DPE")?;
+    let key_pair = env.crypto.derive_key_pair(&cdi, label, b"ECC");
+    if cfi_launder(key_pair.is_ok()) {
+        #[cfg(not(feature = "no-cfi"))]
+        cfi_assert!(key_pair.is_ok());
+    } else {
+        #[cfg(not(feature = "no-cfi"))]
+        cfi_assert!(key_pair.is_err());
+    }
+    let (priv_key, pub_key) = key_pair?;
 
-        // Rotate the handle if it isn't the default context.
-        dpe.roll_onetime_use_handle(env, idx)?;
+    Ok(env.crypto.sign_with_derived(digest, &priv_key, &pub_key)?)
+}
 
-        Ok(Response::Sign(SignResp {
-            new_context_handle: env.state.contexts[idx].handle,
-            sig_r,
-            sig_s,
-            resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
-        }))
+fn execute(
+    dpe: &mut DpeInstance,
+    env: &mut DpeEnv<impl DpeTypes>,
+    handle: &ContextHandle,
+    label: &[u8],
+    digest: &[u8],
+    locality: u32,
+) -> Result<Response, DpeErrorCode> {
+    let idx = env.state.get_active_context_pos(handle, locality)?;
+    let context = &env.state.contexts[idx];
+
+    if context.context_type == ContextType::Simulation {
+        return Err(DpeErrorCode::InvalidArgument);
+    }
+
+    cfg_if! {
+        if #[cfg(not(feature = "no-cfi"))] {
+            cfi_assert_ne(context.context_type, ContextType::Simulation);
+        }
+    }
+
+    let digest = match dpe.profile {
+        #[cfg(feature = "dpe_profile_p256_sha256")]
+        crate::DpeProfile::P256Sha256 => Digest::Sha256(
+            crypto::Sha256::read_from_bytes(digest)
+                .map_err(|_| DpeErrorCode::Crypto(crypto::CryptoError::Size))?,
+        ),
+        #[cfg(feature = "dpe_profile_p384_sha384")]
+        crate::DpeProfile::P384Sha384 => Digest::Sha384(
+            crypto::Sha384::read_from_bytes(digest)
+                .map_err(|_| DpeErrorCode::Crypto(crypto::CryptoError::Size))?,
+        ),
+        _ => Err(DpeErrorCode::InvalidArgument)?,
+    };
+
+    let mut response = match sign(dpe, env, idx, label, &digest)? {
+        #[cfg(feature = "dpe_profile_p256_sha256")]
+        Signature::Ecdsa(EcdsaSignature::Ecdsa256(sig)) => {
+            use crate::response::SignP256Resp;
+            let (&sig_r, &sig_s) = sig.as_slice()?;
+            SignResp::P256(SignP256Resp {
+                new_context_handle: ContextHandle::new_invalid(),
+                sig_r,
+                sig_s,
+                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+            })
+        }
+        #[cfg(feature = "dpe_profile_p384_sha384")]
+        Signature::Ecdsa(EcdsaSignature::Ecdsa384(sig)) => {
+            use crate::response::SignP384Resp;
+            let (&sig_r, &sig_s) = sig.as_slice()?;
+            SignResp::P384(SignP384Resp {
+                new_context_handle: ContextHandle::new_invalid(),
+                sig_r,
+                sig_s,
+                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+            })
+        }
+        _ => Err(DpeErrorCode::InvalidArgument)?,
+    };
+
+    // Rotate the handle if it isn't the default context.
+    dpe.roll_onetime_use_handle(env, idx)?;
+    response.set_handle(&env.state.contexts[idx].handle);
+
+    Ok(Response::Sign(response))
+}
+
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq, IntoBytes, FromBytes, Immutable, KnownLayout)]
+pub struct SignP256Cmd {
+    pub handle: ContextHandle,
+    pub label: [u8; 32],
+    pub flags: SignFlags,
+    pub digest: [u8; 32],
+}
+
+impl CommandExecution for SignP256Cmd {
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    fn execute(
+        &self,
+        dpe: &mut DpeInstance,
+        env: &mut DpeEnv<impl DpeTypes>,
+        locality: u32,
+    ) -> Result<Response, DpeErrorCode> {
+        execute(dpe, env, &self.handle, &self.label, &self.digest, locality)
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq, IntoBytes, FromBytes, Immutable, KnownLayout)]
+pub struct SignP384Cmd {
+    pub handle: ContextHandle,
+    pub label: [u8; 48],
+    pub flags: SignFlags,
+    pub digest: [u8; 48],
+}
+
+impl CommandExecution for SignP384Cmd {
+    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    fn execute(
+        &self,
+        dpe: &mut DpeInstance,
+        env: &mut DpeEnv<impl DpeTypes>,
+        locality: u32,
+    ) -> Result<Response, DpeErrorCode> {
+        execute(dpe, env, &self.handle, &self.label, &self.digest, locality)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "dpe_profile_p256_sha256")]
+    use crate::commands::sign::SignP256Cmd as SignCmd;
+    #[cfg(feature = "dpe_profile_p384_sha384")]
+    use crate::commands::sign::SignP384Cmd as SignCmd;
     use crate::{
         commands::{
             certify_key::{CertifyKeyCmd, CertifyKeyFlags},
             derive_context::DeriveContextFlags,
-            tests::{PROFILES, TEST_DIGEST, TEST_LABEL},
+            tests::{TEST_DIGEST, TEST_LABEL},
             Command, CommandHdr, DeriveContextCmd, InitCtxCmd,
         },
         dpe_instance::tests::{
             test_env, test_state, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_LOCALITIES,
         },
+        DPE_PROFILE,
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use openssl::x509::X509;
@@ -150,14 +244,16 @@ mod tests {
     #[test]
     fn test_deserialize_sign() {
         CfiCounter::reset_for_test();
-        for p in PROFILES {
-            let mut command = CommandHdr::new(p, Command::SIGN).as_bytes().to_vec();
-            command.extend(TEST_SIGN_CMD.as_bytes());
-            assert_eq!(
-                Ok(Command::Sign(&TEST_SIGN_CMD)),
-                Command::deserialize(p, &command)
-            );
-        }
+        let mut command = CommandHdr::new(DPE_PROFILE, Command::SIGN)
+            .as_bytes()
+            .to_vec();
+        command.extend(TEST_SIGN_CMD.as_bytes());
+
+        #[cfg(feature = "dpe_profile_p256_sha256")]
+        let expected = Command::Sign(SignCommand::P256(&TEST_SIGN_CMD));
+        #[cfg(feature = "dpe_profile_p384_sha384")]
+        let expected = Command::Sign(SignCommand::P384(&TEST_SIGN_CMD));
+        assert_eq!(Ok(expected), Command::deserialize(DPE_PROFILE, &command));
     }
 
     #[test]
@@ -247,9 +343,16 @@ mod tests {
                 _ => panic!("Incorrect response type"),
             };
 
+            let (r, s) = match resp {
+                #[cfg(feature = "dpe_profile_p256_sha256")]
+                SignResp::P256(resp) => (resp.sig_r, resp.sig_s),
+                #[cfg(feature = "dpe_profile_p384_sha384")]
+                SignResp::P384(resp) => (resp.sig_r, resp.sig_s),
+            };
+
             EcdsaSig::from_private_components(
-                BigNum::from_slice(&resp.sig_r).unwrap(),
-                BigNum::from_slice(&resp.sig_s).unwrap(),
+                BigNum::from_slice(&r).unwrap(),
+                BigNum::from_slice(&s).unwrap(),
             )
             .unwrap()
         };

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -55,7 +55,7 @@ fn handle_request(dpe: &mut DpeInstance, env: &mut DpeEnv<impl DpeTypes>, stream
         Response::DeriveContextExportedCdi(ref res) => res.resp_hdr.status,
         Response::RotateCtx(ref res) => res.resp_hdr.status,
         Response::CertifyKey(ref res) => res.resp_hdr.status,
-        Response::Sign(ref res) => res.resp_hdr.status,
+        Response::Sign(ref res) => res.resp_hdr().status,
         Response::DestroyCtx(ref resp_hdr) => resp_hdr.status,
         Response::GetCertificateChain(ref res) => res.resp_hdr.status,
         Response::Error(ref resp_hdr) => resp_hdr.status,


### PR DESCRIPTION
This will allow us to expand DPE to support both ECDSA and MLDSA profiles for Caliptra firmware.