### PR TITLE
Move `DPE_PROFILE` to a test-only variable.

### DIFF
--- a/dpe/fuzz/src/fuzz_target_1.rs
+++ b/dpe/fuzz/src/fuzz_target_1.rs
@@ -20,7 +20,7 @@ use dpe::{
     dpe_instance::{DpeEnv, DpeTypes},
     response::Response,
     support::Support,
-    DpeInstance,
+    DpeInstance, DpeProfile,
 };
 use platform::default::{DefaultPlatform, DefaultPlatformProfile, AUTO_INIT_LOCALITY};
 
@@ -56,7 +56,7 @@ fn harness(data: &[u8]) {
         platform: DefaultPlatform(DefaultPlatformProfile::P256),
         state: &mut dpe::State::new(SUPPORT, DpeFlags::empty()),
     };
-    let mut dpe = DpeInstance::new(&mut env, dpe::DPE_PROFILE).unwrap();
+    let mut dpe = DpeInstance::new(&mut env, DpeProfile::P256Sha256).unwrap();
     trace!("----------------------------------");
     if let Ok(command) = dpe.deserialize_command(data) {
         trace!("| Fuzzer's locality requested {command:x?}");

--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -322,10 +322,10 @@ mod tests {
     };
     use crate::{
         commands::{Command, CommandHdr, DeriveContextCommand, DeriveContextFlags, InitCtxCmd},
-        dpe_instance::tests::{test_env, SIMULATION_HANDLE, TEST_LOCALITIES},
+        dpe_instance::tests::{test_env, DPE_PROFILE, SIMULATION_HANDLE, TEST_LOCALITIES},
         support::Support,
         x509::{tests::TcbInfo, DirectoryString, Name},
-        State, DPE_PROFILE, TCI_SIZE,
+        State, TCI_SIZE,
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use cms::{

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -643,12 +643,12 @@ mod tests {
         },
         context::ContextType,
         dpe_instance::tests::{
-            test_env, TestTypes, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_LOCALITIES,
+            test_env, TestTypes, DPE_PROFILE, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_LOCALITIES,
         },
         response::{NewHandleResp, SignResp},
         support::Support,
         validation::DpeValidator,
-        DpeProfile, DPE_PROFILE, MAX_EXPORTED_CDI_SIZE, MAX_HANDLES, TCI_SIZE,
+        DpeProfile, MAX_EXPORTED_CDI_SIZE, MAX_HANDLES, TCI_SIZE,
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use crypto::{Crypto, Hasher};

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -109,9 +109,9 @@ mod tests {
         commands::{tests::PROFILES, Command, CommandHdr, DeriveContextFlags, InitCtxCmd},
         context::{Context, ContextState},
         dpe_instance::tests::{
-            test_env, test_state, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES,
+            test_env, test_state, DPE_PROFILE, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES,
         },
-        DPE_PROFILE, TCI_SIZE,
+        TCI_SIZE,
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use zerocopy::IntoBytes;

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -53,8 +53,7 @@ mod tests {
     use super::*;
     use crate::{
         commands::{tests::PROFILES, Command, CommandHdr},
-        dpe_instance::tests::{test_env, test_state, TEST_LOCALITIES},
-        DPE_PROFILE,
+        dpe_instance::tests::{test_env, test_state, DPE_PROFILE, TEST_LOCALITIES},
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use zerocopy::IntoBytes;

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -116,9 +116,9 @@ mod tests {
     use crate::{
         commands::{tests::PROFILES, Command, CommandHdr},
         context::ContextState,
-        dpe_instance::tests::{test_env, TEST_LOCALITIES},
+        dpe_instance::tests::{test_env, DPE_PROFILE, TEST_LOCALITIES},
         support::Support,
-        DpeFlags, State, DPE_PROFILE,
+        DpeFlags, State,
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use zerocopy::IntoBytes;

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -301,7 +301,8 @@ impl TryFrom<&[u8]> for CommandHdr {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::{DpeProfile, DPE_PROFILE};
+    use crate::dpe_instance::tests::DPE_PROFILE;
+    use crate::DpeProfile;
     use caliptra_cfi_lib_git::CfiCounter;
     use platform::default::{DefaultPlatform, DefaultPlatformProfile};
     use zerocopy::IntoBytes;

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -131,10 +131,10 @@ mod tests {
     use crate::{
         commands::{tests::PROFILES, Command, CommandHdr, InitCtxCmd},
         dpe_instance::tests::{
-            test_env, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES,
+            test_env, DPE_PROFILE, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES,
         },
         support::Support,
-        DpeFlags, DPE_PROFILE,
+        DpeFlags,
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use zerocopy::IntoBytes;

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -275,9 +275,8 @@ mod tests {
             Command, CommandHdr, InitCtxCmd,
         },
         dpe_instance::tests::{
-            test_env, test_state, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_LOCALITIES,
+            test_env, test_state, DPE_PROFILE, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_LOCALITIES,
         },
-        DPE_PROFILE,
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use openssl::x509::X509;

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -411,11 +411,20 @@ pub mod tests {
     use crate::commands::DeriveContextP384Cmd as DeriveContextCmd;
     use crate::response::NewHandleResp;
     use crate::support::test::SUPPORT;
-    use crate::{DpeFlags, CURRENT_PROFILE_MAJOR_VERSION, DPE_PROFILE};
+    use crate::{DpeFlags, CURRENT_PROFILE_MAJOR_VERSION};
     use caliptra_cfi_lib_git::CfiCounter;
     use crypto::RustCryptoImpl;
     use platform::default::{DefaultPlatform, AUTO_INIT_LOCALITY};
     use zerocopy::IntoBytes;
+
+    #[cfg(feature = "p256")]
+    pub const DPE_PROFILE: DpeProfile = DpeProfile::P256Sha256;
+
+    #[cfg(feature = "p384")]
+    pub const DPE_PROFILE: DpeProfile = DpeProfile::P384Sha384;
+
+    #[cfg(feature = "ml-dsa")]
+    pub const DPE_PROFILE: DpeProfile = DpeProfile::Mldsa87ExternalMu;
 
     #[cfg(feature = "p256")]
     use crypto::Ecdsa256RustCrypto;

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -126,15 +126,6 @@ impl From<DpeProfile> for u32 {
 }
 
 #[cfg(feature = "p256")]
-pub const DPE_PROFILE: DpeProfile = DpeProfile::P256Sha256;
-
-#[cfg(feature = "p384")]
-pub const DPE_PROFILE: DpeProfile = DpeProfile::P384Sha384;
-
-#[cfg(feature = "ml-dsa")]
-pub const DPE_PROFILE: DpeProfile = DpeProfile::Mldsa87ExternalMu;
-
-#[cfg(feature = "p256")]
 pub const TCI_SIZE: usize = 32;
 
 #[cfg(any(feature = "p384", feature = "ml-dsa"))]

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -2979,9 +2979,10 @@ fn create_dpe_cert_or_csr(
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use crate::dpe_instance::tests::DPE_PROFILE;
     use crate::tci::{TciMeasurement, TciNodeData};
     use crate::x509::{CertWriter, DirectoryString, MeasurementData, Name};
-    use crate::{DpeProfile, DPE_PROFILE};
+    use crate::DpeProfile;
     use crypto::ecdsa::{EcdsaAlgorithm, EcdsaSig};
     use crypto::ecdsa::{EcdsaPub, EcdsaPubKey};
     #[cfg(feature = "ml-dsa")]

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -5,29 +5,44 @@ compile_error!("must provide a crypto implementation");
 
 use clap::Parser;
 use dpe::DpeFlags;
-use log::{error, info, trace, warn};
-use platform::default::{DefaultPlatform, DefaultPlatformProfile};
-use std::fs;
-use std::io::{Error, ErrorKind, Read, Write};
-use std::os::unix::net::{UnixListener, UnixStream};
-use std::path::Path;
-use std::process;
-
 use dpe::{
     dpe_instance::{DpeEnv, DpeTypes},
     response::Response,
     support::Support,
     DpeInstance,
 };
+use log::{error, info, trace, warn};
+use platform::default::{DefaultPlatform, DefaultPlatformProfile};
+use profile::*;
+use std::fs;
+use std::io::{Error, ErrorKind, Read, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::Path;
+use std::process;
 
 #[cfg(feature = "p256")]
-use crypto::Ecdsa256RustCrypto;
+mod profile {
+    use super::*;
+    pub use crypto::Ecdsa256RustCrypto as RustCrypto;
+    pub const DPE_PROFILE: dpe::DpeProfile = dpe::DpeProfile::P256Sha256;
+    pub const PLATFORM_PROFILE: DefaultPlatformProfile = DefaultPlatformProfile::P256;
+}
 
 #[cfg(feature = "p384")]
-use crypto::Ecdsa384RustCrypto;
+mod profile {
+    use super::*;
+    pub use crypto::Ecdsa384RustCrypto as RustCrypto;
+    pub const DPE_PROFILE: dpe::DpeProfile = dpe::DpeProfile::P384Sha384;
+    pub const PLATFORM_PROFILE: DefaultPlatformProfile = DefaultPlatformProfile::P384;
+}
 
 #[cfg(feature = "ml-dsa")]
-use crypto::MldsaRustCrypto;
+mod profile {
+    use super::*;
+    pub use crypto::Ecdsa256RustCrypto as RustCrypto;
+    pub const DPE_PROFILE: dpe::DpeProfile = dpe::DpeProfile::Mldsa87ExternalMu;
+    pub const PLATFORM_PROFILE: DefaultPlatformProfile = DefaultPlatformProfile::Mldsa87ExternalMu;
+}
 
 const SOCKET_PATH: &str = "/tmp/dpe-sim.socket";
 
@@ -128,14 +143,7 @@ struct Args {
 struct SimTypes {}
 
 impl DpeTypes for SimTypes {
-    #[cfg(feature = "p256")]
-    type Crypto<'a> = Ecdsa256RustCrypto;
-
-    #[cfg(feature = "p384")]
-    type Crypto<'a> = Ecdsa384RustCrypto;
-
-    #[cfg(feature = "ml-dsa")]
-    type Crypto<'a> = MldsaRustCrypto;
+    type Crypto<'a> = RustCrypto;
 
     type Platform<'a> = DefaultPlatform;
 }
@@ -179,19 +187,12 @@ fn main() -> std::io::Result<()> {
         args.mark_dice_extensions_critical,
     );
 
-    #[cfg(feature = "p256")]
-    let p = DefaultPlatformProfile::P256;
-    #[cfg(feature = "p384")]
-    let p = DefaultPlatformProfile::P384;
-    #[cfg(feature = "ml-dsa")]
-    let p = DefaultPlatformProfile::Mldsa87ExternalMu;
-
     let mut env = DpeEnv::<SimTypes> {
         crypto: <SimTypes as DpeTypes>::Crypto::new(),
-        platform: DefaultPlatform(p),
+        platform: DefaultPlatform(PLATFORM_PROFILE),
         state: &mut dpe::State::new(support, flags),
     };
-    let mut dpe = DpeInstance::new(&mut env, dpe::DPE_PROFILE).map_err(|err| {
+    let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).map_err(|err| {
         Error::new(
             ErrorKind::Other,
             format!("{err:?} while creating new DPE instance"),

--- a/tools/src/cert_size.rs
+++ b/tools/src/cert_size.rs
@@ -6,7 +6,7 @@ use clap::{Parser, ValueEnum};
 use dpe::{
     commands::{CertifyKeyCommand, CertifyKeyFlags, CommandExecution, DeriveContextFlags},
     context::ContextHandle,
-    DpeFlags, DpeProfile, DPE_PROFILE,
+    DpeFlags, DpeProfile,
 };
 use dpe::{
     dpe_instance::{DpeEnv, DpeTypes},
@@ -23,6 +23,7 @@ mod alg {
     pub use dpe::commands::{
         CertifyKeyP256Cmd as CertifyKeyCmd, DeriveContextP256Cmd as DeriveContextCmd,
     };
+    pub const DPE_PROFILE: dpe::DpeProfile = dpe::DpeProfile::P256Sha256;
 }
 #[cfg(feature = "p384")]
 mod alg {
@@ -31,6 +32,7 @@ mod alg {
     pub use dpe::commands::{
         CertifyKeyP384Cmd as CertifyKeyCmd, DeriveContextP384Cmd as DeriveContextCmd,
     };
+    pub const DPE_PROFILE: dpe::DpeProfile = dpe::DpeProfile::P384Sha384;
 }
 #[cfg(feature = "ml-dsa")]
 mod alg {
@@ -40,6 +42,7 @@ mod alg {
         CertifyKeyMldsaExternalMu87Cmd as CertifyKeyCmd,
         DeriveContextMldsaExternalMu87Cmd as DeriveContextCmd,
     };
+    pub const DPE_PROFILE: dpe::DpeProfile = dpe::DpeProfile::Mldsa87ExternalMu;
 }
 
 #[derive(ValueEnum, Clone, Debug, Default, Copy)]


### PR DESCRIPTION
This is only a temporary measure. The long term solution is to move all tests to loop over all profiles accessible from the binary.