### PR TITLE
Fix IntegrityRegisters certificate index (1.x)

### DIFF
--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -1253,13 +1253,13 @@ impl CertWriter<'_> {
         // Omit integrityRegisters from tcb_info if DPE_PROFILE does not support recursive
         if supports_recursive {
             // integrityRegisters SEQUENCE OF
-            // IMPLICIT [10] Constructed
+            // IMPLICIT [11] Constructed
             let fwid_size = Self::get_fwid_size(&node.tci_cumulative.0, /*tagged=*/ true)?;
             let fwid_list_size = Self::get_structure_size(fwid_size, /*tagged=*/ true)?;
             let integrity_register_size =
                 Self::get_structure_size(fwid_list_size, /*tagged=*/ true)?;
 
-            bytes_written += self.encode_byte(Self::CONTEXT_SPECIFIC | Self::CONSTRUCTED | 0xa)?;
+            bytes_written += self.encode_byte(Self::CONTEXT_SPECIFIC | Self::CONSTRUCTED | 11)?;
             bytes_written += self.encode_size_field(integrity_register_size)?;
 
             // integrityRegusters[0] SEQUENCE
@@ -2612,6 +2612,8 @@ pub(crate) mod tests {
         #[implicit(9)]
         pub tci_type: Option<&'a [u8]>,
         #[implicit(10)]
+        pub _operational_flags_mask: Option<asn1::BitString<'a>>,
+        #[implicit(11)]
         pub integrity_registers: Option<asn1::SequenceOf<'a, IntegrityRegister<'a>>>,
     }
 

--- a/verification/testing/certifyKey.go
+++ b/verification/testing/certifyKey.go
@@ -64,17 +64,18 @@ type Fwid struct {
 // tcg-dice-TcbInfo OBJECT IDENTIFIER ::= {tcg-dice 1}
 //
 //	DiceTcbInfo 	::== SEQUENCE {
-//			vendor		[0] IMPLICIT UTF8String OPTIONAL,
-//			model 		[1] IMPLICIT UTF8String OPTIONAL,
-//			version 	[2] IMPLICIT UTF8String OPTIONAL,
-//			svn 		[3] IMPLICIT INTEGER OPTIONAL,
-//			layer 		[4] IMPLICIT INTEGER OPTIONAL,
-//			index 		[5] IMPLICIT INTEGER OPTIONAL,
-//			fwids 		[6] IMPLICIT FWIDLIST OPTIONAL,
-//			flags 		[7] IMPLICIT OperationalFlags OPTIONAL,
-//			vendorInfo 	[8] IMPLICIT OCTET STRING OPTIONAL,
-//			type 		[9] IMPLICIT OCTET STRING OPTIONAL,
-//			integrityRegisters 	[10] IMPLICIT IrList OPTIONAL,
+//			vendor		          [ 0] IMPLICIT UTF8String OPTIONAL,
+//			model 		          [ 1] IMPLICIT UTF8String OPTIONAL,
+//			version 	          [ 2] IMPLICIT UTF8String OPTIONAL,
+//			svn 		          [ 3] IMPLICIT INTEGER OPTIONAL,
+//			layer 		          [ 4] IMPLICIT INTEGER OPTIONAL,
+//			index 		          [ 5] IMPLICIT INTEGER OPTIONAL,
+//			fwids 		          [ 6] IMPLICIT FWIDLIST OPTIONAL,
+//			flags 		          [ 7] IMPLICIT OperationalFlags OPTIONAL,
+//			vendorInfo 	          [ 8] IMPLICIT OCTET STRING OPTIONAL,
+//			type 		          [ 9] IMPLICIT OCTET STRING OPTIONAL,
+//			operationalFlagsMask  [10] IMPLICIT flags mask OPTIONAL,
+//			integrityRegisters 	  [11] IMPLICIT IrList OPTIONAL,
 //	}
 //
 // FWIDLIST ::== SEQUENCE SIZE (1..MAX) OF FWID
@@ -99,17 +100,18 @@ type Fwid struct {
 // }
 
 type DiceTcbInfo struct {
-	Vendor             string              `asn1:"optional,tag:0,utf8"`
-	Model              string              `asn1:"optional,tag:1,utf8"`
-	Version            string              `asn1:"optional,tag:2,utf8"`
-	SVN                int                 `asn1:"optional,tag:3"`
-	Layer              int                 `asn1:"optional,tag:4"`
-	Index              int                 `asn1:"optional,tag:5"`
-	Fwids              []Fwid              `asn1:"optional,tag:6"`
-	Flags              OperationalFlag     `asn1:"optional,tag:7"`
-	VendorInfo         []byte              `asn1:"optional,tag:8"`
-	Type               []byte              `asn1:"optional,tag:9"`
-	IntegrityRegisters []IntegrityRegister `asn1:"optional,tag:10"`
+	Vendor               string              `asn1:"optional,tag:0,utf8"`
+	Model                string              `asn1:"optional,tag:1,utf8"`
+	Version              string              `asn1:"optional,tag:2,utf8"`
+	SVN                  int                 `asn1:"optional,tag:3"`
+	Layer                int                 `asn1:"optional,tag:4"`
+	Index                int                 `asn1:"optional,tag:5"`
+	Fwids                []Fwid              `asn1:"optional,tag:6"`
+	Flags                OperationalFlag     `asn1:"optional,tag:7"`
+	VendorInfo           []byte              `asn1:"optional,tag:8"`
+	Type                 []byte              `asn1:"optional,tag:9"`
+	OperationalFlagsMask []byte              `asn1:"optional,tag:10"`
+	IntegrityRegisters   []IntegrityRegister `asn1:"optional,tag:11"`
 }
 
 type IntegrityRegister struct {


### PR DESCRIPTION
Cherry pick of https://github.com/chipsalliance/caliptra-dpe/pull/520

See https://github.com/chipsalliance/caliptra-sw/issues/3061 for more information.

This aligns with the Caliptra DICE certificates and follows the errata published by TCG in https://trustedcomputinggroup.org/wp-content/uploads/Errata-v1.0-r1-for-DICE-Attestation-Architecture-Version-1.2_pub.pdf