### PR TITLE
Make `Hasher` dyn compatible

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -130,7 +130,10 @@ impl CryptoError {
     }
 }
 
-pub trait Hasher: Sized {
+pub trait Hasher {
+    /// Initialize a running hash operation.
+    fn initialize(&mut self) -> Result<(), CryptoError>;
+
     /// Adds a chunk to the running hash.
     ///
     /// # Arguments
@@ -140,9 +143,9 @@ pub trait Hasher: Sized {
 
     /// Finish a running hash operation and return the result.
     ///
-    /// Once this function has been called, the object can no longer be used and
-    /// a new one must be created to hash more data.
-    fn finish(self) -> Result<Digest, CryptoError>;
+    /// Once this function has been called, the object can no longer be used
+    /// until it is re-initialized.
+    fn finish(&mut self) -> Result<Digest, CryptoError>;
 }
 
 #[derive(Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Clone)]
@@ -412,33 +415,25 @@ pub trait CryptoSuite: Crypto + SignatureType + DigestType {
         }
 
         let signature_alg = self.signature_algorithm();
-        let mut hasher = self.hash_initialize()?;
-        match (signature_alg, pub_key) {
+        let digest = match (signature_alg, pub_key) {
             (SignatureAlgorithm::Ecdsa(_), PubKey::Ecdsa(pub_key)) => {
                 let (x, y) = pub_key.as_slice();
-                hasher.update(&[0x4u8])?;
-                hasher.update(x)?;
-                hasher.update(y)?;
+                self.hash_all(&[&[0x4u8], &x, &y])?
             }
             #[cfg(feature = "ml-dsa")]
             (SignatureAlgorithm::Mldsa(_), PubKey::Mldsa(pub_key)) => {
-                hasher.update(pub_key.as_bytes())?;
+                self.hash(pub_key.as_bytes())?
             }
             // This can be reached when the "ml-dsa" feature is enabled.
             #[allow(unreachable_patterns)]
             _ => Err(CryptoError::MismatchedAlgorithm)?,
-        }
-
-        let digest = hasher.finish()?;
+        };
         digest.write_hex_str(serial)
     }
 }
 
 pub trait Crypto {
     type Cdi;
-    type Hasher<'c>: Hasher
-    where
-        Self: 'c;
     type PrivKey;
 
     /// Fills the buffer with random values.
@@ -454,15 +449,42 @@ pub trait Crypto {
     ///
     /// * `bytes` - Value to be hashed.
     fn hash(&mut self, bytes: &[u8]) -> Result<Digest, CryptoError> {
-        let mut hasher = self.hash_initialize()?;
-        hasher.update(bytes)?;
-        hasher.finish()
+        self.hash_all(&[&bytes])
     }
 
-    /// Initialize a running hash. Returns an object that will be able to complete the rest.
+    /// Returns an object that will be able to perform hash operations.
     ///
     /// Used for hashing multiple buffers that may not be in consecutive memory.
-    fn hash_initialize(&mut self) -> Result<Self::Hasher<'_>, CryptoError>;
+    fn hasher(&mut self) -> Result<&mut dyn Hasher, CryptoError>;
+
+    /// Cryptographically hashes the given buffers as a running hash.
+    ///
+    /// # Arguments
+    ///
+    /// * `vals` - Values to be hashed.
+    fn hash_all(&mut self, vals: &[&dyn AsRef<[u8]>]) -> Result<Digest, CryptoError> {
+        self.with_hasher(&|hasher| {
+            for chunk in vals {
+                hasher.update(chunk.as_ref())?;
+            }
+            Ok(())
+        })
+    }
+
+    /// Initialize a running hash and call a closure with it.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - Closure to call with the hasher.
+    fn with_hasher(
+        &mut self,
+        f: &dyn Fn(&mut dyn Hasher) -> Result<(), CryptoError>,
+    ) -> Result<Digest, CryptoError> {
+        let hasher = self.hasher()?;
+        hasher.initialize()?;
+        f(hasher)?;
+        hasher.finish()
+    }
 
     /// Derive a CDI based on the current base CDI and measurements
     ///

--- a/crypto/src/rustcrypto.rs
+++ b/crypto/src/rustcrypto.rs
@@ -92,17 +92,41 @@ impl From<Signature<NistP384>> for EcdsaSignature384 {
 }
 
 pub struct RustCryptoHasher<D: DigestType> {
-    hasher: Box<dyn DynDigest>,
+    hasher: Option<Box<dyn DynDigest>>,
     _alg: PhantomData<D>,
 }
 
+impl<D: DigestType> RustCryptoHasher<D> {
+    fn new() -> Self {
+        Self {
+            hasher: Some(Self::new_hasher()),
+            _alg: Default::default(),
+        }
+    }
+
+    fn new_hasher() -> Box<dyn DynDigest> {
+        match D::DIGEST_ALGORITHM {
+            DigestAlgorithm::Sha256 => Box::new(Sha256::default()),
+            DigestAlgorithm::Sha384 => Box::new(Sha384::default()),
+        }
+    }
+}
+
 impl<D: DigestType> Hasher for RustCryptoHasher<D> {
-    fn update(&mut self, bytes: &[u8]) -> Result<(), CryptoError> {
-        self.hasher.update(bytes);
+    fn initialize(&mut self) -> Result<(), CryptoError> {
+        self.hasher = Some(Self::new_hasher());
         Ok(())
     }
-    fn finish(self) -> Result<Digest, CryptoError> {
-        let digest = &self.hasher.finalize();
+    fn update(&mut self, bytes: &[u8]) -> Result<(), CryptoError> {
+        let Some(hasher) = self.hasher.as_mut() else {
+            return Err(CryptoError::HashError(0));
+        };
+        hasher.update(bytes);
+        Ok(())
+    }
+    fn finish(&mut self) -> Result<Digest, CryptoError> {
+        let hasher = self.hasher.take().ok_or(CryptoError::HashError(1))?;
+        let digest = &hasher.finalize();
         let digest = match D::DIGEST_ALGORITHM {
             DigestAlgorithm::Sha256 => {
                 let sha256 =
@@ -165,6 +189,7 @@ impl SignDataType for MldsaRustCrypto {
 pub struct RustCryptoImpl<S: SignatureType, D: DigestType, SD: SignDataType> {
     rng: StdRng,
     export_cdi_slots: Vec<(<Self as Crypto>::Cdi, ExportedCdiHandle)>,
+    hasher: RustCryptoHasher<D>,
     _signature_alg: PhantomData<S>,
     _digest_alg: PhantomData<D>,
 }
@@ -181,6 +206,7 @@ impl<S: SignatureType, D: DigestType, SD: SignDataType> RustCryptoImpl<S, D, SD>
         Self {
             rng: StdRng::from_entropy(),
             export_cdi_slots: Vec::new(),
+            hasher: RustCryptoHasher::new(),
             _signature_alg: Default::default(),
             _digest_alg: Default::default(),
         }
@@ -193,6 +219,7 @@ impl<S: SignatureType, D: DigestType, SD: SignDataType> RustCryptoImpl<S, D, SD>
         Self {
             rng: seeded_rng,
             export_cdi_slots: Vec::new(),
+            hasher: RustCryptoHasher::new(),
             _signature_alg: Default::default(),
             _digest_alg: Default::default(),
         }
@@ -295,24 +322,10 @@ pub struct RustCryptoPrivKey(Vec<u8>);
 
 impl<S: SignatureType, D: DigestType, SD: SignDataType> Crypto for RustCryptoImpl<S, D, SD> {
     type Cdi = Vec<u8>;
-    type Hasher<'c>
-        = RustCryptoHasher<D>
-    where
-        Self: 'c;
     type PrivKey = RustCryptoPrivKey;
 
-    fn hash_initialize(&mut self) -> Result<Self::Hasher<'_>, CryptoError> {
-        let hasher = match D::DIGEST_ALGORITHM {
-            DigestAlgorithm::Sha256 => RustCryptoHasher {
-                hasher: Box::new(Sha256::default()),
-                _alg: Default::default(),
-            },
-            DigestAlgorithm::Sha384 => RustCryptoHasher {
-                hasher: Box::new(Sha384::default()),
-                _alg: Default::default(),
-            },
-        };
-        Ok(hasher)
+    fn hasher(&mut self) -> Result<&mut dyn Hasher, CryptoError> {
+        Ok(&mut self.hasher)
     }
 
     fn rand_bytes(&mut self, dst: &mut [u8]) -> Result<(), CryptoError> {

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -459,7 +459,7 @@ mod tests {
         DpeProfile, MAX_CERT_SIZE, MAX_EXPORTED_CDI_SIZE, MAX_HANDLES, TCI_SIZE,
     };
     use caliptra_cfi_lib::CfiCounter;
-    use caliptra_dpe_crypto::{Crypto, Hasher};
+    use caliptra_dpe_crypto::Crypto;
     use caliptra_dpe_platform::{Platform, MAX_KEY_IDENTIFIER_SIZE};
     use openssl::{
         bn::BigNum,
@@ -1062,14 +1062,17 @@ mod tests {
         assert!(env.state.contexts[child_idx].allow_export_cdi());
 
         // check tci_cumulative correctly computed
-        let mut hasher = env.crypto.hash_initialize().unwrap();
-        hasher.update(&[0u8; DPE_PROFILE.hash_size()]).unwrap();
-        hasher.update(&[1u8; DPE_PROFILE.hash_size()]).unwrap();
-        let temp_digest = hasher.finish().unwrap();
-        let mut hasher_2 = env.crypto.hash_initialize().unwrap();
-        hasher_2.update(temp_digest.as_slice()).unwrap();
-        hasher_2.update(&[2u8; DPE_PROFILE.hash_size()]).unwrap();
-        let digest = hasher_2.finish().unwrap();
+        let temp_digest = env
+            .crypto
+            .hash_all(&[
+                &[0u8; DPE_PROFILE.hash_size()],
+                &[1u8; DPE_PROFILE.hash_size()],
+            ])
+            .unwrap();
+        let digest = env
+            .crypto
+            .hash_all(&[&temp_digest.as_slice(), &[2u8; DPE_PROFILE.hash_size()]])
+            .unwrap();
         assert_eq!(
             digest.as_slice(),
             env.state.contexts[child_idx].tci.tci_cumulative.0

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -19,7 +19,7 @@ use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_cfi_lib::cfi_launder;
 #[cfg(feature = "cfi")]
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_assert_eq};
-use caliptra_dpe_crypto::{Crypto, CryptoSuite, Digest, Hasher};
+use caliptra_dpe_crypto::{Crypto, CryptoSuite, Digest};
 use caliptra_dpe_platform::Platform;
 #[cfg(not(feature = "disable_internal_dice"))]
 use caliptra_dpe_platform::MAX_CHUNK_SIZE;
@@ -248,10 +248,9 @@ impl DpeInstance {
         }
 
         // Derive the new TCI as HASH(TCI_CUMULATIVE || INPUT_DATA).
-        let mut hasher = env.crypto.hash_initialize()?;
-        hasher.update(&context.tci.tci_cumulative.0)?;
-        hasher.update(&measurement.0)?;
-        let digest = hasher.finish()?;
+        let digest = env
+            .crypto
+            .hash_all(&[&context.tci.tci_cumulative.0, &measurement.0])?;
 
         let digest_bytes = digest.as_slice();
 
@@ -307,7 +306,8 @@ impl DpeInstance {
         env: &mut DpeEnv<impl DpeTypes>,
         start_idx: usize,
     ) -> Result<Digest, DpeErrorCode> {
-        let mut hasher = env.crypto.hash_initialize()?;
+        let hasher = env.crypto.hasher()?;
+        hasher.initialize()?;
 
         let mut uses_internal_input_info = false;
         let mut uses_internal_input_dice = false;
@@ -529,10 +529,10 @@ pub mod tests {
         assert_eq!(data, context.tci.tci_current.0);
 
         // Compute cumulative.
-        let mut hasher = env.crypto.hash_initialize().unwrap();
-        hasher.update(&[0; DPE_PROFILE.hash_size()]).unwrap();
-        hasher.update(&data).unwrap();
-        let first_cumulative = hasher.finish().unwrap();
+        let first_cumulative = env
+            .crypto
+            .hash_all(&[&[0; DPE_PROFILE.hash_size()], &data])
+            .unwrap();
 
         // Make sure the cumulative was computed correctly.
         assert_eq!(first_cumulative.as_slice(), context.tci.tci_cumulative.0);
@@ -549,10 +549,10 @@ pub mod tests {
         env.state.contexts[0] = context;
         assert_eq!(data, context.tci.tci_current.0);
 
-        let mut hasher = env.crypto.hash_initialize().unwrap();
-        hasher.update(first_cumulative.as_slice()).unwrap();
-        hasher.update(&data).unwrap();
-        let second_cumulative = hasher.finish().unwrap();
+        let second_cumulative = env
+            .crypto
+            .hash_all(&[&first_cumulative.as_slice(), &data])
+            .unwrap();
 
         // Make sure the cumulative was computed correctly.
         assert_eq!(second_cumulative.as_slice(), context.tci.tci_cumulative.0);
@@ -593,21 +593,25 @@ pub mod tests {
             last_cdi = curr_cdi;
         }
 
-        let mut hasher = env.crypto.hash_initialize().unwrap();
         let leaf_idx = env
             .state
             .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[0])
             .unwrap();
 
-        for result in ChildToRootIter::new(leaf_idx, &env.state.contexts) {
-            let context = result.unwrap();
-            hasher.update(context.tci.as_bytes()).unwrap();
-            hasher
-                .update(/*allow_x509=*/ context.allow_x509().as_bytes())
-                .unwrap();
-        }
+        let digest = env
+            .crypto
+            .with_hasher(&|hasher| {
+                for result in ChildToRootIter::new(leaf_idx, &env.state.contexts) {
+                    let context = result.unwrap();
+                    hasher.update(context.tci.as_bytes()).unwrap();
+                    hasher
+                        .update(/*allow_x509=*/ context.allow_x509().as_bytes())
+                        .unwrap();
+                }
+                Ok(())
+            })
+            .unwrap();
 
-        let digest = hasher.finish().unwrap();
         let answer = env.crypto.derive_cdi(&digest, b"DPE").unwrap();
         assert_eq!(answer, last_cdi);
     }
@@ -643,12 +647,6 @@ pub mod tests {
         assert!(child_context.uses_internal_input_info());
         assert!(!parent_context.uses_internal_input_info());
 
-        let mut hasher = env.crypto.hash_initialize().unwrap();
-
-        hasher.update(child_context.tci.as_bytes()).unwrap();
-        hasher.update(/*allow_x509=*/ false.as_bytes()).unwrap();
-        hasher.update(parent_context.tci.as_bytes()).unwrap();
-        hasher.update(/*allow_x509=*/ true.as_bytes()).unwrap();
         let mut internal_input_info = [0u8; INTERNAL_INPUT_INFO_SIZE];
         dpe.serialize_internal_input_info(
             &mut env.platform,
@@ -657,11 +655,16 @@ pub mod tests {
         )
         .unwrap();
 
-        hasher
-            .update(&internal_input_info[..INTERNAL_INPUT_INFO_SIZE])
+        let digest = env
+            .crypto
+            .hash_all(&[
+                &child_context.tci.as_bytes(),
+                /*allow_x509=*/ &false.as_bytes(),
+                &parent_context.tci.as_bytes(),
+                /*allow_x509=*/ &true.as_bytes(),
+                &&internal_input_info[..INTERNAL_INPUT_INFO_SIZE],
+            ])
             .unwrap();
-
-        let digest = hasher.finish().unwrap();
         let answer = env.crypto.derive_cdi(&digest, b"DPE").unwrap();
         assert_eq!(answer, cdi_with_internal_input_info);
     }
@@ -697,16 +700,17 @@ pub mod tests {
         assert!(child_context.uses_internal_input_dice());
         assert!(!parent_context.uses_internal_input_dice());
 
-        let mut hasher = env.crypto.hash_initialize().unwrap();
-
-        hasher.update(child_context.tci.as_bytes()).unwrap();
-        hasher.update(/*allow_x509=*/ false.as_bytes()).unwrap();
-        hasher.update(parent_context.tci.as_bytes()).unwrap();
-        hasher.update(/*allow_x509=*/ true.as_bytes()).unwrap();
         let cert_chain = env.platform.0.cert_chain();
-        hasher.update(&cert_chain).unwrap();
-
-        let digest = hasher.finish().unwrap();
+        let digest = env
+            .crypto
+            .hash_all(&[
+                &child_context.tci.as_bytes(),
+                /*allow_x509=*/ &false.as_bytes(),
+                &parent_context.tci.as_bytes(),
+                /*allow_x509=*/ &true.as_bytes(),
+                &cert_chain,
+            ])
+            .unwrap();
         let answer = env.crypto.derive_cdi(&digest, b"DPE").unwrap();
         assert_eq!(answer, cdi_with_internal_input_dice)
     }

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -19,8 +19,7 @@ use caliptra_cfi_lib::cfi_launder;
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool};
 use caliptra_dpe_crypto::{
     ecdsa::{EcdsaPubKey, EcdsaSignature},
-    Crypto, CryptoError, CryptoSuite, Digest, Hasher, PubKey, SignData, Signature,
-    MAX_EXPORTED_CDI_SIZE,
+    Crypto, CryptoError, CryptoSuite, Digest, PubKey, SignData, Signature, MAX_EXPORTED_CDI_SIZE,
 };
 #[cfg(not(feature = "disable_x509"))]
 use caliptra_dpe_platform::CertValidity;
@@ -2774,21 +2773,14 @@ fn get_subject_key_identifier(
     subject_key_identifier: &mut [u8],
 ) -> Result<(), DpeErrorCode> {
     // compute key identifier as SHA hash of the DER encoded subject public key
-    let mut hasher = env.crypto.hash_initialize()?;
-    match pub_key {
+    let hashed_pub_key = match pub_key {
         PubKey::Ecdsa(pub_key) => {
             let (x, y) = pub_key.as_slice();
-            hasher.update(&[0x04])?;
-            hasher.update(x)?;
-            hasher.update(y)?;
+            env.crypto.hash_all(&[&[0x04], &x, &y])?
         }
         #[cfg(feature = "ml-dsa")]
-        PubKey::Mldsa(pub_key) => {
-            hasher.update(pub_key.as_slice())?;
-        }
-    }
-
-    let hashed_pub_key = hasher.finish()?;
+        PubKey::Mldsa(pub_key) => env.crypto.hash(pub_key.as_slice())?,
+    };
     if hashed_pub_key.size() < MAX_KEY_IDENTIFIER_SIZE {
         return Err(DpeErrorCode::InternalError);
     }


### PR DESCRIPTION
This converts the `Hasher` struct to no longer be `Sized` which will make it easier to start making the `Crypto` trait dyn compatible.