### PR TITLE
Add stack optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,11 @@ version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
 
 [[package]]
+name = "caliptra-okref"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fc971ba5f7435be68964ae49b3a759287c0e34e7#fc971ba5f7435be68964ae49b3a759287c0e34e7"
+
+[[package]]
 name = "cc"
 version = "1.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +514,7 @@ dependencies = [
  "bitflags",
  "caliptra-cfi-derive-git",
  "caliptra-cfi-lib-git",
+ "caliptra-okref",
  "cfg-if",
  "cms",
  "constant_time_eq",

--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -30,6 +30,7 @@ log = ["dep:log"]
 bitflags = "2.4.0"
 caliptra-cfi-lib-git = { workspace = true, default-features = false, features = ["cfi", "cfi-counter" ] }
 caliptra-cfi-derive-git.workspace = true
+caliptra-okref = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fc971ba5f7435be68964ae49b3a759287c0e34e7" }
 constant_time_eq.workspace = true
 crypto = {path = "../crypto", default-features = false}
 platform = {path = "../platform", default-features = false}

--- a/dpe/fuzz/Cargo.lock
+++ b/dpe/fuzz/Cargo.lock
@@ -88,6 +88,11 @@ version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
 
 [[package]]
+name = "caliptra-okref"
+version = "0.1.0"
+source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fc971ba5f7435be68964ae49b3a759287c0e34e7#fc971ba5f7435be68964ae49b3a759287c0e34e7"
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,6 +261,7 @@ dependencies = [
  "bitflags",
  "caliptra-cfi-derive-git",
  "caliptra-cfi-lib-git",
+ "caliptra-okref",
  "cfg-if",
  "constant_time_eq",
  "crypto",

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -186,6 +186,7 @@ impl DeriveContextCmd {
 
 impl CommandExecution for DeriveContextCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
     fn execute(
         &self,
         dpe: &mut DpeInstance,

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -85,6 +85,7 @@ pub(crate) fn destroy_context(
 
 impl CommandExecution for DestroyCtxCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
     fn execute(
         &self,
         dpe: &mut DpeInstance,

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -25,6 +25,7 @@ pub struct GetCertificateChainCmd {
 
 impl CommandExecution for GetCertificateChainCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
     fn execute(
         &self,
         dpe: &mut DpeInstance,

--- a/dpe/src/commands/get_profile.rs
+++ b/dpe/src/commands/get_profile.rs
@@ -23,6 +23,7 @@ pub struct GetProfileCmd;
 
 impl CommandExecution for GetProfileCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
     fn execute(
         &self,
         dpe: &mut DpeInstance,

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -51,6 +51,7 @@ impl InitCtxCmd {
 
 impl CommandExecution for InitCtxCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
     fn execute(
         &self,
         dpe: &mut DpeInstance,

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -79,6 +79,7 @@ impl RotateCtxCmd {
 
 impl CommandExecution for RotateCtxCmd {
     #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[inline(never)]
     fn execute(
         &self,
         dpe: &mut DpeInstance,


### PR DESCRIPTION
This reduces stack usage in CertifyKey by approximately 60K bytes by two strategies:

1. avoiding large stack allocations utilizing `okref` to work with stack references.
2. mark a few command handlers as `#[inline(never)]` to reduce the stack usage of inlined functions

This also reduces code size by a few hundred bytes