### PR TITLE
Add conversions from subtypes to `Command`

### DIFF
--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -205,6 +205,13 @@ impl<'a> From<&'a SignMldsaExternalMu87Cmd> for Command<'a> {
     }
 }
 
+#[cfg(not(feature = "disable_rotate_context"))]
+impl<'a> From<&'a RotateCtxCmd> for Command<'a> {
+    fn from(cmd: &'a RotateCtxCmd) -> Command<'a> {
+        Command::RotateCtx(cmd)
+    }
+}
+
 impl<'a> From<&'a DestroyCtxCmd> for Command<'a> {
     fn from(cmd: &'a DestroyCtxCmd) -> Command<'a> {
         Command::DestroyCtx(cmd)


### PR DESCRIPTION
This is helpful while integrating with `caliptra-sw` to reduce a lot of boilerplate.