### PR TITLE
Use external mu for signing with the ML-DSA profile

### DIFF
--- a/verification/client/abi.go
+++ b/verification/client/abi.go
@@ -6,6 +6,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"reflect"
+
+	"golang.org/x/crypto/sha3"
 )
 
 // DefaultContextHandle is the default DPE context handle
@@ -855,4 +857,16 @@ func (s *Support) ToFlags() uint32 {
 		flags |= (1 << 18)
 	}
 	return flags
+}
+
+func CalculateExternalMu(msg []byte, pubKey []byte) []byte {
+	tr := make([]byte, 64)
+	sha3.ShakeSum256(tr, pubKey)
+	mu := make([]byte, 64)
+	sh := sha3.NewShake256()
+	sh.Write(tr)
+	sh.Write([]byte{0, 0})
+	sh.Write(msg)
+	sh.Read(mu)
+	return mu
 }


### PR DESCRIPTION
This change updates the signing logic to use the external mu value for signing when the ML-DSA profile is selected. The external mu is calculated using the public key and the message, and is used as the input to the signing operation instead of the original message digest.

Golang doesn't currently have a built-in way to calculate mu, so the calculation is done manually using the SHA3-256 library.