### PR TITLE
Update CFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,9 +206,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
-name = "caliptra-cfi-derive-git"
+name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
+source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=767d4ef59a106aea683b883c07bd65456fb3ba6b#767d4ef59a106aea683b883c07bd65456fb3ba6b"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -217,9 +217,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "caliptra-cfi-lib-git"
+name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
+source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=767d4ef59a106aea683b883c07bd65456fb3ba6b#767d4ef59a106aea683b883c07bd65456fb3ba6b"
 
 [[package]]
 name = "cc"
@@ -345,8 +345,8 @@ version = "0.1.0"
 dependencies = [
  "arrayvec",
  "base64ct",
- "caliptra-cfi-derive-git",
- "caliptra-cfi-lib-git",
+ "caliptra-cfi-derive",
+ "caliptra-cfi-lib",
  "constant_time_eq",
  "ecdsa",
  "hkdf",
@@ -507,8 +507,8 @@ version = "0.1.0"
 dependencies = [
  "asn1",
  "bitflags",
- "caliptra-cfi-derive-git",
- "caliptra-cfi-lib-git",
+ "caliptra-cfi-derive",
+ "caliptra-cfi-lib",
  "cfg-if",
  "cms",
  "constant_time_eq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ members = [
 ]
 
 [workspace.dependencies]
-caliptra-cfi-lib-git = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-lib-git", rev = "a98e499d279e81ae85881991b1e9eee354151189", default-features = false, features = ["cfi", "cfi-counter" ] }
-caliptra-cfi-derive-git = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-derive-git", rev = "a98e499d279e81ae85881991b1e9eee354151189"}
+caliptra-cfi-lib = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-lib", rev = "767d4ef59a106aea683b883c07bd65456fb3ba6b", default-features = false }
+caliptra-cfi-derive = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-derive", rev = "767d4ef59a106aea683b883c07bd65456fb3ba6b"}
 zerocopy = { version = "0.8.17", features = ["derive"] }
 constant_time_eq = "0.3.0"
 

--- a/ci.sh
+++ b/ci.sh
@@ -7,17 +7,17 @@ set -ex
 function build_rust_targets() {
   profile=$1
 
-  cargo build --release --manifest-path dpe/Cargo.toml --features=$profile,no-cfi --no-default-features
+  cargo build --release --manifest-path dpe/Cargo.toml --features=$profile --no-default-features
 
   cargo build --release --manifest-path crypto/Cargo.toml --no-default-features
   cargo build --release --manifest-path platform/Cargo.toml --no-default-features
-  cargo build --release --manifest-path dpe/Cargo.toml --features=$profile --no-default-features
+  cargo build --release --manifest-path dpe/Cargo.toml --features=$profile,cfi --no-default-features
   cargo build --release --manifest-path simulator/Cargo.toml --features=$profile,rustcrypto --no-default-features
   cargo build --release --manifest-path tools/Cargo.toml --features=$profile --no-default-features
 
   cargo build --manifest-path crypto/Cargo.toml --no-default-features
   cargo build --manifest-path platform/Cargo.toml --no-default-features
-  cargo build --manifest-path dpe/Cargo.toml --features=$profile --no-default-features
+  cargo build --manifest-path dpe/Cargo.toml --features=$profile,cfi --no-default-features
   cargo build --manifest-path simulator/Cargo.toml --features=$profile,rustcrypto --no-default-features
   cargo build --manifest-path tools/Cargo.toml --features=$profile --no-default-features
 }
@@ -27,7 +27,7 @@ function lint_rust_targets() {
 
   cargo clippy --manifest-path crypto/Cargo.toml --no-default-features -- --deny=warnings
   cargo clippy --manifest-path platform/Cargo.toml --no-default-features -- --deny=warnings
-  cargo clippy --manifest-path dpe/Cargo.toml --features=$profile --no-default-features -- --deny=warnings
+  cargo clippy --manifest-path dpe/Cargo.toml --features=$profile,cfi --no-default-features -- --deny=warnings
   cargo clippy --manifest-path simulator/Cargo.toml --features=$profile,rustcrypto --no-default-features -- --deny=warnings
   cargo clippy --manifest-path tools/Cargo.toml --features=$profile --no-default-features -- --deny=warnings
 }
@@ -53,7 +53,7 @@ function test_rust_targets() {
 
   cargo test --manifest-path platform/Cargo.toml --no-default-features
   cargo test --manifest-path crypto/Cargo.toml --no-default-features
-  cargo test --manifest-path dpe/Cargo.toml --features=$profile --no-default-features -- --test-threads=1
+  cargo test --manifest-path dpe/Cargo.toml --features=$profile,cfi --no-default-features -- --test-threads=1
   cargo test --manifest-path simulator/Cargo.toml --features=$profile,rustcrypto --no-default-features
 }
 
@@ -79,15 +79,15 @@ test_rust_targets ml-dsa
 run_verification_tests ml-dsa rustcrypto
 
 # Build check for P384/ML-DSA hybrid
-cargo build --release --manifest-path dpe/Cargo.toml --features=hybrid,no-cfi --no-default-features
-
 cargo build --release --manifest-path dpe/Cargo.toml --features=hybrid --no-default-features
+
+cargo build --release --manifest-path dpe/Cargo.toml --features=hybrid,cfi --no-default-features
 cargo build --release --bin cert-size --features=hybrid --no-default-features
 
-cargo build --manifest-path dpe/Cargo.toml --features=hybrid --no-default-features
+cargo build --manifest-path dpe/Cargo.toml --features=hybrid,cfi --no-default-features
 cargo build --bin cert-size --features=hybrid --no-default-features
 
-cargo clippy --manifest-path dpe/Cargo.toml --features=hybrid --no-default-features -- --deny=warnings
+cargo clippy --manifest-path dpe/Cargo.toml --features=hybrid,cfi --no-default-features -- --deny=warnings
 cargo clippy --bin cert-size --features=hybrid --no-default-features -- --deny=warnings
 
 # Run tests for P256 profile

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -6,15 +6,16 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
+default = ["cfi"]
 rustcrypto = ["dep:hkdf", "dep:p256", "dep:p384", "dep:rand", "dep:sha2", "dep:base64ct", "dep:ecdsa", "dep:sec1", "dep:ml-dsa", "dep:pkcs8"]
 ml-dsa = []
 deterministic_rand = ["dep:rand"]
-no-cfi = []
+cfi = ["caliptra-cfi-lib/cfi", "caliptra-cfi-lib/cfi-counter"]
 
 [dependencies]
 arrayvec = { version = "0.7.4", default-features = false, features = ["zeroize"] }
-caliptra-cfi-lib-git = { workspace = true, default-features = false, features = ["cfi", "cfi-counter" ] }
-caliptra-cfi-derive-git.workspace = true
+caliptra-cfi-lib = { workspace = true, default-features = false }
+caliptra-cfi-derive.workspace = true
 constant_time_eq.workspace = true
 ecdsa = { version = "0.16.9", optional = true, features = ["pem"]}
 hkdf = { version = "0.12.3", optional = true }

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -488,7 +488,7 @@ pub trait Crypto {
     ///
     /// To implement this function, you need to add the
     /// cfi_impl_fn proc_macro to derive_cdi.
-    #[cfg(not(feature = "no-cfi"))]
+    #[cfg(feature = "cfi")]
     fn __cfi_derive_cdi(
         &mut self,
         measurement: &Digest,
@@ -499,7 +499,7 @@ pub trait Crypto {
     ///
     /// To implement this function, you need to add the
     /// cfi_impl_fn proc_macro to derive_exported_cdi.
-    #[cfg(not(feature = "no-cfi"))]
+    #[cfg(feature = "cfi")]
     fn __cfi_derive_exported_cdi(
         &mut self,
         measurement: &Digest,
@@ -539,7 +539,7 @@ pub trait Crypto {
     ///
     /// To implement this function, you need to add the
     /// cfi_impl_fn proc_macro to derive_key_pair.
-    #[cfg(not(feature = "no-cfi"))]
+    #[cfg(feature = "cfi")]
     fn __cfi_derive_key_pair(
         &mut self,
         cdi: &Self::Cdi,
@@ -551,7 +551,7 @@ pub trait Crypto {
     ///
     /// To implement this function, you need to add the
     /// cfi_impl_fn proc_macro to derive_key_pair.
-    #[cfg(not(feature = "no-cfi"))]
+    #[cfg(feature = "cfi")]
     fn __cfi_derive_key_pair_exported(
         &mut self,
         exported_handle: &ExportedCdiHandle,

--- a/crypto/src/rustcrypto.rs
+++ b/crypto/src/rustcrypto.rs
@@ -35,8 +35,8 @@ use sha2::{digest::DynDigest, Sha256, Sha384};
 use std::boxed::Box;
 use zerocopy::FromBytes;
 
-#[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
+#[cfg(feature = "cfi")]
+use caliptra_cfi_derive::cfi_impl_fn;
 
 const RUSTCRYPTO_ECDSA_ERROR: CryptoError = CryptoError::CryptoLibError(1);
 const RUSTCRYPTO_SEC_ERROR: CryptoError = CryptoError::CryptoLibError(2);
@@ -320,12 +320,12 @@ impl<S: SignatureType, D: DigestType, SD: SignDataType> Crypto for RustCryptoImp
         Ok(())
     }
 
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn derive_cdi(&mut self, measurement: &Digest, info: &[u8]) -> Result<Self::Cdi, CryptoError> {
         hkdf_derive_cdi(S::SIGNATURE_ALGORITHM, measurement, info)
     }
 
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn derive_exported_cdi(
         &mut self,
         measurement: &Digest,
@@ -349,7 +349,7 @@ impl<S: SignatureType, D: DigestType, SD: SignDataType> Crypto for RustCryptoImp
         Ok(exported_cdi_handle)
     }
 
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn derive_key_pair(
         &mut self,
         cdi: &Self::Cdi,
@@ -359,7 +359,7 @@ impl<S: SignatureType, D: DigestType, SD: SignDataType> Crypto for RustCryptoImp
         self.derive_key_pair_inner(cdi, label, info)
     }
 
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn derive_key_pair_exported(
         &mut self,
         exported_handle: &ExportedCdiHandle,

--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["p384"]
+default = ["p384", "cfi"]
 p256 = []
 p384 = []
 ml-dsa = ["crypto/ml-dsa"]
@@ -23,13 +23,13 @@ disable_internal_info = []
 disable_internal_dice = []
 disable_retain_parent_context = []
 disable_export_cdi = []
-no-cfi = ["crypto/no-cfi"]
+cfi = ["crypto/cfi", "caliptra-cfi-lib/cfi", "caliptra-cfi-lib/cfi-counter"]
 log = ["dep:log"]
 
 [dependencies]
 bitflags = "2.4.0"
-caliptra-cfi-lib-git = { workspace = true, default-features = false, features = ["cfi", "cfi-counter" ] }
-caliptra-cfi-derive-git.workspace = true
+caliptra-cfi-lib = { workspace = true, default-features = false }
+caliptra-cfi-derive.workspace = true
 constant_time_eq.workspace = true
 crypto = {path = "../crypto", default-features = false}
 platform = {path = "../platform", default-features = false}
@@ -41,7 +41,7 @@ log = { version = "0.4.28", optional = true }
 
 [dev-dependencies]
 asn1 = "0.13.0"
-caliptra-cfi-lib-git = { workspace = true, features = ["cfi-test"] }
+caliptra-cfi-lib = { workspace = true, features = ["cfi-test"] }
 x509-parser = "0.15.1"
 crypto = {path = "../crypto", features = ["deterministic_rand", "rustcrypto"]}
 platform = {path = "../platform", default-features = false, features = ["rustcrypto"]}

--- a/dpe/fuzz/Cargo.lock
+++ b/dpe/fuzz/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "caliptra-cfi-derive-git"
+name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
+source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=767d4ef59a106aea683b883c07bd65456fb3ba6b#767d4ef59a106aea683b883c07bd65456fb3ba6b"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -83,9 +83,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "caliptra-cfi-lib-git"
+name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
+source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=767d4ef59a106aea683b883c07bd65456fb3ba6b#767d4ef59a106aea683b883c07bd65456fb3ba6b"
 
 [[package]]
 name = "cc"
@@ -136,8 +136,8 @@ version = "0.1.0"
 dependencies = [
  "arrayvec",
  "base64ct",
- "caliptra-cfi-derive-git",
- "caliptra-cfi-lib-git",
+ "caliptra-cfi-derive",
+ "caliptra-cfi-lib",
  "constant_time_eq",
  "ecdsa",
  "hkdf",
@@ -254,8 +254,8 @@ name = "dpe"
 version = "0.1.0"
 dependencies = [
  "bitflags",
- "caliptra-cfi-derive-git",
- "caliptra-cfi-lib-git",
+ "caliptra-cfi-derive",
+ "caliptra-cfi-lib",
  "cfg-if",
  "constant_time_eq",
  "crypto",

--- a/dpe/fuzz/Cargo.toml
+++ b/dpe/fuzz/Cargo.toml
@@ -21,14 +21,16 @@ time = "=0.3.36"
 [dependencies.dpe]
 path = ".."
 default-features = false
-features = ["p256", "no-cfi"]
+features = ["p256"]
 
 [dependencies.crypto]
 path = "../../crypto"
+default-features = false
 features = ["rustcrypto"]
 
 [dependencies.platform]
 path = "../../platform"
+default-features = false
 features = ["rustcrypto"]
 
 # Prevent this from interfering with workspaces

--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -9,10 +9,10 @@ use crate::{
     DpeFlags, DpeProfile,
 };
 use bitflags::bitflags;
-#[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
-#[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
+#[cfg(feature = "cfi")]
+use caliptra_cfi_derive::cfi_impl_fn;
+#[cfg(feature = "cfi")]
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_assert_eq};
 use cfg_if::cfg_if;
 #[cfg(any(feature = "p256", feature = "p384"))]
 use crypto::ecdsa::EcdsaPubKey;
@@ -133,7 +133,7 @@ impl<'a> From<&'a CertifyKeyMldsa87Cmd> for CertifyKeyCommand<'a> {
 }
 
 impl CommandExecution for CertifyKeyCommand<'_> {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     fn execute_serialized(
         &self,
@@ -170,7 +170,7 @@ impl CommandExecution for CertifyKeyCommand<'_> {
         }
 
         cfg_if! {
-            if #[cfg(not(feature = "no-cfi"))] {
+            if #[cfg(feature = "cfi")] {
                 cfi_assert!(format != Self::FORMAT_X509 || env.state.support.x509());
                 cfi_assert!(format != Self::FORMAT_X509 || context.allow_x509());
                 cfi_assert!(format != Self::FORMAT_CSR || env.state.support.csr());
@@ -199,7 +199,7 @@ impl CommandExecution for CertifyKeyCommand<'_> {
             Self::FORMAT_X509 => {
                 cfg_if! {
                     if #[cfg(not(feature = "disable_x509"))] {
-                        #[cfg(not(feature = "no-cfi"))]
+                        #[cfg(feature = "cfi")]
                         cfi_assert_eq(format, Self::FORMAT_X509);
                         create_dpe_cert(&args, dpe, env, cert)
                     } else {
@@ -210,7 +210,7 @@ impl CommandExecution for CertifyKeyCommand<'_> {
             Self::FORMAT_CSR => {
                 cfg_if! {
                     if #[cfg(not(feature = "disable_csr"))] {
-                        #[cfg(not(feature = "no-cfi"))]
+                        #[cfg(feature = "cfi")]
                         cfi_assert_eq(format, Self::FORMAT_CSR);
                         crate::x509::create_dpe_csr(&args, dpe, env, cert)
                     } else {
@@ -285,7 +285,7 @@ pub struct CertifyKeyP256Cmd {
 
 #[cfg(feature = "p256")]
 impl CommandExecution for CertifyKeyP256Cmd {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
@@ -319,7 +319,7 @@ impl Default for CertifyKeyP384Cmd {
 
 #[cfg(feature = "p384")]
 impl CommandExecution for CertifyKeyP384Cmd {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
@@ -353,7 +353,7 @@ impl Default for CertifyKeyMldsa87Cmd {
 
 #[cfg(feature = "ml-dsa")]
 impl CommandExecution for CertifyKeyMldsa87Cmd {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
@@ -427,7 +427,7 @@ mod tests {
         x509::{tests::TcbInfo, DirectoryString, Name},
         State, MAX_HANDLES, TCI_SIZE,
     };
-    use caliptra_cfi_lib_git::CfiCounter;
+    use caliptra_cfi_lib::CfiCounter;
     use cms::{
         content_info::{CmsVersion, ContentInfo},
         signed_data::{SignedData, SignerIdentifier},

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -7,11 +7,11 @@ use crate::{
     response::{DpeErrorCode, ResponseHdr},
     State,
 };
-#[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
-use caliptra_cfi_lib_git::cfi_launder;
-#[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
+#[cfg(feature = "cfi")]
+use caliptra_cfi_derive::cfi_impl_fn;
+use caliptra_cfi_lib::cfi_launder;
+#[cfg(feature = "cfi")]
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_assert_eq};
 
 #[repr(C)]
 #[derive(
@@ -38,7 +38,7 @@ pub(crate) fn destroy_context(
     if context.locality != locality {
         return Err(DpeErrorCode::InvalidLocality);
     } else {
-        #[cfg(not(feature = "no-cfi"))]
+        #[cfg(feature = "cfi")]
         cfi_assert_eq(context.locality, locality);
     }
 
@@ -57,7 +57,7 @@ pub(crate) fn destroy_context(
         if parent_context.state == ContextState::Retired && cfi_launder(child_context_count) == 1 {
             retired_contexts.add_child(parent_idx)?;
         } else {
-            #[cfg(not(feature = "no-cfi"))]
+            #[cfg(feature = "cfi")]
             cfi_assert!(parent_context.state != ContextState::Retired || child_context_count != 1);
             break;
         }
@@ -77,7 +77,7 @@ pub(crate) fn destroy_context(
         if to_destroy.has_child(idx) {
             c.destroy();
         } else {
-            #[cfg(not(feature = "no-cfi"))]
+            #[cfg(feature = "cfi")]
             cfi_assert_eq(to_destroy.has_child(idx), false);
         }
     }
@@ -85,7 +85,7 @@ pub(crate) fn destroy_context(
 }
 
 impl CommandExecution for DestroyCtxCmd {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     fn execute_serialized(
         &self,
@@ -114,7 +114,7 @@ mod tests {
         },
         response::Response,
     };
-    use caliptra_cfi_lib_git::CfiCounter;
+    use caliptra_cfi_lib::CfiCounter;
     use zerocopy::IntoBytes;
 
     const TEST_DESTROY_CTX_CMD: DestroyCtxCmd = DestroyCtxCmd {

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -5,8 +5,8 @@ use crate::{
     mutresp,
     response::{DpeErrorCode, GetCertificateChainResp},
 };
-#[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
+#[cfg(feature = "cfi")]
+use caliptra_cfi_derive::cfi_impl_fn;
 use platform::{Platform, MAX_CHUNK_SIZE};
 
 #[repr(C)]
@@ -25,7 +25,7 @@ pub struct GetCertificateChainCmd {
 }
 
 impl CommandExecution for GetCertificateChainCmd {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     fn execute_serialized(
         &self,
@@ -60,7 +60,7 @@ mod tests {
         commands::{tests::PROFILES, Command, CommandHdr},
         dpe_instance::tests::{test_env, test_state, DPE_PROFILE, TEST_LOCALITIES},
     };
-    use caliptra_cfi_lib_git::CfiCounter;
+    use caliptra_cfi_lib::CfiCounter;
     use zerocopy::IntoBytes;
 
     const TEST_GET_CERTIFICATE_CHAIN_CMD: GetCertificateChainCmd = GetCertificateChainCmd {

--- a/dpe/src/commands/get_profile.rs
+++ b/dpe/src/commands/get_profile.rs
@@ -6,8 +6,8 @@ use crate::{
     mutresp,
     response::{DpeErrorCode, GetProfileResp},
 };
-#[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
+#[cfg(feature = "cfi")]
+use caliptra_cfi_derive::cfi_impl_fn;
 
 #[repr(C)]
 #[derive(
@@ -23,7 +23,7 @@ use caliptra_cfi_derive_git::cfi_impl_fn;
 pub struct GetProfileCmd;
 
 impl CommandExecution for GetProfileCmd {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     fn execute_serialized(
         &self,

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -7,10 +7,10 @@ use crate::{
     response::{DpeErrorCode, NewHandleResp},
 };
 use bitflags::bitflags;
-#[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
-#[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
+#[cfg(feature = "cfi")]
+use caliptra_cfi_derive::cfi_impl_fn;
+#[cfg(feature = "cfi")]
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool};
 use cfg_if::cfg_if;
 
 #[repr(C)]
@@ -51,7 +51,7 @@ impl InitCtxCmd {
 }
 
 impl CommandExecution for InitCtxCmd {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     fn execute_serialized(
         &self,
@@ -77,7 +77,7 @@ impl CommandExecution for InitCtxCmd {
         }
 
         cfg_if! {
-            if #[cfg(not(feature = "no-cfi"))] {
+            if #[cfg(feature = "cfi")] {
                 cfi_assert!(!self.flag_is_default() || !env.state.has_initialized());
                 cfi_assert!(!self.flag_is_simulation() || env.state.support.simulation());
                 cfi_assert!(self.flag_is_default() ^ self.flag_is_simulation());
@@ -127,7 +127,7 @@ mod tests {
         support::Support,
         DpeFlags, State,
     };
-    use caliptra_cfi_lib_git::CfiCounter;
+    use caliptra_cfi_lib::CfiCounter;
     use zerocopy::IntoBytes;
 
     const TEST_INIT_CTX_CMD: InitCtxCmd = InitCtxCmd(0x1234_5678);

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -13,8 +13,8 @@ pub use self::get_certificate_chain::GetCertificateChainCmd;
 pub use self::get_profile::GetProfileCmd;
 pub use self::initialize_context::InitCtxCmd;
 pub use self::sign::{SignCommand, SignFlags, SignP256Cmd, SignP384Cmd};
-#[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
+#[cfg(feature = "cfi")]
+use caliptra_cfi_derive::{cfi_impl_fn, Launder};
 
 #[cfg(feature = "ml-dsa")]
 pub use {self::certify_key::CertifyKeyMldsa87Cmd, sign::SignMldsa87Cmd};
@@ -41,6 +41,7 @@ mod rotate_context;
 mod sign;
 
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "cfi", derive(Launder))]
 pub enum Command<'a> {
     GetProfile(&'a GetProfileCmd),
     InitCtx(&'a InitCtxCmd),
@@ -263,7 +264,7 @@ impl<'a> From<&'a SignCommand<'a>> for Command<'a> {
 }
 
 impl CommandExecution for Command<'_> {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
@@ -304,7 +305,7 @@ pub trait CommandExecution {
     ///
     /// To implement this function, you need to add the
     /// cfi_impl_fn proc_macro to execute.
-    #[cfg(not(feature = "no-cfi"))]
+    #[cfg(feature = "cfi")]
     fn __cfi_execute<'a>(
         &'a self,
         dpe: &mut DpeInstance,
@@ -331,7 +332,7 @@ pub trait CommandExecution {
     ///
     /// To implement this function, you need to add the
     /// cfi_impl_fn proc_macro to execute.
-    #[cfg(not(feature = "no-cfi"))]
+    #[cfg(feature = "cfi")]
     fn __cfi_execute_serialized(
         &self,
         dpe: &mut DpeInstance,
@@ -399,7 +400,7 @@ pub mod tests {
     use super::*;
     use crate::dpe_instance::tests::DPE_PROFILE;
     use crate::DpeProfile;
-    use caliptra_cfi_lib_git::CfiCounter;
+    use caliptra_cfi_lib::CfiCounter;
     use platform::default::{DefaultPlatform, DefaultPlatformProfile};
     use zerocopy::IntoBytes;
 

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -8,11 +8,11 @@ use crate::{
     State,
 };
 use bitflags::bitflags;
-#[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
-use caliptra_cfi_lib_git::cfi_launder;
-#[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
+#[cfg(feature = "cfi")]
+use caliptra_cfi_derive::cfi_impl_fn;
+use caliptra_cfi_lib::cfi_launder;
+#[cfg(feature = "cfi")]
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool};
 
 #[repr(C)]
 #[derive(
@@ -79,7 +79,7 @@ impl RotateCtxCmd {
 }
 
 impl CommandExecution for RotateCtxCmd {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     fn execute_serialized(
         &self,
@@ -91,7 +91,7 @@ impl CommandExecution for RotateCtxCmd {
         if !env.state.support.rotate_context() {
             return Err(DpeErrorCode::InvalidCommand);
         } else {
-            #[cfg(not(feature = "no-cfi"))]
+            #[cfg(feature = "cfi")]
             cfi_assert!(env.state.support.rotate_context());
         }
         let response = mutresp::<NewHandleResp>(dpe.profile, out)?;
@@ -107,11 +107,11 @@ impl CommandExecution for RotateCtxCmd {
             if default_context_idx.is_ok() || cfi_launder(non_default_valid_handles_exist) {
                 return Err(DpeErrorCode::InvalidArgument);
             } else {
-                #[cfg(not(feature = "no-cfi"))]
+                #[cfg(feature = "cfi")]
                 cfi_assert!(default_context_idx.is_err() && !non_default_valid_handles_exist);
             }
         } else {
-            #[cfg(not(feature = "no-cfi"))]
+            #[cfg(feature = "cfi")]
             cfi_assert!(!self.uses_target_is_default());
         }
 
@@ -142,7 +142,7 @@ mod tests {
         support::Support,
         DpeFlags,
     };
-    use caliptra_cfi_lib_git::CfiCounter;
+    use caliptra_cfi_lib::CfiCounter;
     use zerocopy::IntoBytes;
 
     const TEST_ROTATE_CTX_CMD: RotateCtxCmd = RotateCtxCmd {

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -8,11 +8,11 @@ use crate::{
     DpeProfile,
 };
 use bitflags::bitflags;
-#[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
-use caliptra_cfi_lib_git::cfi_launder;
-#[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_assert_ne};
+#[cfg(feature = "cfi")]
+use caliptra_cfi_derive::cfi_impl_fn;
+use caliptra_cfi_lib::cfi_launder;
+#[cfg(feature = "cfi")]
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_assert_ne};
 use cfg_if::cfg_if;
 #[cfg(any(feature = "p256", feature = "p384"))]
 use crypto::ecdsa::EcdsaSignature;
@@ -70,7 +70,7 @@ impl SignCommand<'_> {
 }
 
 impl CommandExecution for SignCommand<'_> {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[inline(never)]
     fn execute_serialized(
         &self,
@@ -107,7 +107,7 @@ impl CommandExecution for SignCommand<'_> {
         }
 
         cfg_if! {
-            if #[cfg(not(feature = "no-cfi"))] {
+            if #[cfg(feature = "cfi")] {
                 cfi_assert_ne(context.context_type, ContextType::Simulation);
             }
         }
@@ -187,10 +187,10 @@ fn sign(
     let context = profile.key_context();
     let key_pair = env.crypto.derive_key_pair(&cdi, label, context);
     if cfi_launder(key_pair.is_ok()) {
-        #[cfg(not(feature = "no-cfi"))]
+        #[cfg(feature = "cfi")]
         cfi_assert!(key_pair.is_ok());
     } else {
-        #[cfg(not(feature = "no-cfi"))]
+        #[cfg(feature = "cfi")]
         cfi_assert!(key_pair.is_err());
     }
     let (priv_key, pub_key) = key_pair?;
@@ -209,7 +209,7 @@ pub struct SignP256Cmd {
 
 #[cfg(feature = "p256")]
 impl CommandExecution for SignP256Cmd {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
@@ -232,7 +232,7 @@ pub struct SignP384Cmd {
 
 #[cfg(feature = "p384")]
 impl CommandExecution for SignP384Cmd {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
@@ -255,7 +255,7 @@ pub struct SignMldsa87Cmd {
 
 #[cfg(feature = "ml-dsa")]
 impl CommandExecution for SignMldsa87Cmd {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
@@ -289,7 +289,7 @@ mod tests {
         response::{Response, SignResp},
         tci::TciMeasurement,
     };
-    use caliptra_cfi_lib_git::CfiCounter;
+    use caliptra_cfi_lib::CfiCounter;
     use openssl::x509::X509;
     use openssl::{bn::BigNum, ecdsa::EcdsaSig};
     use zerocopy::IntoBytes;

--- a/dpe/src/state.rs
+++ b/dpe/src/state.rs
@@ -12,8 +12,8 @@ use crypto::Digest;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, TryFromBytes};
 use zeroize::Zeroize;
 
-#[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
+#[cfg(feature = "cfi")]
+use caliptra_cfi_derive::cfi_impl_fn;
 
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, FromBytes, IntoBytes, Immutable, KnownLayout, Zeroize)]
@@ -213,7 +213,7 @@ impl State {
     /// * `nodes` - Array to write TCI nodes to
     ///
     /// Returns the number of TCIs written to `nodes`
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     pub(crate) fn get_tcb_nodes(
         &self,
         start_idx: usize,
@@ -251,7 +251,7 @@ impl State {
 
 #[cfg(test)]
 mod tests {
-    use caliptra_cfi_lib_git::CfiCounter;
+    use caliptra_cfi_lib::CfiCounter;
     use platform::default::AUTO_INIT_LOCALITY;
 
     use crate::dpe_instance::tests::SIMULATION_HANDLE;

--- a/dpe/src/validation.rs
+++ b/dpe/src/validation.rs
@@ -308,7 +308,7 @@ pub mod tests {
         validation::{DpeValidator, ValidationError},
         DpeFlags, OperationHandle, State, U8Bool, HASH_SIZE, TCI_SIZE,
     };
-    use caliptra_cfi_lib_git::CfiCounter;
+    use caliptra_cfi_lib::CfiCounter;
 
     #[test]
     fn test_validate_context_forest() {

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -14,9 +14,9 @@ use crate::{
     DpeInstance, DpeProfile, State, MAX_HANDLES,
 };
 use bitflags::bitflags;
-use caliptra_cfi_lib_git::cfi_launder;
-#[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
+use caliptra_cfi_lib::cfi_launder;
+#[cfg(feature = "cfi")]
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool};
 use crypto::{
     ecdsa::{EcdsaPubKey, EcdsaSignature},
     Crypto, CryptoError, CryptoSuite, Digest, Hasher, PubKey, SignData, Signature,
@@ -2929,10 +2929,10 @@ fn create_dpe_cert_or_csr(
         }
     };
     if cfi_launder(key_pair.is_ok()) {
-        #[cfg(not(feature = "no-cfi"))]
+        #[cfg(feature = "cfi")]
         cfi_assert!(key_pair.is_ok());
     } else {
-        #[cfg(not(feature = "no-cfi"))]
+        #[cfg(feature = "cfi")]
         cfi_assert!(key_pair.is_err());
     }
     let (priv_key, pub_key) = okref(&key_pair)?;

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -12,6 +12,7 @@ p384 = ["dpe/p384"]
 # TODO(clundin): Placeholder name until we decide pattern for DPE profiles and feature flags.
 ml-dsa = ["dpe/ml-dsa"]
 rustcrypto = ["crypto/rustcrypto", "platform/rustcrypto"]
+cfi = ["dpe/cfi"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -20,6 +21,6 @@ ctrlc = { version = "3.0", features = ["termination"] }
 clap = { version = "4.1.8", features = ["derive"] }
 log = "0.4.17"
 env_logger = "0.10.0"
-dpe = { path = "../dpe", default-features = false, features = ["no-cfi"] }
+dpe = { path = "../dpe", default-features = false }
 crypto = { path = "../crypto", default-features = false }
 platform = { path = "../platform", default-features = false}

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -16,10 +16,11 @@ ml-dsa = [
   "dpe/ml-dsa"
 ]
 hybrid = ["p384", "ml-dsa"]
+cfi = ["dpe/cfi"]
 
 [dependencies]
 anyhow = "1.0.70"
-dpe = {path = "../dpe", default-features = false, features = ["no-cfi"]}
+dpe = {path = "../dpe", default-features = false}
 clap = { version = "4.1.8", features = ["derive"] }
 crypto = {path = "../crypto", default-features = false, features = ["deterministic_rand", "rustcrypto"]}
 pem = "2"


### PR DESCRIPTION
* Pin to a newer CFI version that matches the one used by caliptra-sw.
* Replace "no-cfi" with "cfi" flag to follow Rust best practices.
  * CFI is now an additive feature.

This should result in some code space savings in caliptra-sw