### PR TITLE
Replace `GetCertificateChain` parameters with multi-part response

### DIFF
--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -1,26 +1,39 @@
 // Licensed under the Apache-2.0 license.
 use super::CommandExecution;
 use crate::{
+    commands::Command,
     dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
-    response::{DpeErrorCode, GetCertificateChainResp, Response},
+    okref,
+    response::{DpeErrorCode, GetCertificateChainResp, GetCertificateChainRespFlags, Response},
+    state::MultipartOperationState,
+    OperationHandle, State,
 };
 #[cfg(not(feature = "no-cfi"))]
 use caliptra_cfi_derive_git::cfi_impl_fn;
+use crypto::{Crypto, Digest, Hasher};
 use platform::{Platform, MAX_CHUNK_SIZE};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 #[repr(C)]
-#[derive(
-    Debug,
-    PartialEq,
-    Eq,
-    zerocopy::FromBytes,
-    zerocopy::IntoBytes,
-    zerocopy::Immutable,
-    zerocopy::KnownLayout,
-)]
+#[derive(Debug, PartialEq, Eq, FromBytes, IntoBytes, Immutable, KnownLayout)]
 pub struct GetCertificateChainCmd {
-    pub offset: u32,
-    pub size: u32,
+    pub op_handle: OperationHandle,
+}
+
+impl GetCertificateChainCmd {
+    fn command_hash(
+        &self,
+        dpe: &mut DpeInstance,
+        env: &mut DpeEnv<impl DpeTypes>,
+        locality: u32,
+    ) -> Result<Digest, DpeErrorCode> {
+        let mut hasher = env.crypto.hash_initialize()?;
+        hasher.update(Command::GET_CERTIFICATE_CHAIN.as_bytes())?;
+        hasher.update(dpe.profile.as_bytes())?;
+        hasher.update(locality.as_bytes())?;
+        let hash = hasher.finish()?;
+        Ok(hash)
+    }
 }
 
 impl CommandExecution for GetCertificateChainCmd {
@@ -30,20 +43,53 @@ impl CommandExecution for GetCertificateChainCmd {
         &self,
         dpe: &mut DpeInstance,
         env: &mut DpeEnv<impl DpeTypes>,
-        _locality: u32,
+        locality: u32,
     ) -> Result<Response, DpeErrorCode> {
-        // Make sure the operation is supported.
-        if self.size > MAX_CHUNK_SIZE as u32 {
-            return Err(DpeErrorCode::InvalidArgument);
+        let cmd_hash = self.command_hash(dpe, env, locality);
+        let cmd_hash = okref(&cmd_hash)?;
+        let op_handle = &self.op_handle;
+        let multipart_state_idx = env.platform.multipart_state_index_from_locality(locality)?;
+        if multipart_state_idx >= State::MAX_MULTIPART_OPERATIONS {
+            return Err(DpeErrorCode::InternalError);
         }
 
-        let mut cert_chunk = [0u8; MAX_CHUNK_SIZE];
-        let len = env
-            .platform
-            .get_certificate_chain(self.offset, self.size, &mut cert_chunk)?;
+        // Clear the state if the operation handle is blank.
+        if op_handle.blank() {
+            env.state.multipart_state[multipart_state_idx].clear();
+        } else {
+            // If continuing a multi-part operation, make sure it is the same command and has the
+            // correct operation handle.
+            if !env.state.multipart_state[multipart_state_idx]
+                .is_continued_operation(op_handle, cmd_hash)
+            {
+                return Err(DpeErrorCode::InvalidOperationHandle);
+            }
+        }
+
+        let offset = env.state.multipart_state[multipart_state_idx].offset;
+        let mut chunk = [0u8; MAX_CHUNK_SIZE];
+        let (len, last_chunk) = env.platform.get_certificate_chain(offset, &mut chunk)?;
+
+        // If this is the last call, clear the state; otherwise generate a new operation handle and
+        // update the running state.
+        let op_handle = if last_chunk {
+            env.state.multipart_state[multipart_state_idx].clear();
+            OperationHandle::default()
+        } else {
+            let op_handle = OperationHandle::generate(env)?;
+            env.state.multipart_state[multipart_state_idx] = MultipartOperationState {
+                offset: offset + len,
+                handle: op_handle,
+                digest: cmd_hash.as_slice().try_into().unwrap(),
+            };
+            op_handle
+        };
+
         Ok(Response::GetCertificateChain(GetCertificateChainResp {
-            certificate_chain: cert_chunk,
-            certificate_size: len,
+            chunk,
+            chunk_size: len,
+            flags: GetCertificateChainRespFlags::empty(),
+            op_handle,
             resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
         }))
     }
@@ -54,14 +100,15 @@ mod tests {
     use super::*;
     use crate::{
         commands::{tests::PROFILES, Command, CommandHdr},
-        dpe_instance::tests::{test_env, test_state, DPE_PROFILE, TEST_LOCALITIES},
+        dpe_instance::tests::{test_env, DPE_PROFILE, TEST_LOCALITIES},
+        support::Support,
+        DpeFlags,
     };
     use caliptra_cfi_lib_git::CfiCounter;
     use zerocopy::IntoBytes;
 
     const TEST_GET_CERTIFICATE_CHAIN_CMD: GetCertificateChainCmd = GetCertificateChainCmd {
-        offset: 0,
-        size: MAX_CHUNK_SIZE as u32,
+        op_handle: OperationHandle::default(),
     };
 
     #[test]
@@ -82,19 +129,103 @@ mod tests {
     }
 
     #[test]
-    fn test_fails_if_size_greater_than_max_chunk_size() {
+    fn test_get_certificate_chain() {
         CfiCounter::reset_for_test();
-        let mut state = test_state();
+        let mut state = State::new(Support::AUTO_INIT, DpeFlags::empty());
         let mut env = test_env(&mut state);
         let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
-        assert_eq!(
-            Err(DpeErrorCode::InvalidArgument),
-            GetCertificateChainCmd {
-                size: MAX_CHUNK_SIZE as u32 + 1,
-                ..TEST_GET_CERTIFICATE_CHAIN_CMD
-            }
-            .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
-        );
+        let chain = dpe.get_certificate_chain(&mut env, 0).unwrap();
+        assert!(!chain.is_empty());
+    }
+
+    #[test]
+    fn test_restart_get_certificate_chain() {
+        CfiCounter::reset_for_test();
+        let mut state = State::new(Support::AUTO_INIT, DpeFlags::empty());
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
+        let op_handle = OperationHandle::default();
+        let locality = 0;
+
+        let Response::GetCertificateChain(resp) = GetCertificateChainCmd { op_handle }
+            .execute(&mut dpe, &mut env, locality)
+            .unwrap()
+        else {
+            panic!("Unexpected response type");
+        };
+        let first_call_chain = resp.chunk[..resp.chunk_size as usize].to_vec();
+
+        // Can't restart an operation if the certificate chain can be handled in a single command.
+        if resp.op_handle.blank() {
+            return;
+        }
+
+        let chain = dpe.get_certificate_chain(&mut env, locality).unwrap();
+
+        // The first response should be a subset of the total chain.
+        assert!(first_call_chain.len() < chain.len());
+        assert_eq!(first_call_chain, chain[..first_call_chain.len()].to_vec());
+    }
+
+    #[test]
+    fn test_get_certificate_chain_wrong_handle() {
+        CfiCounter::reset_for_test();
+        let mut state = State::new(Support::AUTO_INIT, DpeFlags::empty());
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
+        let op_handle = OperationHandle([1; 16]);
+        let locality = 0;
+
+        let result = GetCertificateChainCmd { op_handle }.execute(&mut dpe, &mut env, locality);
+        assert_eq!(result, Err(DpeErrorCode::InvalidOperationHandle));
+    }
+
+    #[test]
+    fn test_get_certificate_chain_interleaved() {
+        CfiCounter::reset_for_test();
+        let mut state = State::new(Support::AUTO_INIT, DpeFlags::empty());
+        let mut env = test_env(&mut state);
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
+        let op_handle = OperationHandle::default();
+        let first_locality = TEST_LOCALITIES[0];
+        let second_locality = TEST_LOCALITIES[1];
+
+        let mut first_chain = vec![];
+        let Response::GetCertificateChain(resp) = GetCertificateChainCmd { op_handle }
+            .execute(&mut dpe, &mut env, first_locality)
+            .unwrap()
+        else {
+            panic!("Unexpected response type");
+        };
+        first_chain.extend_from_slice(&resp.chunk[..resp.chunk_size as usize]);
+        let original_length = first_chain.len();
+
+        // Can't test interleaved if the cert chain can be retrieved in a single command.
+        if resp.op_handle.blank() {
+            return;
+        }
+
+        let second_chain = dpe
+            .get_certificate_chain(&mut env, second_locality)
+            .unwrap();
+        assert!(!second_chain.is_empty());
+
+        let mut op_handle = resp.op_handle;
+        let mut finished = false;
+        while !finished {
+            let Response::GetCertificateChain(resp) = GetCertificateChainCmd { op_handle }
+                .execute(&mut dpe, &mut env, first_locality)
+                .unwrap()
+            else {
+                panic!("Unexpected response type");
+            };
+
+            first_chain.extend_from_slice(&resp.chunk[..resp.chunk_size as usize]);
+            op_handle = resp.op_handle;
+            finished = resp.op_handle.blank();
+        }
+        assert!(first_chain.len() > original_length);
+        assert_eq!(first_chain, second_chain);
     }
 }

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -119,14 +119,17 @@ pub trait Platform {
     /// # Arguments
     ///
     /// * `offset` - Index where to start reading bytes from in the cert chain.
-    /// * `size` - The requested size of the chunk. Actual written number of bytes could be smaller, depending on size of chain.
     /// * `out` - Output buffer for cert chain chunk to be written to
+    ///
+    /// # Output
+    ///
+    /// The number of bytes written to the output buffer and whether it was the
+    /// last chunk.
     fn get_certificate_chain(
         &mut self,
         offset: u32,
-        size: u32,
         out: &mut [u8; MAX_CHUNK_SIZE],
-    ) -> Result<u32, PlatformError>;
+    ) -> Result<(u32, bool), PlatformError>;
 
     /// Retrieves the parent certificate's DER encoded issuer name.
     ///
@@ -179,4 +182,7 @@ pub trait Platform {
     ///
     /// This is encoded into certificates created by DPE.
     fn get_ueid(&mut self) -> Result<Ueid, PlatformError>;
+
+    /// Retrieves the correct multi-part operation state index for the given locality.
+    fn multipart_state_index_from_locality(&self, locality: u32) -> Result<usize, PlatformError>;
 }

--- a/verification/client/abi.go
+++ b/verification/client/abi.go
@@ -10,6 +10,9 @@ import (
 // DefaultContextHandle is the default DPE context handle
 var DefaultContextHandle = ContextHandle{0}
 
+// DefaultOperationHandle is the default DPE multi-part operation handle
+var DefaultOperationHandle = OperationHandle{0}
+
 // Profile-defined constants
 const (
 	CmdMagic  uint32 = 0x44504543
@@ -132,6 +135,9 @@ type ContextHandle [16]byte
 // ExportedCdi is a handle to an exported CDI
 type ExportedCdi [32]byte
 
+// OperationHandle is a DPE multi-part operation handle
+type OperationHandle [16]byte
+
 // DestroyCtxCmd is input parameters to DestroyContext
 type DestroyCtxCmd struct {
 	handle ContextHandle
@@ -183,8 +189,7 @@ type CertifyKeyResp[CurveParameter Curve, Digest DigestAlgorithm] struct {
 
 // GetCertificateChainReq is the input request to GetCertificateChain
 type GetCertificateChainReq struct {
-	Offset uint32
-	Size   uint32
+	OperationHandle OperationHandle
 }
 
 // GetCertificateChainResp is the output response from GetCertificateChain
@@ -534,31 +539,28 @@ func (c *DPEABI[_, _, _, _]) GetCertificateChainABI() (*GetCertificateChainResp,
 
 	// Initialize request input parameters
 	cmd := GetCertificateChainReq{
-		Offset: 0,
-		Size:   MaxChunkSize,
+		OperationHandle: DefaultOperationHandle,
 	}
 
 	for {
 		respStruct := struct {
+			Flags            uint32
+			OperationHandle  OperationHandle
 			CertificateSize  uint32
 			CertificateChain [2048]byte
 		}{}
 
 		_, err := execCommand(c.transport, c.constants.Codes.GetCertificateChain, c.Profile, cmd, &respStruct)
-		if err == StatusInvalidArgument {
-			// This indicates that there are no more bytes to be read in certificate chain
-			break
-		} else if err != nil {
+		if err != nil {
 			// This indicates error in processing GetCertificateChain command
 			return nil, err
 		}
 
 		certs.CertificateChain = append(certs.CertificateChain, respStruct.CertificateChain[:respStruct.CertificateSize]...)
-		if MaxChunkSize > respStruct.CertificateSize {
+		if respStruct.OperationHandle == DefaultOperationHandle {
 			break
 		}
-		// Increment offset in steps of 2048 bytes till end of cert chain
-		cmd.Offset += MaxChunkSize
+		cmd.OperationHandle = respStruct.OperationHandle
 	}
 
 	if len(certs.CertificateChain) == 0 {


### PR DESCRIPTION
This updates the first command to use the new format for multi-part responses.