### PR TITLE
Add DPE profile parameter to `DpeInstance::new`

### DIFF
--- a/dpe/fuzz/src/fuzz_target_1.rs
+++ b/dpe/fuzz/src/fuzz_target_1.rs
@@ -56,7 +56,7 @@ fn harness(data: &[u8]) {
         platform: DefaultPlatform(DefaultPlatformProfile::P256),
         state: &mut dpe::State::new(SUPPORT, DpeFlags::empty()),
     };
-    let mut dpe = DpeInstance::new(&mut env).unwrap();
+    let mut dpe = DpeInstance::new(&mut env, dpe::DPE_PROFILE).unwrap();
     trace!("----------------------------------");
     if let Ok(command) = dpe.deserialize_command(data) {
         trace!("| Fuzzer's locality requested {command:x?}");

--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -392,7 +392,7 @@ mod tests {
             };
             let mut state = State::new(Support::X509, flags);
             let mut env = test_env(&mut state);
-            let mut dpe = DpeInstance::new(&mut env).unwrap();
+            let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
             let init_resp = match InitCtxCmd::new_use_default()
                 .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -449,7 +449,7 @@ mod tests {
             };
             let mut state = State::new(Support::CSR, flags);
             let mut env = test_env(&mut state);
-            let mut dpe = DpeInstance::new(&mut env).unwrap();
+            let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
             let init_resp = match InitCtxCmd::new_use_default()
                 .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -696,7 +696,7 @@ mod tests {
         CfiCounter::reset_for_test();
         let mut state = State::new(Support::X509 | Support::AUTO_INIT, DpeFlags::empty());
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         // Derive context twice with different types
         let derive_cmd = DeriveContextCmd {

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -694,7 +694,7 @@ mod tests {
             DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         assert_eq!(
             Err(DpeErrorCode::ArgumentNotSupported),
@@ -709,7 +709,7 @@ mod tests {
             Support::AUTO_INIT | Support::INTERNAL_DICE | Support::RETAIN_PARENT_CONTEXT,
             DpeFlags::empty(),
         );
-        dpe = DpeInstance::new(&mut env).unwrap();
+        dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         assert_eq!(
             Err(DpeErrorCode::ArgumentNotSupported),
@@ -724,7 +724,7 @@ mod tests {
             Support::AUTO_INIT | Support::INTERNAL_INFO | Support::INTERNAL_DICE,
             DpeFlags::empty(),
         );
-        dpe = DpeInstance::new(&mut env).unwrap();
+        dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         assert_eq!(
             Err(DpeErrorCode::ArgumentNotSupported),
@@ -741,7 +741,7 @@ mod tests {
         CfiCounter::reset_for_test();
         let mut state = State::default();
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         InitCtxCmd::new_use_default()
             .execute(&mut dpe, &mut env, 0)
@@ -759,7 +759,7 @@ mod tests {
         CfiCounter::reset_for_test();
         let mut state = State::new(Support::AUTO_INIT, DpeFlags::empty());
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         // Fill all contexts with children (minus the auto-init context).
         for _ in 0..MAX_HANDLES - 1 {
@@ -783,7 +783,7 @@ mod tests {
         CfiCounter::reset_for_test();
         let mut state = State::new(Support::AUTO_INIT, DpeFlags::empty());
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         let parent_idx = env
             .state
@@ -817,7 +817,7 @@ mod tests {
         CfiCounter::reset_for_test();
         let mut state = State::new(Support::AUTO_INIT, DpeFlags::empty());
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         DeriveContextCmd {
             flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::CHANGE_LOCALITY,
@@ -843,7 +843,7 @@ mod tests {
         CfiCounter::reset_for_test();
         let mut state = State::new(Support::AUTO_INIT, DpeFlags::empty());
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         // Make sure child handle is default when creating default child.
         assert_eq!(
@@ -883,7 +883,7 @@ mod tests {
             DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         let handle = match (RotateCtxCmd {
             handle: ContextHandle::default(),
@@ -982,7 +982,7 @@ mod tests {
             DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         // Make sure the parent handle is non-sense when not retaining.
         assert_eq!(
@@ -1115,7 +1115,7 @@ mod tests {
             DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         assert_eq!(
             DeriveContextCmd {
@@ -1135,7 +1135,7 @@ mod tests {
             DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         DeriveContextCmd {
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT
@@ -1172,7 +1172,7 @@ mod tests {
             DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         assert_eq!(
             Ok(Response::DeriveContext(DeriveContextResp {
@@ -1247,7 +1247,7 @@ mod tests {
             DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         // When `DeriveContextFlags::EXPORT_CDI` is set, `DeriveContextFlags::CREATE_CERTIFICATE` MUST
         // also be set, or `DpeErrorCode::InvalidArgument` is raised.
@@ -1317,7 +1317,7 @@ mod tests {
             Support::AUTO_INIT | Support::CDI_EXPORT | Support::X509,
             DpeFlags::empty(),
         );
-        dpe = DpeInstance::new(&mut env).unwrap();
+        dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         // Happy case!
         let res = DeriveContextCmd {
@@ -1340,7 +1340,7 @@ mod tests {
             Support::AUTO_INIT | Support::INTERNAL_INFO | Support::INTERNAL_DICE | Support::X509,
             DpeFlags::empty(),
         );
-        dpe = DpeInstance::new(&mut env).unwrap();
+        dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         // `DpeInstance` needs `Support::EXPORT_CDI` to use `DeriveContextFlags::EXPORT_CDI`.
         assert_eq!(
@@ -1384,7 +1384,7 @@ mod tests {
             DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         let Ok(Response::DeriveContext(DeriveContextResp { handle, .. })) = DeriveContextCmd {
             flags: DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT,
@@ -1427,7 +1427,7 @@ mod tests {
             DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         // When `DeriveContextFlags::RETAIN_PARENT_CONTEXT` a new handle to the parent should be
         // returned. If the default handle was used, it should be the default handle.
@@ -1456,7 +1456,7 @@ mod tests {
             Support::AUTO_INIT | Support::CDI_EXPORT | Support::X509,
             DpeFlags::empty(),
         );
-        dpe = DpeInstance::new(&mut env).unwrap();
+        dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         let Ok(Response::DeriveContext(res)) = DeriveContextCmd {
             data: [0xA; DPE_PROFILE.tci_size()],
@@ -1486,7 +1486,7 @@ mod tests {
             Support::AUTO_INIT | Support::CDI_EXPORT | Support::X509,
             DpeFlags::empty(),
         );
-        dpe = DpeInstance::new(&mut env).unwrap();
+        dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         let Ok(Response::DeriveContext(res)) = DeriveContextCmd {
             data: [0xA; DPE_PROFILE.tci_size()],
@@ -1519,7 +1519,7 @@ mod tests {
             DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         let res = DeriveContextCmd {
             data: [0xA; DPE_PROFILE.tci_size()],
@@ -1568,7 +1568,7 @@ mod tests {
             DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         let res = DeriveContextCmd {
             flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
@@ -1606,7 +1606,7 @@ mod tests {
             DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         let res = DeriveContextCmd {
             flags: DeriveContextFlags::EXPORT_CDI
@@ -1654,7 +1654,7 @@ mod tests {
             DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         // We want to use multiple contexts, so rotate out the default handle for a new handle.
         let Ok(Response::RotateCtx(NewHandleResp {
@@ -1753,7 +1753,7 @@ mod tests {
             DpeFlags::empty(),
         );
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         // We want to use multiple contexts, so rotate out the default handle for a new handle.
         let Ok(Response::RotateCtx(NewHandleResp {
@@ -1834,7 +1834,7 @@ mod tests {
             };
             let mut state = State::new(Support::X509 | Support::CDI_EXPORT, flags);
             let mut env = test_env(&mut state);
-            let mut dpe = DpeInstance::new(&mut env).unwrap();
+            let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
             let init_resp = match InitCtxCmd::new_use_default()
                 .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -140,7 +140,7 @@ mod tests {
         CfiCounter::reset_for_test();
         let mut state = State::default();
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         InitCtxCmd::new_use_default()
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -295,7 +295,7 @@ mod tests {
         CfiCounter::reset_for_test();
         let mut state = test_state();
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         // create new context while preserving auto-initialized context
         let handle_1 = match (DeriveContextCmd {
@@ -366,7 +366,7 @@ mod tests {
         CfiCounter::reset_for_test();
         let mut state = test_state();
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         // create new context while preserving auto-initialized context
         let parent_handle = match (DeriveContextCmd {

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -54,6 +54,7 @@ mod tests {
     use crate::{
         commands::{tests::PROFILES, Command, CommandHdr},
         dpe_instance::tests::{test_env, test_state, TEST_LOCALITIES},
+        DPE_PROFILE,
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use zerocopy::IntoBytes;
@@ -85,7 +86,7 @@ mod tests {
         CfiCounter::reset_for_test();
         let mut state = test_state();
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         assert_eq!(
             Err(DpeErrorCode::InvalidArgument),

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -118,7 +118,7 @@ mod tests {
         context::ContextState,
         dpe_instance::tests::{test_env, TEST_LOCALITIES},
         support::Support,
-        DpeFlags, State,
+        DpeFlags, State, DPE_PROFILE,
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use zerocopy::IntoBytes;
@@ -145,7 +145,7 @@ mod tests {
         CfiCounter::reset_for_test();
         let mut state = State::default();
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         let handle = match InitCtxCmd::new_use_default()
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -177,7 +177,7 @@ mod tests {
 
         // Change to support simulation.
         *env.state = State::new(Support::SIMULATION, DpeFlags::empty());
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         // Try setting both flags.
         assert_eq!(

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -134,7 +134,7 @@ mod tests {
             test_env, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES,
         },
         support::Support,
-        DpeFlags,
+        DpeFlags, DPE_PROFILE,
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use zerocopy::IntoBytes;
@@ -164,7 +164,7 @@ mod tests {
         CfiCounter::reset_for_test();
         let mut state = State::default();
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
         // Make sure it returns an error if the command is marked unsupported.
         assert_eq!(
             Err(DpeErrorCode::InvalidCommand),
@@ -177,7 +177,7 @@ mod tests {
 
         // Make a new instance that supports RotateContext.
         *env.state = State::new(Support::ROTATE_CONTEXT, DpeFlags::empty());
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
         InitCtxCmd::new_use_default()
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
             .unwrap();

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -314,7 +314,7 @@ mod tests {
         CfiCounter::reset_for_test();
         let mut state = test_state();
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         // Bad handle.
         assert_eq!(
@@ -370,7 +370,7 @@ mod tests {
         CfiCounter::reset_for_test();
         let mut state = test_state();
         let mut env = test_env(&mut state);
-        let mut dpe = DpeInstance::new(&mut env).unwrap();
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         for i in 0..3 {
             DeriveContextCmd {

--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -26,7 +26,7 @@ pub struct Context {
 
     /// The current state of this context
     pub state: ContextState,
-    /// Whether we should hash internal input info consisting of major_version, minor_version, vendor_id, vendor_sku, max_tci_nodes, flags, and DPE_PROFILE when deriving the CDI
+    /// Whether we should hash internal input info consisting of major_version, minor_version, vendor_id, vendor_sku, max_tci_nodes, flags, and profile when deriving the CDI
     pub uses_internal_input_info: U8Bool,
     /// Whether we should hash internal dice info consisting of the certificate chain when deriving the CDI
     pub uses_internal_input_dice: U8Bool,

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -110,6 +110,12 @@ impl DpeProfile {
     }
 }
 
+impl From<DpeProfile> for u32 {
+    fn from(item: DpeProfile) -> Self {
+        item as u32
+    }
+}
+
 #[cfg(feature = "p256")]
 pub const DPE_PROFILE: DpeProfile = DpeProfile::P256Sha256;
 

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -191,7 +191,7 @@ fn main() -> std::io::Result<()> {
         platform: DefaultPlatform(p),
         state: &mut dpe::State::new(support, flags),
     };
-    let mut dpe = DpeInstance::new(&mut env).map_err(|err| {
+    let mut dpe = DpeInstance::new(&mut env, dpe::DPE_PROFILE).map_err(|err| {
         Error::new(
             ErrorKind::Other,
             format!("{err:?} while creating new DPE instance"),

--- a/tools/src/sample_dpe_cert.rs
+++ b/tools/src/sample_dpe_cert.rs
@@ -134,7 +134,7 @@ fn main() {
         state: &mut dpe::State::new(support, DpeFlags::empty()),
     };
 
-    let mut dpe = DpeInstance::new(&mut env).unwrap();
+    let mut dpe = DpeInstance::new(&mut env, dpe::DPE_PROFILE).unwrap();
 
     add_tcb_info(
         &mut dpe,


### PR DESCRIPTION
This helps decouple `DPE_PROFILE` from the code base.