### PR TITLE
Add SignData crypto types

### DIFF
--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -102,8 +102,9 @@ impl Command<'_> {
             Command::DeriveContext(cmd) => cmd.as_bytes(),
             Command::GetCertificateChain(cmd) => cmd.as_bytes(),
             Command::DestroyCtx(cmd) => cmd.as_bytes(),
-            Command::GetProfile => &[],
+            Command::GetProfile(cmd) => cmd.as_bytes(),
             Command::InitCtx(cmd) => cmd.as_bytes(),
+            #[cfg(not(feature = "disable_rotate_context"))]
             Command::RotateCtx(cmd) => cmd.as_bytes(),
             Command::Sign(cmd) => cmd.as_bytes(),
         }

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -18,7 +18,8 @@ use caliptra_cfi_lib_git::cfi_launder;
 use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
 use crypto::{
     ecdsa::{EcdsaPubKey, EcdsaSignature},
-    Crypto, CryptoError, CryptoSuite, Digest, Hasher, PubKey, Signature, MAX_EXPORTED_CDI_SIZE,
+    Crypto, CryptoError, CryptoSuite, Digest, Hasher, PubKey, SignData, Signature,
+    MAX_EXPORTED_CDI_SIZE,
 };
 #[cfg(not(feature = "disable_x509"))]
 use platform::CertValidity;
@@ -2912,11 +2913,11 @@ fn create_dpe_cert_or_csr(
     };
 
     let mut sign_cb = |data: &[u8], use_derived: bool| {
-        let hash = env.crypto.hash(data)?;
         if use_derived {
-            env.crypto.sign_with_derived(&hash, &priv_key, &pub_key)
+            env.crypto
+                .sign_with_derived(&SignData::Raw(data), &priv_key, &pub_key)
         } else {
-            env.crypto.sign_with_alias(&hash)
+            env.crypto.sign_with_alias(&SignData::Raw(data))
         }
     };
 


### PR DESCRIPTION
This will be used to help specify different ways to sign. This changes ML-DSA to do a raw signature instead of a signature of a hash. This opens the door to signing with external mu, but doesn't implement it yet.