### PR TITLE
Use correct context strings for each profile

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -159,12 +159,13 @@ impl CommandExecution for CertifyKeyCommand<'_> {
             }
         }
 
+        let profile = dpe.profile;
         let args = CreateDpeCertArgs {
             handle,
             locality,
             cdi_label: b"DPE",
             key_label: label,
-            context: b"ECC",
+            context: profile.key_context(),
             ueid: label,
             dice_extensions_are_critical: env
                 .state
@@ -355,15 +356,16 @@ mod tests {
     use caliptra_cfi_lib_git::CfiCounter;
     use cms::{
         content_info::{CmsVersion, ContentInfo},
-        signed_data::{SignedData, SignerIdentifier, SignerInfo},
+        signed_data::{SignedData, SignerIdentifier},
     };
     #[cfg(feature = "ml-dsa")]
     use crypto::ml_dsa::{MldsaAlgorithm, MldsaPublicKey};
     use crypto::{
         ecdsa::{EcdsaAlgorithm, EcdsaPub},
-        Crypto, CryptoSuite, Digest, PubKey, SignatureAlgorithm,
+        Crypto, CryptoSuite, PubKey, SignatureAlgorithm,
     };
     use der::{Decode, Encode};
+    #[cfg(feature = "ml-dsa")]
     use ml_dsa::EncodedSignature;
     use openssl::{
         bn::BigNum,

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -117,6 +117,13 @@ impl DpeProfile {
             }
         }
     }
+    pub fn key_context(&self) -> &[u8] {
+        match self {
+            DpeProfile::P256Sha256 | DpeProfile::P384Sha384 => b"ECC",
+            #[cfg(feature = "ml-dsa")]
+            DpeProfile::Mldsa87 => b"MLDSA",
+        }
+    }
 }
 
 impl From<DpeProfile> for u32 {


### PR DESCRIPTION
The context string was hardcoded to "ECC" for `Sign` and `CertifyKey`. This changes them to use "ECC" for ECDSA profiles and "MLDSA" for ML-DSA.

This also aligns the `Sign` profile specific commands to look like the profile specific commands from `CertifyKey`.