### PR TITLE
[x509]: Don't encode default values in a set or sequence (1.x)

### DIFF
--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -393,6 +393,7 @@ impl CertWriter<'_> {
     /// Get the size of a tcg-dice-MultiTcbInfo extension, including the extension
     /// OID and critical bits.
     fn get_multi_tcb_info_size(
+        &self,
         measurements: &MeasurementData,
         tagged: bool,
     ) -> Result<usize, DpeErrorCode> {
@@ -411,38 +412,54 @@ impl CertWriter<'_> {
         // Size of tcb infos including SEQUENCE OF tag/size
         let multi_tcb_info_size = Self::get_structure_size(tcb_infos_size, /*tagged=*/ true)?;
 
-        let size = Self::get_structure_size(Self::MULTI_TCBINFO_OID.len(), /*tagged=*/true)? // Extension OID
-            + Self::get_structure_size(1, /*tagged=*/true)? // Critical bool
+        let mut size = Self::get_structure_size(Self::MULTI_TCBINFO_OID.len(), /*tagged=*/true)? // Extension OID
             + Self::get_structure_size(multi_tcb_info_size, /*tagged=*/true)?; // OCTET STRING
+
+        if self.crit_dice {
+            size += Self::get_structure_size(1, /*tagged=*/ true)?; // Critical bool
+        }
 
         Self::get_structure_size(size, tagged)
     }
 
     /// Get the size of a tcg-dice-Ueid extension, including the extension
     /// OID and critical bits.
-    fn get_ueid_size(measurements: &MeasurementData, tagged: bool) -> Result<usize, DpeErrorCode> {
+    fn get_ueid_size(
+        &self,
+        measurements: &MeasurementData,
+        tagged: bool,
+    ) -> Result<usize, DpeErrorCode> {
         // Extension data is sequence -> octet string. To compute size, wrap
         // in tagging twice.
         let ext_size = Self::get_structure_size(
             Self::get_structure_size(measurements.label.len(), /*tagged=*/ true)?,
             /*tagged=*/ true,
         )?;
-        let size = Self::get_structure_size(Self::UEID_OID.len(), /*tagged=*/true)? // Extension OID
-            + Self::get_structure_size(1, /*tagged=*/true)? // Critical bool
+        let mut size = Self::get_structure_size(Self::UEID_OID.len(), /*tagged=*/true)? // Extension OID
             + Self::get_structure_size(ext_size, /*tagged=*/true)?; // OCTET STRING
+
+        if self.crit_dice {
+            size += Self::get_structure_size(Self::BOOL_SIZE, /*tagged=*/ true)?;
+            // Critical bool
+        }
 
         Self::get_structure_size(size, tagged)
     }
 
     /// Get the size of a basicConstraints extension, including the extension
     /// OID and critical bits.
-    fn get_basic_constraints_size(tagged: bool) -> Result<usize, DpeErrorCode> {
+    fn get_basic_constraints_size(
+        measurements: &MeasurementData,
+        tagged: bool,
+    ) -> Result<usize, DpeErrorCode> {
         // Extension data is sequence -> octet string. To compute size, wrap
         // in tagging twice.
-        let ext_size = Self::get_structure_size(
-            Self::get_structure_size(Self::BOOL_SIZE, /*tagged=*/ true)?,
-            /*tagged=*/ true,
-        )?;
+        let ca_size = if measurements.is_ca {
+            Self::get_structure_size(Self::BOOL_SIZE, /*tagged=*/ true)?
+        } else {
+            0
+        };
+        let ext_size = Self::get_structure_size(ca_size, /*tagged=*/ true)?;
         let size = Self::get_structure_size(Self::BASIC_CONSTRAINTS_OID.len(), /*tagged=*/true)? // Extension OID
             + Self::get_structure_size(Self::BOOL_SIZE, /*tagged=*/true)? // Critical bool
             + Self::get_structure_size(ext_size, /*tagged=*/true)?; // OCTET STRING
@@ -503,7 +520,6 @@ impl CertWriter<'_> {
         // in tagging twice.
         let ext_size = Self::get_structure_size(ski_size, /*tagged=*/ true)?;
         let size = Self::get_structure_size(Self::SUBJECT_KEY_IDENTIFIER_OID.len(), /*tagged=*/true)? // Extension OID
-            + Self::get_structure_size(Self::BOOL_SIZE, /*tagged=*/true)? // Critical bool
             + Self::get_structure_size(ext_size, /*tagged=*/true)?; // OCTET STRING
 
         Self::get_structure_size(size, tagged)
@@ -578,14 +594,15 @@ impl CertWriter<'_> {
 
     /// Get the size of the TBS Extensions field.
     fn get_extensions_size(
+        &self,
         measurements: &MeasurementData,
         tagged: bool,
         explicit: bool,
         is_x509: bool,
     ) -> Result<usize, DpeErrorCode> {
-        let mut size = Self::get_multi_tcb_info_size(measurements, /*tagged=*/ true)?
-            + Self::get_ueid_size(measurements, /*tagged=*/ true)?
-            + Self::get_basic_constraints_size(/*tagged=*/ true)?
+        let mut size = self.get_multi_tcb_info_size(measurements, /*tagged=*/ true)?
+            + self.get_ueid_size(measurements, /*tagged=*/ true)?
+            + Self::get_basic_constraints_size(measurements, /*tagged=*/ true)?
             + Self::get_key_usage_size(/*tagged=*/ true)?
             + Self::get_extended_key_usage_size(measurements, /*tagged=*/ true)?
             + Self::get_subject_key_identifier_extension_size(
@@ -608,8 +625,10 @@ impl CertWriter<'_> {
 
     /// Get the size of the ASN.1 TBSCertificate structure
     /// If `tagged`, include the tag and size fields
+    #[allow(clippy::too_many_arguments)]
     #[cfg(not(feature = "disable_x509"))]
     fn get_tbs_size(
+        &self,
         serial_number: &[u8],
         issuer_der: &[u8],
         subject_name: &Name,
@@ -625,7 +644,7 @@ impl CertWriter<'_> {
             + Self::get_validity_size(validity, /*tagged=*/ true)?
             + Self::get_rdn_size(subject_name, /*tagged=*/ true)?
             + Self::get_ecdsa_subject_pubkey_info_size(pubkey, /*tagged=*/ true)?
-            + Self::get_extensions_size(
+            + self.get_extensions_size(
                 measurements,
                 /*tagged=*/ true,
                 /*explicit=*/ true,
@@ -639,6 +658,7 @@ impl CertWriter<'_> {
     /// If `tagged`, include the tag and size fields
     #[cfg(not(feature = "disable_csr"))]
     fn get_certification_request_info_size(
+        &self,
         subject_name: &Name,
         pubkey: &EcdsaPub,
         measurements: &MeasurementData,
@@ -647,7 +667,7 @@ impl CertWriter<'_> {
         let cert_req_info_size = Self::get_integer_size(Self::CSR_V0, true)?
             + Self::get_rdn_size(subject_name, /*tagged=*/ true)?
             + Self::get_ecdsa_subject_pubkey_info_size(pubkey, /*tagged=*/ true)?
-            + Self::get_attributes_size(measurements, /*tagged=*/ true)?;
+            + self.get_attributes_size(measurements, /*tagged=*/ true)?;
 
         Self::get_structure_size(cert_req_info_size, tagged)
     }
@@ -808,13 +828,14 @@ impl CertWriter<'_> {
     /// If `tagged`, include the tag and size fields
     #[cfg(not(feature = "disable_csr"))]
     fn get_attribute_size(
+        &self,
         measurements: &MeasurementData,
         tagged: bool,
     ) -> Result<usize, DpeErrorCode> {
         let attribute_size =
             Self::get_structure_size(Self::ID_DATA_OID.len(), /*tagged=*/ true)?
                 + Self::get_structure_size(
-                    Self::get_extensions_size(
+                    self.get_extensions_size(
                         measurements,
                         /*tagged=*/ true,
                         /*explicit=*/ false,
@@ -830,10 +851,11 @@ impl CertWriter<'_> {
     /// If `tagged`, include the tag and size fields
     #[cfg(not(feature = "disable_csr"))]
     fn get_attributes_size(
+        &self,
         measurements: &MeasurementData,
         tagged: bool,
     ) -> Result<usize, DpeErrorCode> {
-        let attribute_size = Self::get_attribute_size(measurements, /*tagged=*/ true)?;
+        let attribute_size = self.get_attribute_size(measurements, /*tagged=*/ true)?;
 
         Self::get_structure_size(attribute_size, tagged)
     }
@@ -1287,17 +1309,18 @@ impl CertWriter<'_> {
         measurements: &MeasurementData,
     ) -> Result<usize, DpeErrorCode> {
         let multi_tcb_info_size =
-            Self::get_multi_tcb_info_size(measurements, /*tagged=*/ false)?;
+            self.get_multi_tcb_info_size(measurements, /*tagged=*/ false)?;
 
         // Encode Extension
         let mut bytes_written = self.encode_byte(Self::SEQUENCE_TAG)?;
         bytes_written += self.encode_size_field(multi_tcb_info_size)?;
         bytes_written += self.encode_oid(Self::MULTI_TCBINFO_OID)?;
 
-        let crit = if self.crit_dice { 0xFF } else { 0x00 };
-        bytes_written += self.encode_byte(Self::BOOL_TAG)?;
-        bytes_written += self.encode_size_field(Self::BOOL_SIZE)?;
-        bytes_written += self.encode_byte(crit)?;
+        if self.crit_dice {
+            bytes_written += self.encode_byte(Self::BOOL_TAG)?;
+            bytes_written += self.encode_size_field(Self::BOOL_SIZE)?;
+            bytes_written += self.encode_byte(0xFF)?;
+        }
 
         let tcb_infos_size = if !measurements.tci_nodes.is_empty() {
             Self::get_tcb_info_size(
@@ -1330,17 +1353,18 @@ impl CertWriter<'_> {
     ///
     /// https://trustedcomputinggroup.org/wp-content/uploads/TCG_DICE_Attestation_Architecture_r22_02dec2020.pdf
     fn encode_ueid(&mut self, measurements: &MeasurementData) -> Result<usize, DpeErrorCode> {
-        let ueid_size = Self::get_ueid_size(measurements, /*tagged=*/ false)?;
+        let ueid_size = self.get_ueid_size(measurements, /*tagged=*/ false)?;
 
         // Encode Extension
         let mut bytes_written = self.encode_byte(Self::SEQUENCE_TAG)?;
         bytes_written += self.encode_size_field(ueid_size)?;
         bytes_written += self.encode_oid(Self::UEID_OID)?;
 
-        let crit = if self.crit_dice { 0xFF } else { 0x00 };
-        bytes_written += self.encode_byte(Self::BOOL_TAG)?;
-        bytes_written += self.encode_size_field(Self::BOOL_SIZE)?;
-        bytes_written += self.encode_byte(crit)?;
+        if self.crit_dice {
+            bytes_written += self.encode_byte(Self::BOOL_TAG)?;
+            bytes_written += self.encode_size_field(Self::BOOL_SIZE)?;
+            bytes_written += self.encode_byte(0xFF)?;
+        }
 
         // Extension data is sequence -> octet string. To compute size, wrap
         // in tagging twice.
@@ -1375,7 +1399,8 @@ impl CertWriter<'_> {
         &mut self,
         measurements: &MeasurementData,
     ) -> Result<usize, DpeErrorCode> {
-        let basic_constraints_size = Self::get_basic_constraints_size(/*tagged=*/ false)?;
+        let basic_constraints_size =
+            Self::get_basic_constraints_size(measurements, /*tagged=*/ false)?;
 
         // Encode Extension
         let mut bytes_written = self.encode_byte(Self::SEQUENCE_TAG)?;
@@ -1388,25 +1413,23 @@ impl CertWriter<'_> {
 
         // Extension data is sequence -> octet string. To compute size, wrap
         // in tagging twice.
+        let ca_size = if measurements.is_ca {
+            Self::get_structure_size(1, /*tagged=*/ true)?
+        } else {
+            0
+        };
         bytes_written += self.encode_byte(Self::OCTET_STRING_TAG)?;
-        bytes_written += self.encode_size_field(Self::get_structure_size(
-            Self::get_structure_size(1, /*tagged=*/ true)?,
-            /*tagged=*/ true,
-        )?)?;
+        bytes_written +=
+            self.encode_size_field(Self::get_structure_size(ca_size, /*tagged=*/ true)?)?;
 
         // Sequence size to just a tagged bool
         bytes_written += self.encode_byte(Self::SEQUENCE_TAG)?;
-        bytes_written += self.encode_size_field(Self::get_structure_size(
-            Self::BOOL_SIZE,
-            /*tagged=*/ true,
-        )?)?;
+        bytes_written += self.encode_size_field(ca_size)?;
 
-        bytes_written += self.encode_byte(Self::BOOL_TAG)?;
-        bytes_written += self.encode_size_field(Self::BOOL_SIZE)?;
         if measurements.is_ca {
+            bytes_written += self.encode_byte(Self::BOOL_TAG)?;
+            bytes_written += self.encode_size_field(Self::BOOL_SIZE)?;
             bytes_written += self.encode_byte(0xFF)?;
-        } else {
-            bytes_written += self.encode_byte(0x00)?;
         }
 
         Ok(bytes_written)
@@ -1666,11 +1689,6 @@ impl CertWriter<'_> {
         bytes_written += self.encode_size_field(ski_extension_size)?;
         bytes_written += self.encode_oid(Self::SUBJECT_KEY_IDENTIFIER_OID)?;
 
-        bytes_written += self.encode_byte(Self::BOOL_TAG)?;
-        bytes_written += self.encode_size_field(Self::BOOL_SIZE)?;
-        // subject key identifier extension must NOT be marked critical
-        bytes_written += self.encode_byte(0x00)?;
-
         // Extension data is sequence -> octet string. To compute size, wrap
         // in tagging once.
         bytes_written += self.encode_byte(Self::OCTET_STRING_TAG)?;
@@ -1696,7 +1714,7 @@ impl CertWriter<'_> {
         if is_x509 {
             // Extensions is EXPLICIT field number 3
             bytes_written += self.encode_byte(Self::CONTEXT_SPECIFIC | Self::CONSTRUCTED | 0x03)?;
-            bytes_written += self.encode_size_field(Self::get_extensions_size(
+            bytes_written += self.encode_size_field(self.get_extensions_size(
                 measurements,
                 /*tagged=*/ true,
                 /*explicit=*/ false,
@@ -1706,7 +1724,7 @@ impl CertWriter<'_> {
 
         // SEQUENCE OF Extension
         bytes_written += self.encode_byte(Self::SEQUENCE_OF_TAG)?;
-        bytes_written += self.encode_size_field(Self::get_extensions_size(
+        bytes_written += self.encode_size_field(self.get_extensions_size(
             measurements,
             /*tagged=*/ false,
             /*explicit=*/ false,
@@ -1809,22 +1827,18 @@ impl CertWriter<'_> {
         // Attributes is EXPLICIT field number 0
         let mut bytes_written =
             self.encode_byte(Self::CONTEXT_SPECIFIC | Self::CONSTRUCTED | 0x0)?;
-        bytes_written += self.encode_size_field(Self::get_attributes_size(
-            measurements,
-            /*tagged=*/ false,
-        )?)?;
+        bytes_written +=
+            self.encode_size_field(self.get_attributes_size(measurements, /*tagged=*/ false)?)?;
 
         // Attribute Sequence
         bytes_written += self.encode_tag_field(Self::SEQUENCE_TAG)?;
-        bytes_written += self.encode_size_field(Self::get_attribute_size(
-            measurements,
-            /*tagged=*/ false,
-        )?)?;
+        bytes_written +=
+            self.encode_size_field(self.get_attribute_size(measurements, /*tagged=*/ false)?)?;
         bytes_written += self.encode_oid(Self::EXTENSION_REQUEST_OID)?;
 
         // attrValues SET OF
         bytes_written += self.encode_tag_field(Self::SET_OF_TAG)?;
-        bytes_written += self.encode_size_field(Self::get_extensions_size(
+        bytes_written += self.encode_size_field(self.get_extensions_size(
             measurements,
             /*tagged=*/ true,
             /*explicit=*/ false,
@@ -2055,7 +2069,7 @@ impl CertWriter<'_> {
         measurements: &MeasurementData,
         validity: &CertValidity,
     ) -> Result<usize, DpeErrorCode> {
-        let tbs_size = Self::get_tbs_size(
+        let tbs_size = self.get_tbs_size(
             serial_number,
             issuer_name,
             subject_name,
@@ -2153,7 +2167,7 @@ impl CertWriter<'_> {
         subject_name: &Name,
         measurements: &MeasurementData,
     ) -> Result<usize, DpeErrorCode> {
-        let cert_req_info_size = Self::get_certification_request_info_size(
+        let cert_req_info_size = self.get_certification_request_info_size(
             subject_name,
             pub_key,
             measurements,

--- a/verification/testing/certs.go
+++ b/verification/testing/certs.go
@@ -33,7 +33,7 @@ var (
 
 // BasicConstraints represents an X.509 BasicConstraints extension
 type BasicConstraints struct {
-	IsCA              bool `asn1`
+	IsCA              bool `asn1:"optional,default:false"`
 	PathLenConstraint int  `asn1:"optional"`
 }
 


### PR DESCRIPTION
This resolves additional issues related to https://github.com/chipsalliance/caliptra-dpe/issues/513

cherry-pick of 34c849542c5787eb580078002dd815de68ae58c7 (#535)