### PR TITLE
Revert "Build DeriveContext for multiple profiles. (#444)"

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -308,20 +308,13 @@ impl CommandExecution for CertifyKeyMldsaExternalMu87Cmd {
 mod tests {
     use super::*;
     #[cfg(feature = "ml-dsa")]
-    use crate::commands::{
-        CertifyKeyMldsaExternalMu87Cmd as CertifyKeyCmd,
-        DeriveContextMldsaExternalMu87Cmd as DeriveContextCmd,
-    };
+    use crate::commands::CertifyKeyMldsaExternalMu87Cmd as CertifyKeyCmd;
     #[cfg(feature = "p256")]
-    use crate::commands::{
-        CertifyKeyP256Cmd as CertifyKeyCmd, DeriveContextP256Cmd as DeriveContextCmd,
-    };
+    use crate::commands::CertifyKeyP256Cmd as CertifyKeyCmd;
     #[cfg(feature = "p384")]
-    use crate::commands::{
-        CertifyKeyP384Cmd as CertifyKeyCmd, DeriveContextP384Cmd as DeriveContextCmd,
-    };
+    use crate::commands::CertifyKeyP384Cmd as CertifyKeyCmd;
     use crate::{
-        commands::{Command, CommandHdr, DeriveContextCommand, DeriveContextFlags, InitCtxCmd},
+        commands::{Command, CommandHdr, DeriveContextCmd, DeriveContextFlags, InitCtxCmd},
         dpe_instance::tests::{test_env, DPE_PROFILE, SIMULATION_HANDLE, TEST_LOCALITIES},
         support::Support,
         x509::{tests::TcbInfo, DirectoryString, Name},
@@ -708,7 +701,7 @@ mod tests {
             svn: 0,
         };
 
-        DeriveContextCommand::from(&derive_cmd)
+        derive_cmd
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
             .unwrap();
 

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -99,14 +99,10 @@ impl CommandExecution for DestroyCtxCmd {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "ml-dsa")]
-    use crate::commands::DeriveContextMldsaExternalMu87Cmd as DeriveContextCmd;
-    #[cfg(feature = "p256")]
-    use crate::commands::DeriveContextP256Cmd as DeriveContextCmd;
-    #[cfg(feature = "p384")]
-    use crate::commands::DeriveContextP384Cmd as DeriveContextCmd;
     use crate::{
-        commands::{tests::PROFILES, Command, CommandHdr, DeriveContextFlags, InitCtxCmd},
+        commands::{
+            tests::PROFILES, Command, CommandHdr, DeriveContextCmd, DeriveContextFlags, InitCtxCmd,
+        },
         context::{Context, ContextState},
         dpe_instance::tests::{
             test_env, test_state, DPE_PROFILE, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES,

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -255,24 +255,17 @@ mod tests {
     #[cfg(feature = "ml-dsa")]
     use crate::commands::{
         sign::SignMldsaExternalMu87Cmd as SignCmd, CertifyKeyMldsaExternalMu87Cmd as CertifyKeyCmd,
-        DeriveContextMldsaExternalMu87Cmd as DeriveContextCmd,
     };
     #[cfg(feature = "p256")]
-    use crate::commands::{
-        sign::SignP256Cmd as SignCmd, CertifyKeyP256Cmd as CertifyKeyCmd,
-        DeriveContextP256Cmd as DeriveContextCmd,
-    };
+    use crate::commands::{sign::SignP256Cmd as SignCmd, CertifyKeyP256Cmd as CertifyKeyCmd};
     #[cfg(feature = "p384")]
-    use crate::commands::{
-        sign::SignP384Cmd as SignCmd, CertifyKeyP384Cmd as CertifyKeyCmd,
-        DeriveContextP384Cmd as DeriveContextCmd,
-    };
+    use crate::commands::{sign::SignP384Cmd as SignCmd, CertifyKeyP384Cmd as CertifyKeyCmd};
     use crate::{
         commands::{
             certify_key::{CertifyKeyCommand, CertifyKeyFlags},
             derive_context::DeriveContextFlags,
             tests::{TEST_DIGEST, TEST_LABEL},
-            Command, CommandHdr, InitCtxCmd,
+            Command, CommandHdr, DeriveContextCmd, InitCtxCmd,
         },
         dpe_instance::tests::{
             test_env, test_state, DPE_PROFILE, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_LOCALITIES,

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -402,13 +402,7 @@ impl Iterator for FlagsIter {
 pub mod tests {
     use super::*;
     use crate::commands::tests::DEFAULT_PLATFORM;
-    use crate::commands::DeriveContextFlags;
-    #[cfg(feature = "ml-dsa")]
-    use crate::commands::DeriveContextMldsaExternalMu87Cmd as DeriveContextCmd;
-    #[cfg(feature = "p256")]
-    use crate::commands::DeriveContextP256Cmd as DeriveContextCmd;
-    #[cfg(feature = "p384")]
-    use crate::commands::DeriveContextP384Cmd as DeriveContextCmd;
+    use crate::commands::{DeriveContextCmd, DeriveContextFlags};
     use crate::response::NewHandleResp;
     use crate::support::test::SUPPORT;
     use crate::{DpeFlags, CURRENT_PROFILE_MAJOR_VERSION};

--- a/tools/src/cert_size.rs
+++ b/tools/src/cert_size.rs
@@ -4,7 +4,9 @@ use alg::*;
 use anyhow::{anyhow, Result};
 use clap::{Parser, ValueEnum};
 use dpe::{
-    commands::{CertifyKeyCommand, CertifyKeyFlags, CommandExecution, DeriveContextFlags},
+    commands::{
+        CertifyKeyCommand, CertifyKeyFlags, CommandExecution, DeriveContextCmd, DeriveContextFlags,
+    },
     context::ContextHandle,
     DpeFlags, DpeProfile,
 };
@@ -20,28 +22,21 @@ use platform::default::{DefaultPlatform, DefaultPlatformProfile};
 mod alg {
     pub use super::Algorithm::Ec as DefaultAlg;
     pub use crypto::Ecdsa256RustCrypto as EcdsaRustCrypto;
-    pub use dpe::commands::{
-        CertifyKeyP256Cmd as CertifyKeyCmd, DeriveContextP256Cmd as DeriveContextCmd,
-    };
+    pub use dpe::commands::CertifyKeyP256Cmd as CertifyKeyCmd;
     pub const DPE_PROFILE: dpe::DpeProfile = dpe::DpeProfile::P256Sha256;
 }
 #[cfg(feature = "p384")]
 mod alg {
     pub use super::Algorithm::Ec as DefaultAlg;
     pub use crypto::Ecdsa384RustCrypto as EcdsaRustCrypto;
-    pub use dpe::commands::{
-        CertifyKeyP384Cmd as CertifyKeyCmd, DeriveContextP384Cmd as DeriveContextCmd,
-    };
+    pub use dpe::commands::CertifyKeyP384Cmd as CertifyKeyCmd;
     pub const DPE_PROFILE: dpe::DpeProfile = dpe::DpeProfile::P384Sha384;
 }
 #[cfg(feature = "ml-dsa")]
 mod alg {
     pub use super::Algorithm::Mldsa as DefaultAlg;
     pub use crypto::MldsaRustCrypto;
-    pub use dpe::commands::{
-        CertifyKeyMldsaExternalMu87Cmd as CertifyKeyCmd,
-        DeriveContextMldsaExternalMu87Cmd as DeriveContextCmd,
-    };
+    pub use dpe::commands::CertifyKeyMldsaExternalMu87Cmd as CertifyKeyCmd;
     pub const DPE_PROFILE: dpe::DpeProfile = dpe::DpeProfile::Mldsa87ExternalMu;
 }
 

--- a/tools/src/sample_dpe_cert.rs
+++ b/tools/src/sample_dpe_cert.rs
@@ -6,7 +6,7 @@ use profile::*;
 use std::env;
 use {
     crypto::RustCryptoImpl,
-    dpe::commands::{self, CertifyKeyFlags, DeriveContextFlags},
+    dpe::commands::{self, CertifyKeyFlags, DeriveContextCmd, DeriveContextFlags},
     dpe::context::ContextHandle,
     dpe::dpe_instance::{DpeEnv, DpeTypes},
     dpe::response::Response,
@@ -20,9 +20,7 @@ use {
 mod profile {
     use super::*;
     pub use crypto::Ecdsa256RustCrypto as RustCrypto;
-    pub use dpe::commands::{
-        CertifyKeyP256Cmd as CertifyKeyCmd, DeriveContextP256Cmd as DeriveContextCmd,
-    };
+    pub use dpe::commands::CertifyKeyP256Cmd as CertifyKeyCmd;
     pub const DPE_PROFILE: dpe::DpeProfile = dpe::DpeProfile::P256Sha256;
     pub const PLATFORM_PROFILE: DefaultPlatformProfile = DefaultPlatformProfile::P256;
 }
@@ -31,9 +29,7 @@ mod profile {
 mod profile {
     use super::*;
     pub use crypto::Ecdsa384RustCrypto as RustCrypto;
-    pub use dpe::commands::{
-        CertifyKeyP384Cmd as CertifyKeyCmd, DeriveContextP384Cmd as DeriveContextCmd,
-    };
+    pub use dpe::commands::CertifyKeyP384Cmd as CertifyKeyCmd;
     pub const DPE_PROFILE: dpe::DpeProfile = dpe::DpeProfile::P384Sha384;
     pub const PLATFORM_PROFILE: DefaultPlatformProfile = DefaultPlatformProfile::P384;
 }
@@ -42,10 +38,7 @@ mod profile {
 mod profile {
     use super::*;
     pub use crypto::Ecdsa256RustCrypto as RustCrypto;
-    pub use dpe::commands::{
-        CertifyKeyMldsaExternalMu87Cmd as CertifyKeyCmd,
-        DeriveContextMldsaExternalMu87Cmd as DeriveContextCmd,
-    };
+    pub use dpe::commands::CertifyKeyMldsaExternalMu87Cmd as CertifyKeyCmd;
     pub const DPE_PROFILE: dpe::DpeProfile = dpe::DpeProfile::Mldsa87ExternalMu;
     pub const PLATFORM_PROFILE: DefaultPlatformProfile = DefaultPlatformProfile::Mldsa87ExternalMu;
 }


### PR DESCRIPTION
This reverts commit 044555c1ddf760023bc90711795e2d94389472d7

Our original plan was to completely remove profile data from build time variables. This looks to be a bit more involved, especially to make the TciMeasurement size generic. So we decided in the short term to make the TCI measurement size static at build time. This makes #444 and #438 obsolete. We may want to re-do them later, but in the meantime it just makes everything less convenient.