### PR TITLE
Add tool to get DPE cert/CSR size.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,51 +13,59 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.4"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.2"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.0"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.1"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arrayvec"
@@ -209,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.8"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
+checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -219,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.8"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
+checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -231,11 +239,11 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -243,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cms"
@@ -261,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "const-oid"
@@ -338,7 +346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
 dependencies = [
  "nix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -495,7 +503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -569,6 +577,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,8 +629,14 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -755,6 +775,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
@@ -996,7 +1022,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1101,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -1117,7 +1143,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -1228,6 +1254,8 @@ dependencies = [
 name = "tools"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "clap",
  "crypto",
  "dpe",
  "pem",
@@ -1279,9 +1307,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcpkg"
@@ -1333,12 +1361,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1347,13 +1390,30 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1363,10 +1423,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1375,10 +1447,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1387,16 +1477,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "x509-cert"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 
 [features]
 default = ["dpe_profile_p256_sha256"]
+# Run ARBITRARY_MAX_HANDLES=n cargo build --features arbitrary_max_handles to use this feature
+arbitrary_max_handles = ["dpe/arbitrary_max_handles"]
 dpe_profile_p256_sha256 = [
   "dpe/dpe_profile_p256_sha256"
 ]
@@ -19,7 +21,9 @@ ml-dsa = [
 ]
 
 [dependencies]
+anyhow = "1.0.70"
 dpe = {path = "../dpe", default-features = false, features = ["no-cfi"]}
+clap = { version = "4.1.8", features = ["derive"] }
 crypto = {path = "../crypto", default-features = false, features = ["deterministic_rand", "rustcrypto"]}
 pem = "2"
 platform = {path = "../platform", default-features = false, features = ["rustcrypto"]}
@@ -29,3 +33,7 @@ zerocopy.workspace = true
 name = "sample_dpe_cert"
 path = "src/sample_dpe_cert.rs"
 target = 'cfg("test")'
+
+[[bin]]
+name = "cert-size"
+path = "src/cert_size.rs"

--- a/tools/src/cert_size.rs
+++ b/tools/src/cert_size.rs
@@ -1,0 +1,199 @@
+// Licensed under the Apache-2.0 license
+
+use alg::*;
+use anyhow::{anyhow, Result};
+use clap::{Parser, ValueEnum};
+use dpe::{
+    commands::{CertifyKeyCommand, CertifyKeyFlags, CommandExecution, DeriveContextFlags},
+    context::ContextHandle,
+    DpeFlags, DPE_PROFILE,
+};
+use dpe::{
+    dpe_instance::{DpeEnv, DpeTypes},
+    response::Response,
+    support::Support,
+    DpeInstance,
+};
+use platform::default::{DefaultPlatform, DefaultPlatformProfile};
+
+#[cfg(feature = "dpe_profile_p256_sha256")]
+mod alg {
+    pub use super::Algorithm::Ec as DefaultAlg;
+    pub use crypto::Ecdsa256RustCrypto as EcdsaRustCrypto;
+    pub use dpe::commands::{
+        CertifyKeyP256Cmd as CertifyKeyCmd, DeriveContextP256Cmd as DeriveContextCmd,
+    };
+}
+#[cfg(feature = "dpe_profile_p384_sha384")]
+mod alg {
+    pub use super::Algorithm::Ec as DefaultAlg;
+    pub use crypto::Ecdsa384RustCrypto as EcdsaRustCrypto;
+    pub use dpe::commands::{
+        CertifyKeyP384Cmd as CertifyKeyCmd, DeriveContextP384Cmd as DeriveContextCmd,
+    };
+}
+#[cfg(feature = "ml-dsa")]
+mod alg {
+    pub use super::Algorithm::Mldsa as DefaultAlg;
+    pub use crypto::MldsaRustCrypto;
+    pub use dpe::commands::{
+        CertifyKeyMldsaExternalMu87Cmd as CertifyKeyCmd,
+        DeriveContextMldsaExternalMu87Cmd as DeriveContextCmd,
+    };
+}
+
+#[derive(ValueEnum, Clone, Debug, Default)]
+pub enum Algorithm {
+    /// Use EC P256 or P384 depending on the build feature
+    #[cfg(any(
+        feature = "dpe_profile_p256_sha256",
+        feature = "dpe_profile_p384_sha384"
+    ))]
+    #[default]
+    Ec,
+    #[cfg(feature = "ml-dsa")]
+    #[default]
+    /// Use ML-DSA
+    Mldsa,
+}
+
+impl From<Algorithm> for DefaultPlatformProfile {
+    fn from(algorithm: Algorithm) -> Self {
+        match algorithm {
+            #[cfg(feature = "dpe_profile_p256_sha256")]
+            Algorithm::Ec => DefaultPlatformProfile::P256,
+            #[cfg(feature = "dpe_profile_p384_sha384")]
+            Algorithm::Ec => DefaultPlatformProfile::P384,
+            #[cfg(feature = "ml-dsa")]
+            Algorithm::Mldsa => DefaultPlatformProfile::Mldsa87ExternalMu,
+        }
+    }
+}
+
+/// Starts a DPE simulator that will receive commands and send responses over unix streams.
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Which algorithm to use.
+    #[arg(long, short, value_enum, default_value_t = DefaultAlg)]
+    algorithm: Algorithm,
+    /// Number of contexts to create.
+    #[arg(long, short, default_value_t = 1)]
+    num_contexts: usize,
+    /// Whether to generate a cert or CSR
+    #[arg(long)]
+    cert: bool,
+}
+
+#[cfg(any(
+    feature = "dpe_profile_p256_sha256",
+    feature = "dpe_profile_p384_sha384"
+))]
+struct SimTypesEc;
+#[cfg(any(
+    feature = "dpe_profile_p256_sha256",
+    feature = "dpe_profile_p384_sha384"
+))]
+impl DpeTypes for SimTypesEc {
+    type Crypto<'a> = EcdsaRustCrypto;
+    type Platform<'a> = DefaultPlatform;
+}
+
+#[cfg(feature = "ml-dsa")]
+struct SimTypesMldsa;
+#[cfg(feature = "ml-dsa")]
+impl DpeTypes for SimTypesMldsa {
+    type Crypto<'a> = MldsaRustCrypto;
+    type Platform<'a> = DefaultPlatform;
+}
+
+fn run<T: DpeTypes>(env: &mut DpeEnv<T>, args: &Args) -> Result<()> {
+    let mut dpe =
+        DpeInstance::new(env).map_err(|e| anyhow!("DPE error creating instance: {e:?}"))?;
+
+    // Minus 1 to account for the default context
+    for i in 0..args.num_contexts - 1 {
+        let _resp = DeriveContextCmd {
+            handle: ContextHandle::default(),
+            data: [1; DPE_PROFILE.tci_size()],
+            flags: DeriveContextFlags::MAKE_DEFAULT
+                | DeriveContextFlags::INTERNAL_INPUT_INFO
+                | DeriveContextFlags::INTERNAL_INPUT_DICE,
+            tci_type: 0,
+            target_locality: 0,
+            svn: 0,
+        }
+        .execute(&mut dpe, env, 0)
+        .map_err(|e| anyhow!("DPE error creating {i}th context: {e:?}"));
+    }
+
+    let certify_cmd = CertifyKeyCmd {
+        handle: ContextHandle::default(),
+        flags: CertifyKeyFlags::empty(),
+        label: [0; DPE_PROFILE.hash_size()],
+        format: if args.cert {
+            CertifyKeyCommand::FORMAT_X509
+        } else {
+            CertifyKeyCommand::FORMAT_CSR
+        },
+    };
+
+    let certify_resp = CertifyKeyCommand::from(&certify_cmd)
+        .execute(&mut dpe, env, 0)
+        .map_err(|e| anyhow!("DPE error certifying key: {e:?}"))?;
+    let Response::CertifyKey(certify_resp) = certify_resp else {
+        return Err(anyhow!("Unexpected response type"));
+    };
+    let len = certify_resp
+        .cert()
+        .expect("Failed to parse cert from response")
+        .len();
+    println!(
+        "Total {} size: {len}",
+        if args.cert { "certificate" } else { "CSR" }
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let mut support = Support::default();
+    support.set(Support::SIMULATION, true);
+    support.set(Support::AUTO_INIT, true);
+    support.set(Support::X509, args.cert);
+    support.set(Support::CSR, !args.cert);
+    support.set(Support::RECURSIVE, true);
+    support.set(Support::ROTATE_CONTEXT, true);
+    support.set(Support::INTERNAL_DICE, true);
+    support.set(Support::INTERNAL_INFO, true);
+    support.set(Support::RETAIN_PARENT_CONTEXT, true);
+    support.set(Support::CDI_EXPORT, true);
+
+    let flags = DpeFlags::empty();
+    let mut state = dpe::State::new(support, flags);
+
+    match args.algorithm {
+        #[cfg(any(
+            feature = "dpe_profile_p256_sha256",
+            feature = "dpe_profile_p384_sha384"
+        ))]
+        Algorithm::Ec => run(
+            &mut DpeEnv::<SimTypesEc> {
+                crypto: EcdsaRustCrypto::new(),
+                platform: DefaultPlatform(DefaultPlatformProfile::P256),
+                state: &mut state,
+            },
+            &args,
+        ),
+        #[cfg(feature = "ml-dsa")]
+        Algorithm::Mldsa => run(
+            &mut DpeEnv::<SimTypesMldsa> {
+                crypto: MldsaRustCrypto::new(),
+                platform: DefaultPlatform(DefaultPlatformProfile::Mldsa87ExternalMu),
+                state: &mut state,
+            },
+            &args,
+        ),
+    }
+}


### PR DESCRIPTION
This can be used to check the size of a certificate or CSR. There are options for the number of contexts to be contained in the certificate, which algorithm to use and whether to export an X509 certificate or a CSR.