### PR TITLE
Revert "Convert some TciMeasurement parameters to Digest. (#438)"

### DIFF
--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -15,7 +15,6 @@ use caliptra_cfi_derive_git::cfi_impl_fn;
 #[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
 use cfg_if::cfg_if;
-use crypto::Digest;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use platform::Platform;
@@ -262,7 +261,7 @@ impl CommandExecution for DeriveContextCmd {
                     dpe.add_tci_measurement(
                         env,
                         &mut tmp_context,
-                        &Digest::from(data.0),
+                        data,
                         target_locality,
                     )?;
 
@@ -398,12 +397,7 @@ impl CommandExecution for DeriveContextCmd {
             svn,
         });
 
-        dpe.add_tci_measurement(
-            env,
-            &mut tmp_child_context,
-            &Digest::from(data.0),
-            target_locality,
-        )?;
+        dpe.add_tci_measurement(env, &mut tmp_child_context, data, target_locality)?;
 
         // Add child to the parent's list of children.
         let children_with_child_idx = tmp_parent_context.add_child(child_idx)?;


### PR DESCRIPTION
This reverts commit d73a83e9880cbedee008a5d3e87292b3613fe654.

Our original plan was to completely remove profile data from build time variables. This looks to be a bit more involved, especially to make the TciMeasurement size generic. So we decided in the short term to make the TCI measurement size static at build time. This makes #444 and #438 obsolete. We may want to re-do them later, but in the meantime it just makes everything less convenient.