### PR TITLE
Switch `DeriveContext` to use `TciMeasurement`

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -317,6 +317,7 @@ mod tests {
         commands::{Command, CommandHdr, DeriveContextCmd, DeriveContextFlags, InitCtxCmd},
         dpe_instance::tests::{test_env, DPE_PROFILE, SIMULATION_HANDLE, TEST_LOCALITIES},
         support::Support,
+        tci::TciMeasurement,
         x509::{tests::TcbInfo, DirectoryString, Name},
         State, TCI_SIZE,
     };
@@ -694,7 +695,7 @@ mod tests {
         // Derive context twice with different types
         let derive_cmd = DeriveContextCmd {
             handle: ContextHandle::default(),
-            data: [1; TCI_SIZE],
+            data: TciMeasurement([1; TCI_SIZE]),
             flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INPUT_ALLOW_X509,
             tci_type: 1,
             target_locality: 0,

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -107,7 +107,6 @@ mod tests {
         dpe_instance::tests::{
             test_env, test_state, DPE_PROFILE, SIMULATION_HANDLE, TEST_HANDLE, TEST_LOCALITIES,
         },
-        TCI_SIZE,
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use zerocopy::IntoBytes;
@@ -295,12 +294,9 @@ mod tests {
 
         // create new context while preserving auto-initialized context
         let handle_1 = match (DeriveContextCmd {
-            handle: ContextHandle::default(),
-            data: [0u8; TCI_SIZE],
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT | DeriveContextFlags::CHANGE_LOCALITY,
-            tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
-            svn: 0,
+            ..Default::default()
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         {
@@ -312,11 +308,8 @@ mod tests {
         // retire context with handle 1 and create new context
         let handle_2 = match (DeriveContextCmd {
             handle: handle_1,
-            data: [0u8; TCI_SIZE],
-            flags: DeriveContextFlags::empty(),
-            tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
-            svn: 0,
+            ..Default::default()
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])
         {
@@ -328,11 +321,8 @@ mod tests {
         // retire context with handle 2 and create new context
         let handle_3 = match (DeriveContextCmd {
             handle: handle_2,
-            data: [0u8; TCI_SIZE],
-            flags: DeriveContextFlags::empty(),
-            tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
-            svn: 0,
+            ..Default::default()
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])
         {
@@ -366,12 +356,9 @@ mod tests {
 
         // create new context while preserving auto-initialized context
         let parent_handle = match (DeriveContextCmd {
-            handle: ContextHandle::default(),
-            data: [0u8; TCI_SIZE],
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT | DeriveContextFlags::CHANGE_LOCALITY,
-            tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
-            svn: 0,
+            ..Default::default()
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         {
@@ -383,11 +370,9 @@ mod tests {
         // derive one child from the parent
         let parent_handle = match (DeriveContextCmd {
             handle: parent_handle,
-            data: [0u8; TCI_SIZE],
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
-            tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
-            svn: 0,
+            ..Default::default()
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])
         {
@@ -399,11 +384,8 @@ mod tests {
         // derive another child while retiring the parent handle
         let handle_b = match (DeriveContextCmd {
             handle: parent_handle,
-            data: [0u8; TCI_SIZE],
-            flags: DeriveContextFlags::empty(),
-            tci_type: 0,
             target_locality: TEST_LOCALITIES[1],
-            svn: 0,
+            ..Default::default()
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])
         {

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -270,6 +270,7 @@ mod tests {
         dpe_instance::tests::{
             test_env, test_state, DPE_PROFILE, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_LOCALITIES,
         },
+        tci::TciMeasurement,
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use openssl::x509::X509;
@@ -367,7 +368,7 @@ mod tests {
         for i in 0..3 {
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [i; DPE_PROFILE.hash_size()],
+                data: TciMeasurement([i; DPE_PROFILE.hash_size()]),
                 flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INPUT_ALLOW_X509,
                 tci_type: i as u32,
                 target_locality: 0,

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -405,6 +405,7 @@ pub mod tests {
     use crate::commands::{DeriveContextCmd, DeriveContextFlags};
     use crate::response::NewHandleResp;
     use crate::support::test::SUPPORT;
+    use crate::tci::TciMeasurement;
     use crate::{DpeFlags, CURRENT_PROFILE_MAJOR_VERSION};
     use caliptra_cfi_lib_git::CfiCounter;
     use crypto::RustCryptoImpl;
@@ -568,7 +569,7 @@ pub mod tests {
         for i in 0..3 {
             DeriveContextCmd {
                 handle: ContextHandle::default(),
-                data: [i; DPE_PROFILE.hash_size()],
+                data: TciMeasurement([i; DPE_PROFILE.hash_size()]),
                 flags: DeriveContextFlags::MAKE_DEFAULT,
                 tci_type: i as u32,
                 target_locality: 0,
@@ -622,12 +623,8 @@ pub mod tests {
             .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[0])
             .unwrap();
         DeriveContextCmd {
-            handle: ContextHandle::default(),
-            data: [0; DPE_PROFILE.hash_size()],
             flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INTERNAL_INPUT_INFO,
-            tci_type: 0u32,
-            target_locality: 0,
-            svn: 0,
+            ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         .unwrap();
@@ -680,12 +677,8 @@ pub mod tests {
             .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[0])
             .unwrap();
         DeriveContextCmd {
-            handle: ContextHandle::default(),
-            data: [0; DPE_PROFILE.hash_size()],
             flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INTERNAL_INPUT_DICE,
-            tci_type: 0u32,
-            target_locality: 0,
-            svn: 0,
+            ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         .unwrap();

--- a/tools/src/cert_size.rs
+++ b/tools/src/cert_size.rs
@@ -116,14 +116,10 @@ fn run<T: DpeTypes>(env: &mut DpeEnv<T>, args: &Args) -> Result<()> {
     // Minus 1 to account for the default context
     for i in 0..args.num_contexts - 1 {
         let _resp = DeriveContextCmd {
-            handle: ContextHandle::default(),
-            data: [1; dpe::TCI_SIZE],
             flags: DeriveContextFlags::MAKE_DEFAULT
                 | DeriveContextFlags::INTERNAL_INPUT_INFO
                 | DeriveContextFlags::INTERNAL_INPUT_DICE,
-            tci_type: 0,
-            target_locality: 0,
-            svn: 0,
+            ..Default::default()
         }
         .execute(&mut dpe, env, 0)
         .map_err(|e| anyhow!("DPE error creating {i}th context: {e:?}"));

--- a/tools/src/sample_dpe_cert.rs
+++ b/tools/src/sample_dpe_cert.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use dpe::DpeFlags;
+use dpe::{tci::TciMeasurement, DpeFlags};
 use platform::default::DefaultPlatformProfile;
 use profile::*;
 use std::env;
@@ -56,7 +56,7 @@ impl DpeTypes for TestTypes {
 fn add_tcb_info(
     dpe: &mut DpeInstance,
     env: &mut DpeEnv<TestTypes>,
-    data: &[u8; DPE_PROFILE.hash_size()],
+    data: &TciMeasurement,
     tci_type: u32,
     svn: u32,
 ) {
@@ -140,7 +140,7 @@ fn main() {
     add_tcb_info(
         &mut dpe,
         &mut env,
-        &[0; DPE_PROFILE.hash_size()],
+        &TciMeasurement::default(),
         u32::from_be_bytes(*b"TEST"),
         0,
     );


### PR DESCRIPTION
We have a type for this already, we might as well use it directly.