### PR TITLE
Increase the max number of contexts to 64

### DIFF
--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -363,15 +363,15 @@ impl DpeInstance {
 ///
 /// * `flags` - bits to be iterated over
 /// * `max` - number of bits to be considered
-pub(crate) fn flags_iter(flags: u32, max: usize) -> FlagsIter {
-    assert!((1..=u32::BITS).contains(&(max as u32)));
+pub(crate) fn flags_iter(flags: u64, max: usize) -> FlagsIter {
+    assert!((1..=u64::BITS).contains(&(max as u32)));
     FlagsIter {
-        flags: flags & (u32::MAX >> (u32::BITS - max as u32)),
+        flags: flags & (u64::MAX >> (u64::BITS - max as u32)),
     }
 }
 
 pub(crate) struct FlagsIter {
-    flags: u32,
+    flags: u64,
 }
 
 impl Iterator for FlagsIter {

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -41,11 +41,11 @@ pub use crypto::{ecdsa::EcdsaAlgorithm, ExportedCdiHandle, MAX_EXPORTED_CDI_SIZE
 
 // Max cert size returned by CertifyKey
 #[cfg(feature = "ml-dsa")]
-const MAX_CERT_SIZE: usize = 17 * 1024;
+const MAX_CERT_SIZE: usize = 22 * 1024;
 #[cfg(not(feature = "ml-dsa"))]
-const MAX_CERT_SIZE: usize = 7872;
+const MAX_CERT_SIZE: usize = 11 * 1024;
 #[cfg(not(feature = "arbitrary_max_handles"))]
-pub const MAX_HANDLES: usize = 32;
+pub const MAX_HANDLES: usize = 64;
 #[cfg(feature = "arbitrary_max_handles")]
 include!(concat!(env!("OUT_DIR"), "/arbitrary_max_handles.rs"));
 

--- a/dpe/src/validation.rs
+++ b/dpe/src/validation.rs
@@ -173,7 +173,7 @@ impl DpeValidator<'_> {
             }
         }
         // Check if any children do not exist
-        for child in flags_iter(context.children.into(), 32) {
+        for child in flags_iter(context.children.into(), 64) {
             if child >= MAX_HANDLES {
                 return Err(ValidationError::ChildDoesNotExist);
             }
@@ -420,7 +420,7 @@ pub mod tests {
         );
 
         dpe_validator.dpe.contexts[0].parent_idx = Context::ROOT_INDEX;
-        dpe_validator.dpe.contexts[0].children = u32::MAX.into();
+        dpe_validator.dpe.contexts[0].children = u64::MAX.into();
         assert_eq!(
             dpe_validator.validate_dpe_state(),
             Err(ValidationError::InactiveContextWithChildren)

--- a/verification/client/profile.go
+++ b/verification/client/profile.go
@@ -128,10 +128,10 @@ type DigestAlgorithm interface {
 type DPEMinCertificate [2048]byte
 
 // DPEFullCertificate represents a certificate for the DPE full iRoT profiles
-type DPEFullCertificate [6144]byte
+type DPEFullCertificate [11 * 1024]byte
 
 // DPEMldsaCertificate represents a certificate for the DPE ML-DSA profile
-type DPEMldsaCertificate [17408]byte
+type DPEMldsaCertificate [22 * 1024]byte
 
 // DPECertificate is a type constraint for DPE certificates.
 type DPECertificate interface {

--- a/verification/sim/transport.go
+++ b/verification/sim/transport.go
@@ -23,7 +23,7 @@ const (
 
 	DPESimulatorAutoInitLocality    uint32 = 0
 	DPESimulatorOtherLocality       uint32 = 0x4f544852
-	DPESimulatorMaxTCINodes         uint32 = 32
+	DPESimulatorMaxTCINodes         uint32 = 64
 	DPESimulatorMajorProfileVersion uint16 = client.CurrentProfileMajorVersion
 	DPESimulatorMinorProfileVersion uint16 = client.CurrentProfileMinorVersion
 	DPESimulatorVendorID            uint32 = 0


### PR DESCRIPTION
There have been several requests to increase the number of DPE contexts for Caliptra. This change increases the maximum number from 32 to 64.

This increases the worst case EC-P384 CSR size to `10501` bytes and ML-DSA CSR to `22050` bytes.

This increases dpe::State from `4492` bytes to `9228` bytes.