### PR TITLE
Start work for multi-part responses

### DIFF
--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -462,7 +462,6 @@ mod tests {
         x509::X509,
     };
     use platform::{Platform, MAX_KEY_IDENTIFIER_SIZE};
-    use public_key::PublicKey;
     use x509_parser::{nom::Parser, oid_registry::asn1_rs::oid, prelude::*};
     use zerocopy::IntoBytes;
 

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -16,6 +16,7 @@ mod log_stub;
 extern crate log;
 
 pub use dpe_instance::DpeInstance;
+pub use operation_handle::OperationHandle;
 pub use state::{DpeFlags, State};
 
 use zeroize::Zeroize;
@@ -23,6 +24,7 @@ use zeroize::Zeroize;
 pub mod commands;
 pub mod context;
 pub mod dpe_instance;
+mod operation_handle;
 pub mod response;
 mod state;
 pub mod support;
@@ -140,6 +142,12 @@ pub const TCI_SIZE: usize = 32;
 
 #[cfg(any(feature = "p384", feature = "ml-dsa"))]
 pub const TCI_SIZE: usize = 48;
+
+#[cfg(feature = "p256")]
+pub const HASH_SIZE: usize = 32;
+
+#[cfg(any(feature = "p384", feature = "ml-dsa"))]
+pub const HASH_SIZE: usize = 48;
 
 // Recursive macro that does a union of all the flags passed to it. This is
 // const and looks about as nice as using the | operator.

--- a/dpe/src/operation_handle.rs
+++ b/dpe/src/operation_handle.rs
@@ -1,0 +1,90 @@
+// Licensed under the Apache-2.0 license.
+
+use constant_time_eq::constant_time_eq_16;
+use crypto::Crypto;
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+use zeroize::Zeroize;
+
+use crate::{
+    dpe_instance::{DpeEnv, DpeTypes},
+    response::DpeErrorCode,
+};
+
+#[repr(C)]
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    IntoBytes,
+    FromBytes,
+    Immutable,
+    KnownLayout,
+    Zeroize,
+    PartialEq,
+    Eq,
+)]
+pub struct OperationHandle(pub [u8; OperationHandle::SIZE]);
+
+impl OperationHandle {
+    pub const SIZE: usize = 16;
+    pub const MAX_NEW_HANDLE_ATTEMPTS: usize = 8;
+    const DEFAULT: OperationHandle = OperationHandle([0; Self::SIZE]);
+
+    /// Returns the default operation handle.
+    pub const fn default() -> OperationHandle {
+        Self::DEFAULT
+    }
+
+    pub fn generate(env: &mut DpeEnv<impl DpeTypes>) -> Result<OperationHandle, DpeErrorCode> {
+        for _ in 0..Self::MAX_NEW_HANDLE_ATTEMPTS {
+            let mut handle = OperationHandle::default();
+            env.crypto.rand_bytes(&mut handle.0)?;
+            if !handle.is_default() {
+                return Ok(handle);
+            }
+        }
+        Err(DpeErrorCode::InternalError)
+    }
+
+    #[inline(never)]
+    pub fn equals(&self, other: &OperationHandle) -> bool {
+        constant_time_eq_16(&self.0, &other.0)
+    }
+
+    /// Whether the handle is the default operation handle.
+    pub fn is_default(&self) -> bool {
+        self.equals(&Self::DEFAULT)
+    }
+
+    /// Whether the handle is all zeros.
+    pub fn blank(&self) -> bool {
+        self.is_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{dpe_instance::tests::test_env, State};
+
+    #[test]
+    fn test_operation_blank_and_default() {
+        let handle = OperationHandle([1; OperationHandle::SIZE]);
+        assert!(!handle.is_default());
+        assert!(!handle.blank());
+
+        let handle = OperationHandle::default();
+        assert!(handle.is_default());
+        assert!(handle.blank());
+    }
+
+    #[test]
+    fn test_operation_handle_generation() {
+        let mut state = State::default();
+        let mut env = test_env(&mut state);
+        let handle = OperationHandle::generate(&mut env).unwrap();
+        assert!(!handle.is_default());
+        assert!(!handle.blank());
+    }
+}


### PR DESCRIPTION
This starts implementation of the change in the DPE iRoT profile to enable breaking large responses into chunks so they can more easily be sent over small mailbox interfaces.

This is especially relevant for Caliptra 2.1 ML-DSA certificates. The mailbox is only 16KB and CSRs can be as large as 22KB for 64 contexts.

Integration with commands will come in subsequent PRs.