### PR TITLE
Add a TCI_SIZE const

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -325,7 +325,7 @@ mod tests {
         dpe_instance::tests::{test_env, SIMULATION_HANDLE, TEST_LOCALITIES},
         support::Support,
         x509::{tests::TcbInfo, DirectoryString, Name},
-        State, DPE_PROFILE,
+        State, DPE_PROFILE, TCI_SIZE,
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use cms::{
@@ -701,7 +701,7 @@ mod tests {
         // Derive context twice with different types
         let derive_cmd = DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: [1; DPE_PROFILE.tci_size()],
+            data: [1; TCI_SIZE],
             flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INPUT_ALLOW_X509,
             tci_type: 1,
             target_locality: 0,

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -648,7 +648,7 @@ mod tests {
         response::{NewHandleResp, SignResp},
         support::Support,
         validation::DpeValidator,
-        DpeProfile, DPE_PROFILE, MAX_EXPORTED_CDI_SIZE, MAX_HANDLES,
+        DpeProfile, DPE_PROFILE, MAX_EXPORTED_CDI_SIZE, MAX_HANDLES, TCI_SIZE,
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use crypto::{Crypto, Hasher};
@@ -1182,7 +1182,7 @@ mod tests {
             })),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [1; DPE_PROFILE.tci_size()],
+                data: [1; TCI_SIZE],
                 flags: DeriveContextFlags::MAKE_DEFAULT
                     | DeriveContextFlags::RECURSIVE
                     | DeriveContextFlags::INTERNAL_INPUT_INFO
@@ -1196,7 +1196,7 @@ mod tests {
 
         DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: [2; DPE_PROFILE.tci_size()],
+            data: [2; TCI_SIZE],
             flags: DeriveContextFlags::MAKE_DEFAULT
                 | DeriveContextFlags::RECURSIVE
                 | DeriveContextFlags::INTERNAL_INPUT_INFO
@@ -1459,7 +1459,7 @@ mod tests {
         dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         let Ok(Response::DeriveContext(res)) = DeriveContextCmd {
-            data: [0xA; DPE_PROFILE.tci_size()],
+            data: [0xA; TCI_SIZE],
             target_locality: TEST_LOCALITIES[0],
             ..Default::default()
         }
@@ -1489,7 +1489,7 @@ mod tests {
         dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         let Ok(Response::DeriveContext(res)) = DeriveContextCmd {
-            data: [0xA; DPE_PROFILE.tci_size()],
+            data: [0xA; TCI_SIZE],
             target_locality: TEST_LOCALITIES[0],
             ..Default::default()
         }
@@ -1522,7 +1522,7 @@ mod tests {
         let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         let res = DeriveContextCmd {
-            data: [0xA; DPE_PROFILE.tci_size()],
+            data: [0xA; TCI_SIZE],
             flags: DeriveContextFlags::MAKE_DEFAULT
                 | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT,
             target_locality: TEST_LOCALITIES[0],

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -111,7 +111,7 @@ mod tests {
         dpe_instance::tests::{
             test_env, test_state, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES,
         },
-        DPE_PROFILE,
+        DPE_PROFILE, TCI_SIZE,
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use zerocopy::IntoBytes;
@@ -300,7 +300,7 @@ mod tests {
         // create new context while preserving auto-initialized context
         let handle_1 = match (DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: [0u8; DPE_PROFILE.tci_size()],
+            data: [0u8; TCI_SIZE],
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT | DeriveContextFlags::CHANGE_LOCALITY,
             tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
@@ -316,7 +316,7 @@ mod tests {
         // retire context with handle 1 and create new context
         let handle_2 = match (DeriveContextCmd {
             handle: handle_1,
-            data: [0u8; DPE_PROFILE.tci_size()],
+            data: [0u8; TCI_SIZE],
             flags: DeriveContextFlags::empty(),
             tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
@@ -332,7 +332,7 @@ mod tests {
         // retire context with handle 2 and create new context
         let handle_3 = match (DeriveContextCmd {
             handle: handle_2,
-            data: [0u8; DPE_PROFILE.tci_size()],
+            data: [0u8; TCI_SIZE],
             flags: DeriveContextFlags::empty(),
             tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
@@ -371,7 +371,7 @@ mod tests {
         // create new context while preserving auto-initialized context
         let parent_handle = match (DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: [0u8; DPE_PROFILE.tci_size()],
+            data: [0u8; TCI_SIZE],
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT | DeriveContextFlags::CHANGE_LOCALITY,
             tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
@@ -387,7 +387,7 @@ mod tests {
         // derive one child from the parent
         let parent_handle = match (DeriveContextCmd {
             handle: parent_handle,
-            data: [0u8; DPE_PROFILE.tci_size()],
+            data: [0u8; TCI_SIZE],
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
             tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
@@ -403,7 +403,7 @@ mod tests {
         // derive another child while retiring the parent handle
         let handle_b = match (DeriveContextCmd {
             handle: parent_handle,
-            data: [0u8; DPE_PROFILE.tci_size()],
+            data: [0u8; TCI_SIZE],
             flags: DeriveContextFlags::empty(),
             tci_type: 0,
             target_locality: TEST_LOCALITIES[1],

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -125,6 +125,12 @@ pub const DPE_PROFILE: DpeProfile = DpeProfile::P384Sha384;
 #[cfg(feature = "ml-dsa")]
 pub const DPE_PROFILE: DpeProfile = DpeProfile::Mldsa87ExternalMu;
 
+#[cfg(feature = "p256")]
+pub const TCI_SIZE: usize = 32;
+
+#[cfg(any(feature = "p384", feature = "ml-dsa"))]
+pub const TCI_SIZE: usize = 48;
+
 // Recursive macro that does a union of all the flags passed to it. This is
 // const and looks about as nice as using the | operator.
 #[macro_export]

--- a/dpe/src/tci.rs
+++ b/dpe/src/tci.rs
@@ -1,5 +1,5 @@
 // Licensed under the Apache-2.0 license.
-use crate::DPE_PROFILE;
+use crate::TCI_SIZE;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
@@ -19,8 +19,8 @@ impl TciNodeData {
     pub const fn new() -> TciNodeData {
         TciNodeData {
             tci_type: 0,
-            tci_cumulative: TciMeasurement([0; DPE_PROFILE.tci_size()]),
-            tci_current: TciMeasurement([0; DPE_PROFILE.tci_size()]),
+            tci_cumulative: TciMeasurement([0; TCI_SIZE]),
+            tci_current: TciMeasurement([0; TCI_SIZE]),
             locality: 0,
             svn: 0,
         }
@@ -31,10 +31,10 @@ impl TciNodeData {
 #[derive(
     Copy, Clone, Debug, IntoBytes, FromBytes, KnownLayout, Immutable, PartialEq, Eq, Zeroize,
 )]
-pub struct TciMeasurement(pub [u8; DPE_PROFILE.tci_size()]);
+pub struct TciMeasurement(pub [u8; TCI_SIZE]);
 
 impl Default for TciMeasurement {
     fn default() -> Self {
-        Self([0; DPE_PROFILE.tci_size()])
+        Self([0; TCI_SIZE])
     }
 }

--- a/dpe/src/validation.rs
+++ b/dpe/src/validation.rs
@@ -290,7 +290,7 @@ pub mod tests {
         support::Support,
         tci::TciMeasurement,
         validation::{DpeValidator, ValidationError},
-        DpeFlags, State, U8Bool, DPE_PROFILE,
+        DpeFlags, State, U8Bool, TCI_SIZE,
     };
     use caliptra_cfi_lib_git::CfiCounter;
 
@@ -418,7 +418,7 @@ pub mod tests {
         );
 
         dpe_validator.dpe.contexts[0].children = 0;
-        dpe_validator.dpe.contexts[0].tci.tci_current = TciMeasurement([1; DPE_PROFILE.tci_size()]);
+        dpe_validator.dpe.contexts[0].tci.tci_current = TciMeasurement([1; TCI_SIZE]);
         assert_eq!(
             dpe_validator.validate_dpe_state(),
             Err(ValidationError::InactiveContextWithMeasurement)

--- a/tools/src/cert_size.rs
+++ b/tools/src/cert_size.rs
@@ -119,7 +119,7 @@ fn run<T: DpeTypes>(env: &mut DpeEnv<T>, args: &Args) -> Result<()> {
     for i in 0..args.num_contexts - 1 {
         let _resp = DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: [1; DPE_PROFILE.tci_size()],
+            data: [1; dpe::TCI_SIZE],
             flags: DeriveContextFlags::MAKE_DEFAULT
                 | DeriveContextFlags::INTERNAL_INPUT_INFO
                 | DeriveContextFlags::INTERNAL_INPUT_DICE,


### PR DESCRIPTION
This reduces dependence on DPE_PROFILE. All other profile dependent sizes can be used at runtime.