### PR TITLE
Vendor `okref` functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,11 +222,6 @@ version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
 
 [[package]]
-name = "caliptra-okref"
-version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fc971ba5f7435be68964ae49b3a759287c0e34e7#fc971ba5f7435be68964ae49b3a759287c0e34e7"
-
-[[package]]
 name = "cc"
 version = "1.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,7 +509,6 @@ dependencies = [
  "bitflags",
  "caliptra-cfi-derive-git",
  "caliptra-cfi-lib-git",
- "caliptra-okref",
  "cfg-if",
  "cms",
  "constant_time_eq",

--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -30,7 +30,6 @@ log = ["dep:log"]
 bitflags = "2.4.0"
 caliptra-cfi-lib-git = { workspace = true, default-features = false, features = ["cfi", "cfi-counter" ] }
 caliptra-cfi-derive-git.workspace = true
-caliptra-okref = { git = "https://github.com/chipsalliance/caliptra-sw", rev = "fc971ba5f7435be68964ae49b3a759287c0e34e7" }
 constant_time_eq.workspace = true
 crypto = {path = "../crypto", default-features = false}
 platform = {path = "../platform", default-features = false}

--- a/dpe/fuzz/Cargo.lock
+++ b/dpe/fuzz/Cargo.lock
@@ -88,11 +88,6 @@ version = "0.1.0"
 source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
 
 [[package]]
-name = "caliptra-okref"
-version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-sw?rev=fc971ba5f7435be68964ae49b3a759287c0e34e7#fc971ba5f7435be68964ae49b3a759287c0e34e7"
-
-[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,7 +256,6 @@ dependencies = [
  "bitflags",
  "caliptra-cfi-derive-git",
  "caliptra-cfi-lib-git",
- "caliptra-okref",
  "cfg-if",
  "constant_time_eq",
  "crypto",

--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -3,6 +3,7 @@ use super::CommandExecution;
 use crate::{
     context::ContextHandle,
     dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
+    okref,
     response::{CertifyKeyResp, DpeErrorCode, Response},
     x509::{create_dpe_cert, CreateDpeCertArgs, CreateDpeCertResult},
     DpeFlags, DpeProfile, MAX_CERT_SIZE,
@@ -12,7 +13,6 @@ use bitflags::bitflags;
 use caliptra_cfi_derive_git::cfi_impl_fn;
 #[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
-use caliptra_okref::okref;
 use cfg_if::cfg_if;
 #[cfg(any(feature = "p256", feature = "p384"))]
 use crypto::ecdsa::EcdsaPubKey;

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -3,6 +3,7 @@ use super::CommandExecution;
 use crate::{
     context::{ContextHandle, ContextType},
     dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
+    okref,
     response::{DpeErrorCode, Response, SignResp},
     DpeProfile,
 };
@@ -12,7 +13,6 @@ use caliptra_cfi_derive_git::cfi_impl_fn;
 use caliptra_cfi_lib_git::cfi_launder;
 #[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_assert_ne};
-use caliptra_okref::okref;
 use cfg_if::cfg_if;
 #[cfg(any(feature = "p256", feature = "p384"))]
 use crypto::{ecdsa::EcdsaSignature, Digest};

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -152,6 +152,23 @@ macro_rules! bitflags_join {
     ($x: expr, $($z: expr),+) => ($x.union(bitflags_join!($($z),*)));
 }
 
+// Copied from https://github.com/chipsalliance/caliptra-sw/tree/main/common/okref
+// unfortunately we cannot depend on caliptra-okref directly due to dependency
+// cycles. So we copy the relevant code here.
+pub fn okref<T, E: Copy>(r: &Result<T, E>) -> Result<&T, E> {
+    match r {
+        Ok(r) => Ok(r),
+        Err(e) => Err(*e),
+    }
+}
+
+pub fn okmutref<T, E: Copy>(r: &mut Result<T, E>) -> Result<&mut T, E> {
+    match r {
+        Ok(r) => Ok(r),
+        Err(e) => Err(*e),
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     /// Convenience function to initialize logging for unit tests

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -8,6 +8,7 @@
 use crate::{
     context::ContextHandle,
     dpe_instance::{DpeEnv, DpeTypes},
+    okref,
     response::DpeErrorCode,
     tci::{TciMeasurement, TciNodeData},
     DpeInstance, DpeProfile, State, MAX_HANDLES,
@@ -16,7 +17,6 @@ use bitflags::bitflags;
 use caliptra_cfi_lib_git::cfi_launder;
 #[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
-use caliptra_okref::okref;
 use crypto::{
     ecdsa::{EcdsaPubKey, EcdsaSignature},
     Crypto, CryptoError, CryptoSuite, Digest, Hasher, PubKey, SignData, Signature,


### PR DESCRIPTION
Unfortunately, we cannot depend on caliptra-okref directly due to dependency cycles. So I copied the relevant code here.

Fortunately, it is very small and simple.