### PR TITLE
Add a Children type instead of a flat u32

### DIFF
--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -609,7 +609,10 @@ mod tests {
         assert_eq!(parent_idx, child.parent_idx as usize);
         assert_eq!(
             child_idx,
-            env.state.contexts[parent_idx].children.trailing_zeros() as usize
+            env.state.contexts[parent_idx]
+                .children
+                .bits()
+                .trailing_zeros() as usize
         );
         assert_eq!(7, child.tci.tci_type);
         assert_eq!(TEST_LOCALITIES[1], child.locality);

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -736,7 +736,7 @@ pub mod tests {
             auto_init_measurement
         );
         assert_eq!(env.state.contexts[idx].parent_idx, Context::ROOT_INDEX);
-        assert_eq!(env.state.contexts[idx].children, 0);
+        assert!(env.state.contexts[idx].children.is_empty());
         assert_eq!(env.state.contexts[idx].state, ContextState::Active);
         assert_eq!(env.state.contexts[idx].handle, ContextHandle::default());
         assert!(env.state.has_initialized());


### PR DESCRIPTION
This is a cleaner more readable interface and will make it easy to upgrade to 64 contexts later.