### PR TITLE
[verification] Support variable length certificates

### DIFF
--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -345,13 +345,13 @@ impl CommandExecution for DeriveContextCmd {
                         env.state.contexts[parent_idx] = tmp_parent_context;
                     }
 
-
                     response.handle = ContextHandle::new_invalid();
                     response.parent_handle = env.state.contexts[parent_idx].handle;
                     response.resp_hdr = dpe.response_hdr(DpeErrorCode::NoError);
                     response.exported_cdi = *exported_cdi_handle;
                     response.certificate_size = *cert_size;
-                    return Ok(size_of_val(response));
+                    let response_size = size_of_val(response) - size_of_val(&response.new_certificate) + *cert_size as usize;
+                    return Ok(response_size);
                 } else {
                     Err(DpeErrorCode::ArgumentNotSupported)?
                 }

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -82,7 +82,8 @@ fn handle_request(dpe: &mut DpeInstance, env: &mut DpeEnv<impl DpeTypes>, stream
     trace!("| Response Code {response_code:#06x}");
     trace!("----------------------------------");
 
-    stream.write_all(response.as_bytes()).unwrap();
+    let bytes = response.as_bytes_partial().unwrap();
+    stream.write_all(bytes).unwrap();
 }
 
 fn cleanup() {

--- a/verification/client/helpers.go
+++ b/verification/client/helpers.go
@@ -23,7 +23,7 @@ func checkRespHdr(hdr RespHdr) error {
 
 // execCommand executes the command. It returns the response header in the case of success, for internal use (i.e., GetProfile).
 // cmd must be a struct of fixed-size values (or pointer to such), and rsp must be a pointer to such a struct.
-func execCommand(t Transport, code CommandCode, profile Profile, cmd any, rsp any) (*RespHdr, error) {
+func execCommand(t Transport, code CommandCode, profile Profile, cmd any, rsp any) (*RespHdr, *bytes.Reader, error) {
 	hdr := CommandHdr{
 		magic:   CmdMagic,
 		cmd:     code,
@@ -36,22 +36,22 @@ func execCommand(t Transport, code CommandCode, profile Profile, cmd any, rsp an
 
 	resp, err := t.SendCmd(buf.Bytes())
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	respHdr := RespHdr{}
 
 	r := bytes.NewReader(resp)
 	if err = binary.Read(r, binary.LittleEndian, &respHdr); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err = checkRespHdr(respHdr); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if err = binary.Read(r, binary.LittleEndian, rsp); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return &respHdr, nil
+	return &respHdr, r, nil
 }


### PR DESCRIPTION
This adds support to the golang DPE verification client for variable length certificates. The certificate is now read in as a byte slice of the appropriate length, instead of being read directly into a fixed-size array. This allows for more flexibility in the size of the certificate that can be handled by the client. Some implementations may choose to return a certificate that is smaller than the maximum size.