### PR TITLE
Rename some ML-DSA items

### DIFF
--- a/crypto/src/hkdf.rs
+++ b/crypto/src/hkdf.rs
@@ -34,12 +34,12 @@ pub fn hkdf_derive_cdi(
             Ok(cdi.to_vec())
         }
         #[cfg(feature = "ml-dsa")]
-        SignatureAlgorithm::MlDsa(MldsaAlgorithm::ExternalMu87) => {
+        SignatureAlgorithm::MlDsa(MldsaAlgorithm::Mldsa87) => {
             // This block assumes that the size of `xi` is the same as `SHA256`.
-            const _: () = assert!(MldsaAlgorithm::ExternalMu87.seed_size() == 256 / 8);
+            const _: () = assert!(MldsaAlgorithm::Mldsa87.seed_size() == 256 / 8);
 
             let hk = Hkdf::<Sha256>::new(Some(info), measurement.as_slice());
-            let mut cdi = [0u8; MldsaAlgorithm::ExternalMu87.seed_size()];
+            let mut cdi = [0u8; MldsaAlgorithm::Mldsa87.seed_size()];
             hk.expand(measurement.as_slice(), &mut cdi)?;
 
             Ok(cdi.to_vec())
@@ -69,9 +69,9 @@ pub fn hkdf_get_priv_key(
             Ok(priv_key.into())
         }
         #[cfg(feature = "ml-dsa")]
-        SignatureAlgorithm::MlDsa(MldsaAlgorithm::ExternalMu87) => {
+        SignatureAlgorithm::MlDsa(MldsaAlgorithm::Mldsa87) => {
             let hk = Hkdf::<Sha256>::new(Some(info), cdi);
-            let mut priv_key = [0u8; MldsaAlgorithm::ExternalMu87.seed_size()];
+            let mut priv_key = [0u8; MldsaAlgorithm::Mldsa87.seed_size()];
             hk.expand(label, &mut priv_key)?;
 
             Ok(priv_key.into())

--- a/crypto/src/ml_dsa.rs
+++ b/crypto/src/ml_dsa.rs
@@ -6,51 +6,51 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 #[derive(Debug, Clone, Copy)]
 pub enum MldsaAlgorithm {
-    ExternalMu87,
+    Mldsa87,
 }
 
 #[cfg(test)]
 impl Default for MldsaAlgorithm {
     fn default() -> Self {
-        Self::ExternalMu87
+        Self::Mldsa87
     }
 }
 
 impl MldsaAlgorithm {
     pub const fn seed_size(self) -> usize {
         match self {
-            Self::ExternalMu87 => 32,
+            Self::Mldsa87 => 32,
         }
     }
     pub const fn signature_size(self) -> usize {
         match self {
-            Self::ExternalMu87 => 4627,
+            Self::Mldsa87 => 4627,
         }
     }
     pub const fn public_key_size(self) -> usize {
         match self {
-            Self::ExternalMu87 => 2592,
+            Self::Mldsa87 => 2592,
         }
     }
     pub const fn private_key_size(self) -> usize {
         match self {
-            Self::ExternalMu87 => 4896,
+            Self::Mldsa87 => 4896,
         }
     }
     pub const fn external_mu_size(self) -> usize {
         match self {
-            Self::ExternalMu87 => 64,
+            Self::Mldsa87 => 64,
         }
     }
 }
 
 #[derive(FromBytes, IntoBytes, KnownLayout, Immutable)]
 #[repr(C)]
-pub struct ExternalMu(pub [u8; MldsaAlgorithm::ExternalMu87.external_mu_size()]);
+pub struct ExternalMu(pub [u8; MldsaAlgorithm::Mldsa87.external_mu_size()]);
 
 impl SignatureType for ExternalMu {
     const SIGNATURE_ALGORITHM: SignatureAlgorithm =
-        SignatureAlgorithm::MlDsa(MldsaAlgorithm::ExternalMu87);
+        SignatureAlgorithm::MlDsa(MldsaAlgorithm::Mldsa87);
 }
 
 impl DigestType for ExternalMu {
@@ -59,10 +59,10 @@ impl DigestType for ExternalMu {
 
 #[derive(Clone, FromBytes, IntoBytes, KnownLayout, Immutable)]
 #[repr(C)]
-pub struct MldsaPublicKey(pub [u8; MldsaAlgorithm::ExternalMu87.public_key_size()]);
+pub struct MldsaPublicKey(pub [u8; MldsaAlgorithm::Mldsa87.public_key_size()]);
 
 impl MldsaPublicKey {
-    pub fn from_slice(pub_key: &[u8; MldsaAlgorithm::ExternalMu87.public_key_size()]) -> Self {
+    pub fn from_slice(pub_key: &[u8; MldsaAlgorithm::Mldsa87.public_key_size()]) -> Self {
         Self(*pub_key)
     }
     pub fn as_slice(&self) -> &[u8] {
@@ -72,7 +72,7 @@ impl MldsaPublicKey {
 
 #[derive(Clone, FromBytes, IntoBytes, KnownLayout, Immutable)]
 #[repr(C)]
-pub struct MldsaSignature(pub [u8; MldsaAlgorithm::ExternalMu87.signature_size()]);
+pub struct MldsaSignature(pub [u8; MldsaAlgorithm::Mldsa87.signature_size()]);
 
 impl MldsaSignature {
     pub fn as_slice(&self) -> &[u8] {

--- a/crypto/src/rustcrypto.rs
+++ b/crypto/src/rustcrypto.rs
@@ -236,7 +236,7 @@ impl<S: SignatureType, D: DigestType, SD: SignDataType> RustCryptoImpl<S, D, SD>
                 ))
             }
             #[cfg(feature = "ml-dsa")]
-            alg @ SignatureAlgorithm::MlDsa(MldsaAlgorithm::ExternalMu87) => {
+            alg @ SignatureAlgorithm::MlDsa(MldsaAlgorithm::Mldsa87) => {
                 let secret = hkdf_get_priv_key(alg, cdi, label, info)?;
                 let kp = MlDsa87::from_seed(
                     secret
@@ -406,7 +406,7 @@ impl<S: SignatureType, D: DigestType, SD: SignDataType> Crypto for RustCryptoImp
                 Ok(EcdsaSig::from(sig).into())
             }
             #[cfg(feature = "ml-dsa")]
-            SignatureAlgorithm::MlDsa(MldsaAlgorithm::ExternalMu87) => {
+            SignatureAlgorithm::MlDsa(MldsaAlgorithm::Mldsa87) => {
                 let ml_dsa_secret = KeyPair::<MlDsa87>::from_pkcs8_pem(include_str!(concat!(
                     env!("OUT_DIR"),
                     "/alias_priv_mldsa_87.pem"
@@ -434,7 +434,7 @@ impl<S: SignatureType, D: DigestType, SD: SignDataType> Crypto for RustCryptoImp
                 Ok(EcdsaSig::from(sig).into())
             }
             #[cfg(feature = "ml-dsa")]
-            SignatureAlgorithm::MlDsa(MldsaAlgorithm::ExternalMu87) => {
+            SignatureAlgorithm::MlDsa(MldsaAlgorithm::Mldsa87) => {
                 let ml_dsa_secret = MlDsa87::from_seed(priv_key.0.as_slice().try_into().unwrap());
                 self.mldsa_sign_data(&ml_dsa_secret, data)
             }

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -432,9 +432,7 @@ impl Default for DeriveContextCmd {
 mod tests {
     use super::*;
     #[cfg(feature = "ml-dsa")]
-    use crate::commands::{
-        sign::SignMldsaExternalMu87Cmd as SignCmd, CertifyKeyMldsaExternalMu87Cmd as CertifyKeyCmd,
-    };
+    use crate::commands::{sign::SignMldsa87Cmd as SignCmd, CertifyKeyMldsa87Cmd as CertifyKeyCmd};
     #[cfg(feature = "p256")]
     use crate::commands::{sign::SignP256Cmd as SignCmd, CertifyKeyP256Cmd as CertifyKeyCmd};
     #[cfg(feature = "p384")]
@@ -1715,9 +1713,7 @@ mod tests {
                             OpenSSLHasher::new(MessageDigest::sha384()).unwrap()
                         }
                         #[cfg(feature = "ml-dsa")]
-                        DpeProfile::Mldsa87ExternalMu => {
-                            OpenSSLHasher::new(MessageDigest::sha384()).unwrap()
-                        }
+                        DpeProfile::Mldsa87 => OpenSSLHasher::new(MessageDigest::sha384()).unwrap(),
                     };
                     hasher.update(pub_key).unwrap();
                     let expected_ski: &[u8] = &hasher.finish().unwrap();

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -15,7 +15,7 @@ pub use self::initialize_context::InitCtxCmd;
 pub use self::sign::{SignCommand, SignFlags, SignP256Cmd, SignP384Cmd};
 
 #[cfg(feature = "ml-dsa")]
-pub use {self::certify_key::CertifyKeyMldsaExternalMu87Cmd, sign::SignMldsaExternalMu87Cmd};
+pub use {self::certify_key::CertifyKeyMldsa87Cmd, sign::SignMldsa87Cmd};
 
 #[cfg(not(feature = "disable_rotate_context"))]
 pub use self::rotate_context::{RotateCtxCmd, RotateCtxFlags};
@@ -172,9 +172,9 @@ impl<'a> From<&'a CertifyKeyP384Cmd> for Command<'a> {
 }
 
 #[cfg(feature = "ml-dsa")]
-impl<'a> From<&'a CertifyKeyMldsaExternalMu87Cmd> for Command<'a> {
-    fn from(cmd: &'a CertifyKeyMldsaExternalMu87Cmd) -> Command<'a> {
-        Command::CertifyKey(CertifyKeyCommand::ExternalMu87(cmd))
+impl<'a> From<&'a CertifyKeyMldsa87Cmd> for Command<'a> {
+    fn from(cmd: &'a CertifyKeyMldsa87Cmd) -> Command<'a> {
+        Command::CertifyKey(CertifyKeyCommand::Mldsa87(cmd))
     }
 }
 
@@ -199,9 +199,9 @@ impl<'a> From<&'a SignP384Cmd> for Command<'a> {
 }
 
 #[cfg(feature = "ml-dsa")]
-impl<'a> From<&'a SignMldsaExternalMu87Cmd> for Command<'a> {
-    fn from(cmd: &'a SignMldsaExternalMu87Cmd) -> Command<'a> {
-        Command::Sign(SignCommand::ExternalMu87(cmd))
+impl<'a> From<&'a SignMldsa87Cmd> for Command<'a> {
+    fn from(cmd: &'a SignMldsa87Cmd) -> Command<'a> {
+        Command::Sign(SignCommand::Mldsa87(cmd))
     }
 }
 
@@ -334,8 +334,7 @@ pub mod tests {
     #[cfg(feature = "p384")]
     pub const DEFAULT_PLATFORM: DefaultPlatform = DefaultPlatform(DefaultPlatformProfile::P384);
     #[cfg(feature = "ml-dsa")]
-    pub const DEFAULT_PLATFORM: DefaultPlatform =
-        DefaultPlatform(DefaultPlatformProfile::Mldsa87ExternalMu);
+    pub const DEFAULT_PLATFORM: DefaultPlatform = DefaultPlatform(DefaultPlatformProfile::Mldsa87);
 
     pub const PROFILES: [DpeProfile; 2] = [DpeProfile::P256Sha256, DpeProfile::P384Sha384];
 

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -408,7 +408,7 @@ pub mod tests {
     pub const DPE_PROFILE: DpeProfile = DpeProfile::P384Sha384;
 
     #[cfg(feature = "ml-dsa")]
-    pub const DPE_PROFILE: DpeProfile = DpeProfile::Mldsa87ExternalMu;
+    pub const DPE_PROFILE: DpeProfile = DpeProfile::Mldsa87;
 
     #[cfg(feature = "p256")]
     use crypto::Ecdsa256RustCrypto;

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -88,8 +88,8 @@ pub enum DpeProfile {
     P256Sha256 = 3,
     P384Sha384 = 4,
     #[cfg(feature = "ml-dsa")]
-    Mldsa87ExternalMu = 5, // TODO(clundin): Added this to get past compiler / feature flags. We
-                           // will want a real solution here.
+    Mldsa87 = 5, // TODO(clundin): Added this to get past compiler / feature flags. We
+                 // will want a real solution here.
 }
 
 impl DpeProfile {
@@ -98,7 +98,7 @@ impl DpeProfile {
             DpeProfile::P256Sha256 => 32,
             DpeProfile::P384Sha384 => 48,
             #[cfg(feature = "ml-dsa")]
-            DpeProfile::Mldsa87ExternalMu => 48,
+            DpeProfile::Mldsa87 => 48,
         }
     }
     pub const fn ecc_int_size(&self) -> usize {
@@ -112,8 +112,8 @@ impl DpeProfile {
             DpeProfile::P256Sha256 => crypto::SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit256),
             DpeProfile::P384Sha384 => crypto::SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit384),
             #[cfg(feature = "ml-dsa")]
-            DpeProfile::Mldsa87ExternalMu => {
-                crypto::SignatureAlgorithm::MlDsa(crypto::ml_dsa::MldsaAlgorithm::ExternalMu87)
+            DpeProfile::Mldsa87 => {
+                crypto::SignatureAlgorithm::MlDsa(crypto::ml_dsa::MldsaAlgorithm::Mldsa87)
             }
         }
     }

--- a/dpe/src/response.rs
+++ b/dpe/src/response.rs
@@ -178,7 +178,7 @@ pub enum CertifyKeyResp {
     #[cfg(feature = "p384")]
     P384(CertifyKeyP384Resp),
     #[cfg(feature = "ml-dsa")]
-    MldsaExternalMu87(CertifyKeyMldsaExternalMu87Resp),
+    Mldsa87(CertifyKeyMldsa87Resp),
 }
 
 impl CertifyKeyResp {
@@ -189,7 +189,7 @@ impl CertifyKeyResp {
             #[cfg(feature = "p384")]
             CertifyKeyResp::P384(resp) => resp.new_context_handle = *handle,
             #[cfg(feature = "ml-dsa")]
-            CertifyKeyResp::MldsaExternalMu87(resp) => resp.new_context_handle = *handle,
+            CertifyKeyResp::Mldsa87(resp) => resp.new_context_handle = *handle,
         }
     }
 
@@ -200,7 +200,7 @@ impl CertifyKeyResp {
             #[cfg(feature = "p384")]
             CertifyKeyResp::P384(resp) => &resp.resp_hdr,
             #[cfg(feature = "ml-dsa")]
-            CertifyKeyResp::MldsaExternalMu87(resp) => &resp.resp_hdr,
+            CertifyKeyResp::Mldsa87(resp) => &resp.resp_hdr,
         }
     }
 
@@ -211,7 +211,7 @@ impl CertifyKeyResp {
             #[cfg(feature = "p384")]
             CertifyKeyResp::P384(resp) => resp.as_bytes(),
             #[cfg(feature = "ml-dsa")]
-            CertifyKeyResp::MldsaExternalMu87(resp) => resp.as_bytes(),
+            CertifyKeyResp::Mldsa87(resp) => resp.as_bytes(),
         }
     }
 
@@ -222,7 +222,7 @@ impl CertifyKeyResp {
             #[cfg(feature = "p384")]
             CertifyKeyResp::P384(r) => (&r.cert, r.cert_size),
             #[cfg(feature = "ml-dsa")]
-            CertifyKeyResp::MldsaExternalMu87(r) => (&r.cert, r.cert_size),
+            CertifyKeyResp::Mldsa87(r) => (&r.cert, r.cert_size),
         };
         buf.get(..size as usize).ok_or(DpeErrorCode::InternalError)
     }
@@ -253,10 +253,10 @@ pub struct CertifyKeyP384Resp {
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, IntoBytes, TryFromBytes, Immutable, KnownLayout)]
 #[cfg(feature = "ml-dsa")]
-pub struct CertifyKeyMldsaExternalMu87Resp {
+pub struct CertifyKeyMldsa87Resp {
     pub resp_hdr: ResponseHdr,
     pub new_context_handle: ContextHandle,
-    pub pubkey: [u8; MldsaAlgorithm::ExternalMu87.public_key_size()],
+    pub pubkey: [u8; MldsaAlgorithm::Mldsa87.public_key_size()],
     pub cert_size: u32,
     pub cert: [u8; MAX_CERT_SIZE],
 }
@@ -331,7 +331,7 @@ pub struct SignP384Resp {
 pub struct SignMlDsaResp {
     pub resp_hdr: ResponseHdr,
     pub new_context_handle: ContextHandle,
-    pub sig: [u8; crypto::ml_dsa::MldsaAlgorithm::ExternalMu87.signature_size()],
+    pub sig: [u8; crypto::ml_dsa::MldsaAlgorithm::Mldsa87.signature_size()],
     pub _padding: [u8; 1],
 }
 

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -371,7 +371,7 @@ impl CertWriter<'_> {
             #[cfg(feature = "p384")]
             DpeProfile::P384Sha384 => Ok(profile_oids::ECDSA_WITH_SHA384_OID),
             #[cfg(feature = "ml-dsa")]
-            DpeProfile::Mldsa87ExternalMu => Ok(Self::MLDSA_OID),
+            DpeProfile::Mldsa87 => Ok(Self::MLDSA_OID),
             _ => Err(DpeErrorCode::X509AlgorithmMismatch),
         }
     }
@@ -383,7 +383,7 @@ impl CertWriter<'_> {
             #[cfg(feature = "p384")]
             DpeProfile::P384Sha384 => Ok(Self::HASH_SHA384_OID),
             #[cfg(feature = "ml-dsa")]
-            DpeProfile::Mldsa87ExternalMu => Ok(Self::HASH_SHA384_OID),
+            DpeProfile::Mldsa87 => Ok(Self::HASH_SHA384_OID),
             _ => Err(DpeErrorCode::X509AlgorithmMismatch),
         }
     }
@@ -3125,7 +3125,7 @@ pub(crate) mod tests {
     #[test]
     fn test_subject_pubkey() {
         let mut cert = [0u8; 4096];
-        let test_key = MldsaPublicKey([0; MldsaAlgorithm::ExternalMu87.public_key_size()]);
+        let test_key = MldsaPublicKey([0; MldsaAlgorithm::Mldsa87.public_key_size()]);
 
         let mut w = CertWriter::new(&mut cert, DPE_PROFILE, true);
         let bytes_written = w.encode_mldsa_subject_pubkey_info(&test_key).unwrap();
@@ -3259,7 +3259,7 @@ pub(crate) mod tests {
             DpeProfile::P256Sha256 => Hasher::new(MessageDigest::sha256()).unwrap(),
             DpeProfile::P384Sha384 => Hasher::new(MessageDigest::sha384()).unwrap(),
             #[cfg(feature = "ml-dsa")]
-            DpeProfile::Mldsa87ExternalMu => {
+            DpeProfile::Mldsa87 => {
                 unreachable!("tried to build ecdsa test cert for ml-dsa profile!")
             }
         };
@@ -3376,7 +3376,7 @@ pub(crate) mod tests {
         let node = TciNodeData::new();
 
         let mut hasher = match DPE_PROFILE {
-            DpeProfile::Mldsa87ExternalMu => Hasher::new(MessageDigest::sha384()).unwrap(),
+            DpeProfile::Mldsa87 => Hasher::new(MessageDigest::sha384()).unwrap(),
             _ => unreachable!("tried to build ml-dsa test cert for non ml-dsa profile!"),
         };
         hasher.update(test_pub.as_slice()).unwrap();
@@ -3416,13 +3416,13 @@ pub(crate) mod tests {
 
         let pub_key = match DPE_PROFILE.alg() {
             #[cfg(feature = "ml-dsa")]
-            SignatureAlgorithm::MlDsa(MldsaAlgorithm::ExternalMu87) => PubKey::MlDsa(test_pub),
+            SignatureAlgorithm::MlDsa(MldsaAlgorithm::Mldsa87) => PubKey::MlDsa(test_pub),
             _ => panic!("Missing signature"),
         };
 
         let test_sig: Signature = match DPE_PROFILE.alg() {
             #[cfg(feature = "ml-dsa")]
-            SignatureAlgorithm::MlDsa(MldsaAlgorithm::ExternalMu87) => {
+            SignatureAlgorithm::MlDsa(MldsaAlgorithm::Mldsa87) => {
                 Signature::MlDsa(MldsaSignature([0xBB; ALGORITHM.signature_size()]))
             }
             _ => panic!("Missing signature"),
@@ -3579,7 +3579,7 @@ pub(crate) mod tests {
             DpeProfile::P256Sha256 => Hasher::new(MessageDigest::sha256()).unwrap(),
             DpeProfile::P384Sha384 => Hasher::new(MessageDigest::sha384()).unwrap(),
             #[cfg(feature = "ml-dsa")]
-            DpeProfile::Mldsa87ExternalMu => Hasher::new(MessageDigest::sha384()).unwrap(),
+            DpeProfile::Mldsa87 => Hasher::new(MessageDigest::sha384()).unwrap(),
         };
         hasher.update(pub_key).unwrap();
         let expected_key_identifier: &[u8] = &hasher.finish().unwrap();

--- a/platform/src/default.rs
+++ b/platform/src/default.rs
@@ -11,7 +11,7 @@ use core::cmp::min;
 pub enum DefaultPlatformProfile {
     P256,
     P384,
-    Mldsa87ExternalMu,
+    Mldsa87,
 }
 
 // Run ./generate.sh to generate all test certs and test private keys
@@ -20,7 +20,7 @@ impl DefaultPlatformProfile {
         match self {
             DefaultPlatformProfile::P256 => include_bytes!("test_data/cert_256.pem"),
             DefaultPlatformProfile::P384 => include_bytes!("test_data/cert_384.pem"),
-            DefaultPlatformProfile::Mldsa87ExternalMu => {
+            DefaultPlatformProfile::Mldsa87 => {
                 include_bytes!("test_data/cert_mldsa_87.pem")
             }
         }
@@ -30,7 +30,7 @@ impl DefaultPlatformProfile {
         match self {
             DefaultPlatformProfile::P256 => include_bytes!("test_data/cert_256.der"),
             DefaultPlatformProfile::P384 => include_bytes!("test_data/cert_384.der"),
-            DefaultPlatformProfile::Mldsa87ExternalMu => {
+            DefaultPlatformProfile::Mldsa87 => {
                 include_bytes!("test_data/cert_mldsa_87.der")
             }
         }

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -40,8 +40,8 @@ mod profile {
 mod profile {
     use super::*;
     pub use crypto::MldsaRustCrypto as RustCrypto;
-    pub const DPE_PROFILE: dpe::DpeProfile = dpe::DpeProfile::Mldsa87ExternalMu;
-    pub const PLATFORM_PROFILE: DefaultPlatformProfile = DefaultPlatformProfile::Mldsa87ExternalMu;
+    pub const DPE_PROFILE: dpe::DpeProfile = dpe::DpeProfile::Mldsa87;
+    pub const PLATFORM_PROFILE: DefaultPlatformProfile = DefaultPlatformProfile::Mldsa87;
 }
 
 const SOCKET_PATH: &str = "/tmp/dpe-sim.socket";

--- a/tools/src/cert_size.rs
+++ b/tools/src/cert_size.rs
@@ -32,7 +32,7 @@ mod ec {
 #[cfg(feature = "ml-dsa")]
 mod ml_dsa {
     pub use crypto::MldsaRustCrypto;
-    pub use dpe::commands::CertifyKeyMldsaExternalMu87Cmd as CertifyKeyMldsaCmd;
+    pub use dpe::commands::CertifyKeyMldsa87Cmd as CertifyKeyMldsaCmd;
 
     pub struct SimTypesMldsa;
     impl dpe::dpe_instance::DpeTypes for SimTypesMldsa {
@@ -67,7 +67,7 @@ impl From<Algorithm> for DefaultPlatformProfile {
             #[cfg(feature = "p384")]
             Algorithm::Ec => DefaultPlatformProfile::P384,
             #[cfg(feature = "ml-dsa")]
-            Algorithm::Mldsa => DefaultPlatformProfile::Mldsa87ExternalMu,
+            Algorithm::Mldsa => DefaultPlatformProfile::Mldsa87,
             #[allow(unreachable_patterns)]
             _ => panic!("Unsupported algorithm"),
         }
@@ -82,7 +82,7 @@ impl From<Algorithm> for DpeProfile {
             #[cfg(feature = "p384")]
             Algorithm::Ec => DpeProfile::P384Sha384,
             #[cfg(feature = "ml-dsa")]
-            Algorithm::Mldsa => DpeProfile::Mldsa87ExternalMu,
+            Algorithm::Mldsa => DpeProfile::Mldsa87,
             #[allow(unreachable_patterns)]
             _ => panic!("Unsupported algorithm"),
         }
@@ -213,7 +213,7 @@ fn main() -> Result<()> {
         Algorithm::Mldsa => run(
             &mut DpeEnv::<SimTypesMldsa> {
                 crypto: MldsaRustCrypto::new(),
-                platform: DefaultPlatform(DefaultPlatformProfile::Mldsa87ExternalMu),
+                platform: DefaultPlatform(DefaultPlatformProfile::Mldsa87),
                 state: &mut state,
             },
             &args,

--- a/tools/src/sample_dpe_cert.rs
+++ b/tools/src/sample_dpe_cert.rs
@@ -38,9 +38,9 @@ mod profile {
 mod profile {
     use super::*;
     pub use crypto::Ecdsa256RustCrypto as RustCrypto;
-    pub use dpe::commands::CertifyKeyMldsaExternalMu87Cmd as CertifyKeyCmd;
-    pub const DPE_PROFILE: dpe::DpeProfile = dpe::DpeProfile::Mldsa87ExternalMu;
-    pub const PLATFORM_PROFILE: DefaultPlatformProfile = DefaultPlatformProfile::Mldsa87ExternalMu;
+    pub use dpe::commands::CertifyKeyMldsa87Cmd as CertifyKeyCmd;
+    pub const DPE_PROFILE: dpe::DpeProfile = dpe::DpeProfile::Mldsa87;
+    pub const PLATFORM_PROFILE: DefaultPlatformProfile = DefaultPlatformProfile::Mldsa87;
 }
 
 pub struct TestTypes {}

--- a/verification/client/abi.go
+++ b/verification/client/abi.go
@@ -296,7 +296,7 @@ type DPEABI256 = DPEABI[NISTP256Parameter, SHA256Digest, DPEFullCertificate, ECD
 // DPEABI384 is a client that implements DPE_PROFILE_IROT_P384_SHA384
 type DPEABI384 = DPEABI[NISTP384Parameter, SHA384Digest, DPEFullCertificate, ECDSASignature[SHA384Digest]]
 
-// DPEABIMldsa87 is a client that implements DPE_PROFILE_IROT_MLDSA_87_EXTERNAL_MU
+// DPEABIMldsa87 is a client that implements DPE_PROFILE_IROT_MLDSA_87
 type DPEABIMldsa87 = DPEABI[Mldsa87Parameter, SHA384Digest, DPEMldsaCertificate, Mldsa87Signature]
 
 // dpeProfileImplementsTypeConstraints checks that the requested DPEABI type constraints are compatible with the DPE profile.
@@ -328,7 +328,7 @@ func dpeProfileImplementsTypeConstraints[C Curve, D DigestAlgorithm, Cert DPECer
 	} else if isP384 && isSHA384 && !isMin && isEcdsa384Sig {
 		targetProfile = ProfileP384SHA384
 	} else if isMldsa87Param && isSHA384 && isMldsaCert && isMldsa87Sig {
-		targetProfile = ProfileMldsa87ExternalMu
+		targetProfile = ProfileMldsa87
 	} else {
 		return fmt.Errorf("client requested (Curve = %v, Digest = %v, Certificate = %v, Signature = %v), this is an invalid DPE profile",
 			reflect.TypeOf(c), reflect.TypeOf(d), reflect.TypeOf(cert), reflect.TypeOf(s))
@@ -476,7 +476,7 @@ func (c *DPEABI[_, _, _, _]) DestroyContextABI(cmd *DestroyCtxCmd) error {
 func (c *DPEABI[CurveParameter, Digest, Cert, _]) CertifyKeyABI(cmd *CertifyKeyReq[Digest]) (*CertifyKeyResp[CurveParameter, Digest], error) {
 	// Define an anonymous struct for the response, because we have to accept the variable-sized certificate.
 	// ML-DSA has a different ABI.
-	if c.Profile == ProfileMldsa87ExternalMu {
+	if c.Profile == ProfileMldsa87 {
 		respStruct := struct {
 			NewContextHandle [16]byte
 			DerivedPublicKey CurveParameter // Bad type name but just the size of an ML-DSA 87 pub key.
@@ -775,7 +775,7 @@ func (c *DPEABI[_, Digest, _, Signature]) Sign(handle *ContextHandle, label []by
 
 	// Handle Signature extraction based on type
 	var signedResp *DPESignedHash
-	if c.Profile == ProfileMldsa87ExternalMu {
+	if c.Profile == ProfileMldsa87 {
 		// For ML-DSA, Signature is Mldsa87Signature
 		sig, ok := any(resp.Signature).(Mldsa87Signature)
 		if !ok {

--- a/verification/client/client.go
+++ b/verification/client/client.go
@@ -70,7 +70,7 @@ func NewClient(t Transport, p Profile) (DPEClient, error) {
 		return NewDPEABI256(t)
 	case ProfileP384SHA384:
 		return NewDPEABI384(t)
-	case ProfileMldsa87ExternalMu:
+	case ProfileMldsa87:
 		return NewDPEABIMldsa87(t)
 	default:
 		return nil, fmt.Errorf("cannot create a DPE client for profile %d", p)

--- a/verification/client/profile.go
+++ b/verification/client/profile.go
@@ -19,8 +19,8 @@ const (
 	ProfileP256SHA256 Profile = 3
 	// ProfileP384SHA384 is NIST P-384, SHA-384 "minimal" profile
 	ProfileP384SHA384 Profile = 4
-	// ProfileMldsa87ExternalMu is ML-DSA-87, SHA-384 profile
-	ProfileMldsa87ExternalMu Profile = 5
+	// ProfileMldsa87 is ML-DSA-87, SHA-384 profile
+	ProfileMldsa87 Profile = 5
 )
 
 // GetDigestSize gets the digest size of the profile's supported hash algorithm
@@ -34,7 +34,7 @@ func (p Profile) GetDigestSize() int {
 		fallthrough
 	case ProfileP384SHA384:
 		fallthrough
-	case ProfileMldsa87ExternalMu:
+	case ProfileMldsa87:
 		return 48
 	}
 	return 0
@@ -51,7 +51,7 @@ func (p Profile) GetECCIntSize() int {
 		fallthrough
 	case ProfileP384SHA384:
 		return 48
-	case ProfileMldsa87ExternalMu:
+	case ProfileMldsa87:
 		return 2592
 	}
 	return 0
@@ -67,8 +67,8 @@ func (p Profile) String() string {
 		return "DPE_PROFILE_IROT_MIN_P384_SHA384"
 	case ProfileP384SHA384:
 		return "DPE_PROFILE_IROT_P384_SHA384"
-	case ProfileMldsa87ExternalMu:
-		return "DPE_PROFILE_IROT_MLDSA_87_EXTERNAL_MU"
+	case ProfileMldsa87:
+		return "DPE_PROFILE_IROT_MLDSA_87"
 	}
 	return fmt.Sprintf("unrecognized DPE profile: 0x%0x", uint32(p))
 }

--- a/verification/testing/certifyKey.go
+++ b/verification/testing/certifyKey.go
@@ -199,7 +199,7 @@ func TestCertifyKeyCsr(d client.TestDPEInstance, c client.DPEClient, t *testing.
 	}
 	_, err = wrappedCSR.Verify(x509.VerifyOptions{Roots: certPool})
 	if err != nil {
-		if profile == client.ProfileMldsa87ExternalMu {
+		if profile == client.ProfileMldsa87 {
 			// TODO(clundin): Verify the CMS wrapper for ML-DSA.
 			t.Logf("[WARN]: Skipping CMS wrapper signature verification for ML-DSA (not supported): %v", err)
 		} else {
@@ -224,7 +224,7 @@ func TestCertifyKeyCsr(d client.TestDPEInstance, c client.DPEClient, t *testing.
 	// Check that CSR is self-signed
 	err = csr.CheckSignature()
 	if err != nil {
-		if profile == client.ProfileMldsa87ExternalMu {
+		if profile == client.ProfileMldsa87 {
 			var pk mldsa87.PublicKey
 			// certifyKeyResp.Pub.X contains the raw public key bytes for ML-DSA
 			if err := pk.UnmarshalBinary(certifyKeyResp.Pub.X); err != nil {
@@ -649,7 +649,7 @@ func validateLeafCertChain(t *testing.T, certChain []*x509.Certificate, leafCert
 	removeTcgDiceCriticalExtensions(t, certsToProcess)
 	removeTcgDiceExtendedKeyUsages(t, certsToProcess)
 
-	if profile == client.ProfileMldsa87ExternalMu {
+	if profile == client.ProfileMldsa87 {
 		// Manual verification for ML-DSA
 		if len(certChain) == 0 {
 			t.Errorf("[ERROR]: Certificate chain is empty")
@@ -762,7 +762,7 @@ func getKeyUsageNames(keyUsage x509.KeyUsage) []string {
 }
 
 func checkPubKey(t *testing.T, p client.Profile, pubkey any, response client.CertifiedKey) {
-	if p == client.ProfileMldsa87ExternalMu {
+	if p == client.ProfileMldsa87 {
 		// TODO(clundin): Check ML-DSA Pub key.
 		return
 	}

--- a/verification/testing/sign.go
+++ b/verification/testing/sign.go
@@ -52,7 +52,7 @@ func TestAsymmetricSigning(d client.TestDPEInstance, c client.DPEClient, t *test
 		t.Fatalf("[FATAL]: Could not CertifyKey: %v", err)
 	}
 
-	if profile == client.ProfileMldsa87ExternalMu {
+	if profile == client.ProfileMldsa87 {
 		if len(signResp.Signature) != mldsa87.SignatureSize {
 			t.Errorf("Incorrect signature length for ML-DSA-87: got %d, want %d", len(signResp.Signature), mldsa87.SignatureSize)
 		}

--- a/verification/testing/tpm.go
+++ b/verification/testing/tpm.go
@@ -75,7 +75,7 @@ func TestTpmPolicySigning(d dpe.TestDPEInstance, c dpe.DPEClient, t *testing.T) 
 	if err != nil {
 		t.Fatalf("Could not get profile: %v", err)
 	}
-	if profile == dpe.ProfileMldsa87ExternalMu {
+	if profile == dpe.ProfileMldsa87 {
 		// TODO(clundin): Add Test support for ML-DSA.
 		t.Skip("TPM Policy Signing test not supported for ML-DSA")
 	}


### PR DESCRIPTION
Only one ML-DSA profile is planned. This renames some values to be more generic and less prescriptive.