### PR TITLE
Align settings with caliptra-sw defaults

### DIFF
--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["p256", "no-cfi"]
+default = ["p384"]
 p256 = []
 p384 = []
 ml-dsa = ["crypto/ml-dsa"]

--- a/dpe/fuzz/Cargo.toml
+++ b/dpe/fuzz/Cargo.toml
@@ -20,6 +20,8 @@ time = "=0.3.36"
 
 [dependencies.dpe]
 path = ".."
+default-features = false
+features = ["p256", "no-cfi"]
 
 [dependencies.crypto]
 path = "../../crypto"

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -42,7 +42,7 @@ pub use crypto::{ecdsa::EcdsaAlgorithm, ExportedCdiHandle, MAX_EXPORTED_CDI_SIZE
 // Max cert size returned by CertifyKey
 const MAX_CERT_SIZE: usize = 17 * 1024;
 #[cfg(not(feature = "arbitrary_max_handles"))]
-pub const MAX_HANDLES: usize = 24;
+pub const MAX_HANDLES: usize = 32;
 #[cfg(feature = "arbitrary_max_handles")]
 include!(concat!(env!("OUT_DIR"), "/arbitrary_max_handles.rs"));
 

--- a/dpe/src/validation.rs
+++ b/dpe/src/validation.rs
@@ -453,7 +453,7 @@ pub mod tests {
         dpe_validator.dpe.contexts[0].children = Children::from(1 << 30);
         assert_eq!(
             dpe_validator.validate_dpe_state(),
-            Err(ValidationError::ChildDoesNotExist)
+            Err(ValidationError::InactiveChild)
         );
 
         dpe_validator.dpe.contexts[0].children = Children::from(1 << 10);

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["p256", "rustcrypto"]
+default = ["p384", "rustcrypto"]
 p256 = ["dpe/p256"]
 p384 = ["dpe/p384"]
 # TODO(clundin): Placeholder name until we decide pattern for DPE profiles and feature flags.

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["p256"]
+default = ["p384"]
 # Run ARBITRARY_MAX_HANDLES=n cargo build --features arbitrary_max_handles to use this feature
 arbitrary_max_handles = ["dpe/arbitrary_max_handles"]
 p256 = ["dpe/p256"]

--- a/verification/sim/transport.go
+++ b/verification/sim/transport.go
@@ -23,7 +23,7 @@ const (
 
 	DPESimulatorAutoInitLocality    uint32 = 0
 	DPESimulatorOtherLocality       uint32 = 0x4f544852
-	DPESimulatorMaxTCINodes         uint32 = 24
+	DPESimulatorMaxTCINodes         uint32 = 32
 	DPESimulatorMajorProfileVersion uint16 = client.CurrentProfileMajorVersion
 	DPESimulatorMinorProfileVersion uint16 = client.CurrentProfileMinorVersion
 	DPESimulatorVendorID            uint32 = 0


### PR DESCRIPTION
Considering this repo is intended as first party Caliptra software that can also support other platforms, this sets the default settings to be what Caliptra expects.