### PR TITLE
Rename profile features to simpler names

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -78,16 +78,16 @@ build_rust_targets ml-dsa
 lint_rust_targets ml-dsa
 
 # Run tests for P256 profile
-build_rust_targets dpe_profile_p256_sha256
-lint_rust_targets dpe_profile_p256_sha256
-test_rust_targets dpe_profile_p256_sha256
-run_verification_tests dpe_profile_p256_sha256 rustcrypto
+build_rust_targets p256
+lint_rust_targets p256
+test_rust_targets p256
+run_verification_tests p256 rustcrypto
 
 # Run tests for P384 profile
-build_rust_targets dpe_profile_p384_sha384
-lint_rust_targets dpe_profile_p384_sha384
-test_rust_targets dpe_profile_p384_sha384
-run_verification_tests dpe_profile_p384_sha384 rustcrypto
+build_rust_targets p384
+lint_rust_targets p384
+test_rust_targets p384
+run_verification_tests p384 rustcrypto
 
 # Build fuzz target
 ( cd dpe/fuzz

--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -6,9 +6,9 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["dpe_profile_p256_sha256", "no-cfi"]
-dpe_profile_p256_sha256 = []
-dpe_profile_p384_sha384 = []
+default = ["p256", "no-cfi"]
+p256 = []
+p384 = []
 ml-dsa = ["crypto/ml-dsa"]
 # Run ARBITRARY_MAX_HANDLES=n cargo build --features arbitrary_max_handles to use this feature
 arbitrary_max_handles = []

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -82,9 +82,9 @@ impl DeriveContextFlags {
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum DeriveContextCommand<'a> {
-    #[cfg(feature = "dpe_profile_p256_sha256")]
+    #[cfg(feature = "p256")]
     P256(&'a DeriveContextP256Cmd),
-    #[cfg(feature = "dpe_profile_p384_sha384")]
+    #[cfg(feature = "p384")]
     P384(&'a DeriveContextP384Cmd),
     #[cfg(feature = "ml-dsa")]
     ExternalMu87(&'a DeriveContextMldsaExternalMu87Cmd),
@@ -96,11 +96,11 @@ impl DeriveContextCommand<'_> {
         bytes: &[u8],
     ) -> Result<DeriveContextCommand, DpeErrorCode> {
         match profile {
-            #[cfg(feature = "dpe_profile_p256_sha256")]
+            #[cfg(feature = "p256")]
             DpeProfile::P256Sha256 => {
                 DeriveContextCommand::parse_command(DeriveContextCommand::P256, bytes)
             }
-            #[cfg(feature = "dpe_profile_p384_sha384")]
+            #[cfg(feature = "p384")]
             DpeProfile::P384Sha384 => {
                 DeriveContextCommand::parse_command(DeriveContextCommand::P384, bytes)
             }
@@ -123,9 +123,9 @@ impl DeriveContextCommand<'_> {
 
     pub fn as_bytes(&self) -> &[u8] {
         match self {
-            #[cfg(feature = "dpe_profile_p256_sha256")]
+            #[cfg(feature = "p256")]
             DeriveContextCommand::P256(cmd) => cmd.as_bytes(),
-            #[cfg(feature = "dpe_profile_p384_sha384")]
+            #[cfg(feature = "p384")]
             DeriveContextCommand::P384(cmd) => cmd.as_bytes(),
             #[cfg(feature = "ml-dsa")]
             DeriveContextCommand::ExternalMu87(cmd) => cmd.as_bytes(),
@@ -242,7 +242,7 @@ impl CommandExecution for DeriveContextCommand<'_> {
     ) -> Result<Response, DpeErrorCode> {
         let support = env.state.support;
         let (handle, data, flags, tci_type, target_locality, svn) = match self {
-            #[cfg(feature = "dpe_profile_p256_sha256")]
+            #[cfg(feature = "p256")]
             DeriveContextCommand::P256(cmd) => (
                 &cmd.handle,
                 Digest::from(cmd.data),
@@ -251,7 +251,7 @@ impl CommandExecution for DeriveContextCommand<'_> {
                 cmd.target_locality,
                 cmd.svn,
             ),
-            #[cfg(feature = "dpe_profile_p384_sha384")]
+            #[cfg(feature = "p384")]
             DeriveContextCommand::P384(cmd) => (
                 &cmd.handle,
                 Digest::from(cmd.data),
@@ -485,14 +485,14 @@ impl CommandExecution for DeriveContextCommand<'_> {
     }
 }
 
-#[cfg(feature = "dpe_profile_p256_sha256")]
+#[cfg(feature = "p256")]
 impl<'a> From<&'a DeriveContextP256Cmd> for DeriveContextCommand<'a> {
     fn from(value: &'a DeriveContextP256Cmd) -> Self {
         DeriveContextCommand::P256(value)
     }
 }
 
-#[cfg(feature = "dpe_profile_p384_sha384")]
+#[cfg(feature = "p384")]
 impl<'a> From<&'a DeriveContextP384Cmd> for DeriveContextCommand<'a> {
     fn from(value: &'a DeriveContextP384Cmd) -> Self {
         DeriveContextCommand::P384(value)
@@ -530,7 +530,7 @@ impl Default for DeriveContextP256Cmd {
     }
 }
 
-#[cfg(feature = "dpe_profile_p256_sha256")]
+#[cfg(feature = "p256")]
 impl CommandExecution for DeriveContextP256Cmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     fn execute(
@@ -567,7 +567,7 @@ impl Default for DeriveContextP384Cmd {
     }
 }
 
-#[cfg(feature = "dpe_profile_p384_sha384")]
+#[cfg(feature = "p384")]
 impl CommandExecution for DeriveContextP384Cmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
     fn execute(
@@ -625,12 +625,12 @@ mod tests {
         sign::SignMldsaExternalMu87Cmd as SignCmd, CertifyKeyMldsaExternalMu87Cmd as CertifyKeyCmd,
         DeriveContextMldsaExternalMu87Cmd as DeriveContextCmd,
     };
-    #[cfg(feature = "dpe_profile_p256_sha256")]
+    #[cfg(feature = "p256")]
     use crate::commands::{
         sign::SignP256Cmd as SignCmd, CertifyKeyP256Cmd as CertifyKeyCmd,
         DeriveContextP256Cmd as DeriveContextCmd,
     };
-    #[cfg(feature = "dpe_profile_p384_sha384")]
+    #[cfg(feature = "p384")]
     use crate::commands::{
         sign::SignP384Cmd as SignCmd, CertifyKeyP384Cmd as CertifyKeyCmd,
         DeriveContextP384Cmd as DeriveContextCmd,
@@ -916,7 +916,7 @@ mod tests {
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         {
-            #[cfg(feature = "dpe_profile_p256_sha256")]
+            #[cfg(feature = "p256")]
             Ok(Response::Sign(SignResp::P256(resp))) => (
                 resp.new_context_handle,
                 EcdsaSig::from_private_components(
@@ -925,7 +925,7 @@ mod tests {
                 )
                 .unwrap(),
             ),
-            #[cfg(feature = "dpe_profile_p384_sha384")]
+            #[cfg(feature = "p384")]
             Ok(Response::Sign(SignResp::P384(resp))) => (
                 resp.new_context_handle,
                 EcdsaSig::from_private_components(

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -101,9 +101,9 @@ mod tests {
     use super::*;
     #[cfg(feature = "ml-dsa")]
     use crate::commands::DeriveContextMldsaExternalMu87Cmd as DeriveContextCmd;
-    #[cfg(feature = "dpe_profile_p256_sha256")]
+    #[cfg(feature = "p256")]
     use crate::commands::DeriveContextP256Cmd as DeriveContextCmd;
-    #[cfg(feature = "dpe_profile_p384_sha384")]
+    #[cfg(feature = "p384")]
     use crate::commands::DeriveContextP384Cmd as DeriveContextCmd;
     use crate::{
         commands::{tests::PROFILES, Command, CommandHdr, DeriveContextFlags, InitCtxCmd},

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -130,14 +130,14 @@ impl<'a> From<DeriveContextCommand<'a>> for Command<'a> {
     }
 }
 
-#[cfg(feature = "dpe_profile_p256_sha256")]
+#[cfg(feature = "p256")]
 impl<'a> From<&'a DeriveContextP256Cmd> for Command<'a> {
     fn from(cmd: &'a DeriveContextP256Cmd) -> Command<'a> {
         Command::DeriveContext(DeriveContextCommand::P256(cmd))
     }
 }
 
-#[cfg(feature = "dpe_profile_p384_sha384")]
+#[cfg(feature = "p384")]
 impl<'a> From<&'a DeriveContextP384Cmd> for Command<'a> {
     fn from(cmd: &'a DeriveContextP384Cmd) -> Command<'a> {
         Command::DeriveContext(DeriveContextCommand::P384(cmd))
@@ -157,14 +157,14 @@ impl<'a> From<CertifyKeyCommand<'a>> for Command<'a> {
     }
 }
 
-#[cfg(feature = "dpe_profile_p256_sha256")]
+#[cfg(feature = "p256")]
 impl<'a> From<&'a CertifyKeyP256Cmd> for Command<'a> {
     fn from(cmd: &'a CertifyKeyP256Cmd) -> Command<'a> {
         Command::CertifyKey(CertifyKeyCommand::P256(cmd))
     }
 }
 
-#[cfg(feature = "dpe_profile_p384_sha384")]
+#[cfg(feature = "p384")]
 impl<'a> From<&'a CertifyKeyP384Cmd> for Command<'a> {
     fn from(cmd: &'a CertifyKeyP384Cmd) -> Command<'a> {
         Command::CertifyKey(CertifyKeyCommand::P384(cmd))
@@ -184,14 +184,14 @@ impl<'a> From<SignCommand<'a>> for Command<'a> {
     }
 }
 
-#[cfg(feature = "dpe_profile_p256_sha256")]
+#[cfg(feature = "p256")]
 impl<'a> From<&'a SignP256Cmd> for Command<'a> {
     fn from(cmd: &'a SignP256Cmd) -> Command<'a> {
         Command::Sign(SignCommand::P256(cmd))
     }
 }
 
-#[cfg(feature = "dpe_profile_p384_sha384")]
+#[cfg(feature = "p384")]
 impl<'a> From<&'a SignP384Cmd> for Command<'a> {
     fn from(cmd: &'a SignP384Cmd) -> Command<'a> {
         Command::Sign(SignCommand::P384(cmd))
@@ -306,31 +306,31 @@ pub mod tests {
     use platform::default::{DefaultPlatform, DefaultPlatformProfile};
     use zerocopy::IntoBytes;
 
-    #[cfg(feature = "dpe_profile_p256_sha256")]
+    #[cfg(feature = "p256")]
     pub const TEST_DIGEST: [u8; DPE_PROFILE.hash_size()] = [
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
         26, 27, 28, 29, 30, 31, 32,
     ];
-    #[cfg(any(feature = "dpe_profile_p384_sha384", feature = "ml-dsa"))]
+    #[cfg(any(feature = "p384", feature = "ml-dsa"))]
     pub const TEST_DIGEST: [u8; DPE_PROFILE.hash_size()] = [
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
         26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
     ];
 
-    #[cfg(feature = "dpe_profile_p256_sha256")]
+    #[cfg(feature = "p256")]
     pub const TEST_LABEL: [u8; DPE_PROFILE.hash_size()] = [
         32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10,
         9, 8, 7, 6, 5, 4, 3, 2, 1,
     ];
-    #[cfg(any(feature = "dpe_profile_p384_sha384", feature = "ml-dsa"))]
+    #[cfg(any(feature = "p384", feature = "ml-dsa"))]
     pub const TEST_LABEL: [u8; DPE_PROFILE.hash_size()] = [
         48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26,
         25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
     ];
 
-    #[cfg(feature = "dpe_profile_p256_sha256")]
+    #[cfg(feature = "p256")]
     pub const DEFAULT_PLATFORM: DefaultPlatform = DefaultPlatform(DefaultPlatformProfile::P256);
-    #[cfg(feature = "dpe_profile_p384_sha384")]
+    #[cfg(feature = "p384")]
     pub const DEFAULT_PLATFORM: DefaultPlatform = DefaultPlatform(DefaultPlatformProfile::P384);
     #[cfg(feature = "ml-dsa")]
     pub const DEFAULT_PLATFORM: DefaultPlatform =
@@ -380,9 +380,9 @@ pub mod tests {
 
         // Test wrong profile.
         let profile = DPE_PROFILE;
-        #[cfg(feature = "dpe_profile_p256_sha256")]
+        #[cfg(feature = "p256")]
         let wrong_profile = DpeProfile::P384Sha384 as u32;
-        #[cfg(feature = "dpe_profile_p384_sha384")]
+        #[cfg(feature = "p384")]
         let wrong_profile = DpeProfile::P256Sha256 as u32;
         #[cfg(feature = "ml-dsa")]
         let wrong_profile = DpeProfile::P256Sha256 as u32;

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -406,9 +406,9 @@ pub mod tests {
     use crate::commands::DeriveContextFlags;
     #[cfg(feature = "ml-dsa")]
     use crate::commands::DeriveContextMldsaExternalMu87Cmd as DeriveContextCmd;
-    #[cfg(feature = "dpe_profile_p256_sha256")]
+    #[cfg(feature = "p256")]
     use crate::commands::DeriveContextP256Cmd as DeriveContextCmd;
-    #[cfg(feature = "dpe_profile_p384_sha384")]
+    #[cfg(feature = "p384")]
     use crate::commands::DeriveContextP384Cmd as DeriveContextCmd;
     use crate::response::NewHandleResp;
     use crate::support::test::SUPPORT;
@@ -418,10 +418,10 @@ pub mod tests {
     use platform::default::{DefaultPlatform, AUTO_INIT_LOCALITY};
     use zerocopy::IntoBytes;
 
-    #[cfg(feature = "dpe_profile_p256_sha256")]
+    #[cfg(feature = "p256")]
     use crypto::Ecdsa256RustCrypto;
 
-    #[cfg(feature = "dpe_profile_p384_sha384")]
+    #[cfg(feature = "p384")]
     use crypto::Ecdsa384RustCrypto;
 
     #[cfg(feature = "ml-dsa")]
@@ -429,10 +429,10 @@ pub mod tests {
 
     pub struct TestTypes;
     impl DpeTypes for TestTypes {
-        #[cfg(feature = "dpe_profile_p256_sha256")]
+        #[cfg(feature = "p256")]
         type Crypto<'a> = Ecdsa256RustCrypto;
 
-        #[cfg(feature = "dpe_profile_p384_sha384")]
+        #[cfg(feature = "p384")]
         type Crypto<'a> = Ecdsa384RustCrypto;
 
         #[cfg(feature = "ml-dsa")]

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -110,10 +110,10 @@ impl DpeProfile {
     }
 }
 
-#[cfg(feature = "dpe_profile_p256_sha256")]
+#[cfg(feature = "p256")]
 pub const DPE_PROFILE: DpeProfile = DpeProfile::P256Sha256;
 
-#[cfg(feature = "dpe_profile_p384_sha384")]
+#[cfg(feature = "p384")]
 pub const DPE_PROFILE: DpeProfile = DpeProfile::P384Sha384;
 
 #[cfg(feature = "ml-dsa")]

--- a/dpe/src/response.rs
+++ b/dpe/src/response.rs
@@ -172,9 +172,9 @@ pub struct DeriveContextExportedCdiResp {
 
 #[derive(PartialEq, Debug, Eq)]
 pub enum CertifyKeyResp {
-    #[cfg(feature = "dpe_profile_p256_sha256")]
+    #[cfg(feature = "p256")]
     P256(CertifyKeyP256Resp),
-    #[cfg(feature = "dpe_profile_p384_sha384")]
+    #[cfg(feature = "p384")]
     P384(CertifyKeyP384Resp),
     #[cfg(feature = "ml-dsa")]
     MldsaExternalMu87(CertifyKeyMldsaExternalMu87Resp),
@@ -183,9 +183,9 @@ pub enum CertifyKeyResp {
 impl CertifyKeyResp {
     pub fn set_handle(&mut self, handle: &ContextHandle) {
         match self {
-            #[cfg(feature = "dpe_profile_p256_sha256")]
+            #[cfg(feature = "p256")]
             CertifyKeyResp::P256(resp) => resp.new_context_handle = *handle,
-            #[cfg(feature = "dpe_profile_p384_sha384")]
+            #[cfg(feature = "p384")]
             CertifyKeyResp::P384(resp) => resp.new_context_handle = *handle,
             #[cfg(feature = "ml-dsa")]
             CertifyKeyResp::MldsaExternalMu87(resp) => resp.new_context_handle = *handle,
@@ -194,9 +194,9 @@ impl CertifyKeyResp {
 
     pub fn resp_hdr(&self) -> &ResponseHdr {
         match self {
-            #[cfg(feature = "dpe_profile_p256_sha256")]
+            #[cfg(feature = "p256")]
             CertifyKeyResp::P256(resp) => &resp.resp_hdr,
-            #[cfg(feature = "dpe_profile_p384_sha384")]
+            #[cfg(feature = "p384")]
             CertifyKeyResp::P384(resp) => &resp.resp_hdr,
             #[cfg(feature = "ml-dsa")]
             CertifyKeyResp::MldsaExternalMu87(resp) => &resp.resp_hdr,
@@ -205,9 +205,9 @@ impl CertifyKeyResp {
 
     pub fn as_bytes(&self) -> &[u8] {
         match self {
-            #[cfg(feature = "dpe_profile_p256_sha256")]
+            #[cfg(feature = "p256")]
             CertifyKeyResp::P256(resp) => resp.as_bytes(),
-            #[cfg(feature = "dpe_profile_p384_sha384")]
+            #[cfg(feature = "p384")]
             CertifyKeyResp::P384(resp) => resp.as_bytes(),
             #[cfg(feature = "ml-dsa")]
             CertifyKeyResp::MldsaExternalMu87(resp) => resp.as_bytes(),
@@ -216,9 +216,9 @@ impl CertifyKeyResp {
 
     pub fn cert(&self) -> Result<&[u8], DpeErrorCode> {
         let (buf, size) = match self {
-            #[cfg(feature = "dpe_profile_p256_sha256")]
+            #[cfg(feature = "p256")]
             CertifyKeyResp::P256(r) => (&r.cert, r.cert_size),
-            #[cfg(feature = "dpe_profile_p384_sha384")]
+            #[cfg(feature = "p384")]
             CertifyKeyResp::P384(r) => (&r.cert, r.cert_size),
             #[cfg(feature = "ml-dsa")]
             CertifyKeyResp::MldsaExternalMu87(r) => (&r.cert, r.cert_size),
@@ -262,9 +262,9 @@ pub struct CertifyKeyMldsaExternalMu87Resp {
 
 #[derive(PartialEq, Debug, Eq)]
 pub enum SignResp {
-    #[cfg(feature = "dpe_profile_p256_sha256")]
+    #[cfg(feature = "p256")]
     P256(SignP256Resp),
-    #[cfg(feature = "dpe_profile_p384_sha384")]
+    #[cfg(feature = "p384")]
     P384(SignP384Resp),
     #[cfg(feature = "ml-dsa")]
     MlDsa(SignMlDsaResp),
@@ -273,9 +273,9 @@ pub enum SignResp {
 impl SignResp {
     pub fn set_handle(&mut self, handle: &ContextHandle) {
         match self {
-            #[cfg(feature = "dpe_profile_p256_sha256")]
+            #[cfg(feature = "p256")]
             SignResp::P256(resp) => resp.new_context_handle = *handle,
-            #[cfg(feature = "dpe_profile_p384_sha384")]
+            #[cfg(feature = "p384")]
             SignResp::P384(resp) => resp.new_context_handle = *handle,
             #[cfg(feature = "ml-dsa")]
             SignResp::MlDsa(_) => {
@@ -287,9 +287,9 @@ impl SignResp {
 
     pub fn resp_hdr(&self) -> &ResponseHdr {
         match self {
-            #[cfg(feature = "dpe_profile_p256_sha256")]
+            #[cfg(feature = "p256")]
             SignResp::P256(resp) => &resp.resp_hdr,
-            #[cfg(feature = "dpe_profile_p384_sha384")]
+            #[cfg(feature = "p384")]
             SignResp::P384(resp) => &resp.resp_hdr,
             #[cfg(feature = "ml-dsa")]
             _ => todo!("clundin: Add ML-DSA variant"),
@@ -298,9 +298,9 @@ impl SignResp {
 
     pub fn as_bytes(&self) -> &[u8] {
         match self {
-            #[cfg(feature = "dpe_profile_p256_sha256")]
+            #[cfg(feature = "p256")]
             SignResp::P256(resp) => resp.as_bytes(),
-            #[cfg(feature = "dpe_profile_p384_sha384")]
+            #[cfg(feature = "p384")]
             SignResp::P384(resp) => resp.as_bytes(),
             #[cfg(feature = "ml-dsa")]
             _ => todo!("clundin: Add ML-DSA variant"),

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -3235,11 +3235,11 @@ pub(crate) mod tests {
         };
 
         let pub_key = match DPE_PROFILE.alg() {
-            #[cfg(feature = "dpe_profile_p256_sha256")]
+            #[cfg(feature = "p256")]
             SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit256) => {
                 PubKey::Ecdsa(EcdsaPubKey::Ecdsa256(test_pub))
             }
-            #[cfg(feature = "dpe_profile_p384_sha384")]
+            #[cfg(feature = "p384")]
             SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit384) => {
                 PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(test_pub))
             }
@@ -3247,11 +3247,11 @@ pub(crate) mod tests {
         };
 
         let test_sig: Signature = match DPE_PROFILE.alg() {
-            #[cfg(feature = "dpe_profile_p256_sha256")]
+            #[cfg(feature = "p256")]
             SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit256) => Signature::Ecdsa(
                 EcdsaSig::from_slice(&[0xCC; ECC_INT_SIZE], &[0xDD; ECC_INT_SIZE]).into(),
             ),
-            #[cfg(feature = "dpe_profile_p384_sha384")]
+            #[cfg(feature = "p384")]
             SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit384) => Signature::Ecdsa(
                 EcdsaSig::from_slice(&[0xCC; ECC_INT_SIZE], &[0xDD; ECC_INT_SIZE]).into(),
             ),

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -6,9 +6,9 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["dpe_profile_p256_sha256", "rustcrypto"]
-dpe_profile_p256_sha256 = ["dpe/dpe_profile_p256_sha256"]
-dpe_profile_p384_sha384 = ["dpe/dpe_profile_p384_sha384"]
+default = ["p256", "rustcrypto"]
+p256 = ["dpe/p256"]
+p384 = ["dpe/p384"]
 # TODO(clundin): Placeholder name until we decide pattern for DPE profiles and feature flags.
 ml-dsa = ["dpe/ml-dsa"]
 rustcrypto = ["crypto/rustcrypto", "platform/rustcrypto"]

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -20,10 +20,10 @@ use dpe::{
     DpeInstance,
 };
 
-#[cfg(feature = "dpe_profile_p256_sha256")]
+#[cfg(feature = "p256")]
 use crypto::Ecdsa256RustCrypto;
 
-#[cfg(feature = "dpe_profile_p384_sha384")]
+#[cfg(feature = "p384")]
 use crypto::Ecdsa384RustCrypto;
 
 #[cfg(feature = "ml-dsa")]
@@ -128,10 +128,10 @@ struct Args {
 struct SimTypes {}
 
 impl DpeTypes for SimTypes {
-    #[cfg(feature = "dpe_profile_p256_sha256")]
+    #[cfg(feature = "p256")]
     type Crypto<'a> = Ecdsa256RustCrypto;
 
-    #[cfg(feature = "dpe_profile_p384_sha384")]
+    #[cfg(feature = "p384")]
     type Crypto<'a> = Ecdsa384RustCrypto;
 
     #[cfg(feature = "ml-dsa")]
@@ -179,9 +179,9 @@ fn main() -> std::io::Result<()> {
         args.mark_dice_extensions_critical,
     );
 
-    #[cfg(feature = "dpe_profile_p256_sha256")]
+    #[cfg(feature = "p256")]
     let p = DefaultPlatformProfile::P256;
-    #[cfg(feature = "dpe_profile_p384_sha384")]
+    #[cfg(feature = "p384")]
     let p = DefaultPlatformProfile::P384;
     #[cfg(feature = "ml-dsa")]
     let p = DefaultPlatformProfile::Mldsa87ExternalMu;

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -6,15 +6,11 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["dpe_profile_p256_sha256"]
+default = ["p256"]
 # Run ARBITRARY_MAX_HANDLES=n cargo build --features arbitrary_max_handles to use this feature
 arbitrary_max_handles = ["dpe/arbitrary_max_handles"]
-dpe_profile_p256_sha256 = [
-  "dpe/dpe_profile_p256_sha256"
-]
-dpe_profile_p384_sha384 = [
-  "dpe/dpe_profile_p384_sha384"
-]
+p256 = ["dpe/p256"]
+p384 = ["dpe/p384"]
 # TODO(clundin): Placeholder name until we decide pattern for DPE profiles and feature flags.
 ml-dsa = [
   "dpe/ml-dsa"

--- a/tools/src/cert_size.rs
+++ b/tools/src/cert_size.rs
@@ -16,7 +16,7 @@ use dpe::{
 };
 use platform::default::{DefaultPlatform, DefaultPlatformProfile};
 
-#[cfg(feature = "dpe_profile_p256_sha256")]
+#[cfg(feature = "p256")]
 mod alg {
     pub use super::Algorithm::Ec as DefaultAlg;
     pub use crypto::Ecdsa256RustCrypto as EcdsaRustCrypto;
@@ -24,7 +24,7 @@ mod alg {
         CertifyKeyP256Cmd as CertifyKeyCmd, DeriveContextP256Cmd as DeriveContextCmd,
     };
 }
-#[cfg(feature = "dpe_profile_p384_sha384")]
+#[cfg(feature = "p384")]
 mod alg {
     pub use super::Algorithm::Ec as DefaultAlg;
     pub use crypto::Ecdsa384RustCrypto as EcdsaRustCrypto;
@@ -45,10 +45,7 @@ mod alg {
 #[derive(ValueEnum, Clone, Debug, Default)]
 pub enum Algorithm {
     /// Use EC P256 or P384 depending on the build feature
-    #[cfg(any(
-        feature = "dpe_profile_p256_sha256",
-        feature = "dpe_profile_p384_sha384"
-    ))]
+    #[cfg(any(feature = "p256", feature = "p384"))]
     #[default]
     Ec,
     #[cfg(feature = "ml-dsa")]
@@ -60,9 +57,9 @@ pub enum Algorithm {
 impl From<Algorithm> for DefaultPlatformProfile {
     fn from(algorithm: Algorithm) -> Self {
         match algorithm {
-            #[cfg(feature = "dpe_profile_p256_sha256")]
+            #[cfg(feature = "p256")]
             Algorithm::Ec => DefaultPlatformProfile::P256,
-            #[cfg(feature = "dpe_profile_p384_sha384")]
+            #[cfg(feature = "p384")]
             Algorithm::Ec => DefaultPlatformProfile::P384,
             #[cfg(feature = "ml-dsa")]
             Algorithm::Mldsa => DefaultPlatformProfile::Mldsa87ExternalMu,
@@ -85,15 +82,9 @@ struct Args {
     cert: bool,
 }
 
-#[cfg(any(
-    feature = "dpe_profile_p256_sha256",
-    feature = "dpe_profile_p384_sha384"
-))]
+#[cfg(any(feature = "p256", feature = "p384"))]
 struct SimTypesEc;
-#[cfg(any(
-    feature = "dpe_profile_p256_sha256",
-    feature = "dpe_profile_p384_sha384"
-))]
+#[cfg(any(feature = "p256", feature = "p384"))]
 impl DpeTypes for SimTypesEc {
     type Crypto<'a> = EcdsaRustCrypto;
     type Platform<'a> = DefaultPlatform;
@@ -174,10 +165,7 @@ fn main() -> Result<()> {
     let mut state = dpe::State::new(support, flags);
 
     match args.algorithm {
-        #[cfg(any(
-            feature = "dpe_profile_p256_sha256",
-            feature = "dpe_profile_p384_sha384"
-        ))]
+        #[cfg(any(feature = "p256", feature = "p384"))]
         Algorithm::Ec => run(
             &mut DpeEnv::<SimTypesEc> {
                 crypto: EcdsaRustCrypto::new(),

--- a/tools/src/sample_dpe_cert.rs
+++ b/tools/src/sample_dpe_cert.rs
@@ -16,13 +16,13 @@ use {
     zerocopy::IntoBytes,
 };
 
-#[cfg(feature = "dpe_profile_p256_sha256")]
+#[cfg(feature = "p256")]
 use {
     commands::CertifyKeyP256Cmd as CertifyKeyCmd,
     commands::DeriveContextP256Cmd as DeriveContextCmd, crypto::Ecdsa256RustCrypto as RustCrypto,
 };
 
-#[cfg(feature = "dpe_profile_p384_sha384")]
+#[cfg(feature = "p384")]
 use {
     commands::CertifyKeyP384Cmd as CertifyKeyCmd,
     commands::DeriveContextP384Cmd as DeriveContextCmd, crypto::Ecdsa384RustCrypto as RustCrypto,
@@ -121,9 +121,9 @@ fn main() {
     };
     let support = Support::AUTO_INIT | Support::X509 | Support::CSR;
 
-    #[cfg(feature = "dpe_profile_p256_sha256")]
+    #[cfg(feature = "p256")]
     let p = DefaultPlatformProfile::P256;
-    #[cfg(feature = "dpe_profile_p384_sha384")]
+    #[cfg(feature = "p384")]
     let p = DefaultPlatformProfile::P384;
     #[cfg(feature = "ml-dsa")]
     let p = DefaultPlatformProfile::Mldsa87ExternalMu;


### PR DESCRIPTION
This separates the idea of the feature as the profile. It makes it will make it more obvious when multiple profiles supported that it is not chosen at compile time.