### PR TITLE
Make DpeEnv a `dyn trait`

### DIFF
--- a/dpe/fuzz/src/fuzz_target_1.rs
+++ b/dpe/fuzz/src/fuzz_target_1.rs
@@ -17,7 +17,7 @@ use simplelog::{Config, WriteLogger};
 use std::fs::OpenOptions;
 
 use caliptra_dpe::{
-    dpe_instance::DpeEnv, response::Response, support::Support, DpeInstance, DpeProfile,
+    dpe_instance::DpeEnvImpl, response::Response, support::Support, DpeInstance, DpeProfile,
 };
 use caliptra_dpe_platform::default::{DefaultPlatform, DefaultPlatformProfile, AUTO_INIT_LOCALITY};
 
@@ -41,7 +41,7 @@ fn harness(data: &[u8]) {
             .unwrap(),
     );
 
-    let mut env = DpeEnv {
+    let mut env = DpeEnvImpl {
         crypto: &mut RustCryptoImpl::new_ecc256(),
         platform: &mut DefaultPlatform(DefaultPlatformProfile::P256),
         state: &mut caliptra_dpe::State::new(SUPPORT, DpeFlags::empty()),

--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -138,7 +138,7 @@ impl CommandExecution for CertifyKeyCommand<'_> {
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode> {
@@ -150,17 +150,17 @@ impl CommandExecution for CertifyKeyCommand<'_> {
             #[cfg(feature = "ml-dsa")]
             CertifyKeyCommand::Mldsa87(cmd) => (&cmd.handle, cmd.format, cmd.label.as_slice()),
         };
-        let idx = env.state.get_active_context_pos(handle, locality)?;
-        let context = &env.state.contexts[idx];
+        let idx = env.state().get_active_context_pos(handle, locality)?;
+        let context = env.state().contexts[idx];
 
         if format == Self::FORMAT_X509 {
-            if !env.state.support.x509() {
+            if !env.state().support.x509() {
                 return Err(DpeErrorCode::ArgumentNotSupported);
             }
             if !context.allow_x509() {
                 return Err(DpeErrorCode::InvalidArgument);
             }
-        } else if format == Self::FORMAT_CSR && !env.state.support.csr() {
+        } else if format == Self::FORMAT_CSR && !env.state().support.csr() {
             return Err(DpeErrorCode::ArgumentNotSupported);
         }
 
@@ -171,9 +171,9 @@ impl CommandExecution for CertifyKeyCommand<'_> {
 
         cfg_if! {
             if #[cfg(feature = "cfi")] {
-                cfi_assert!(format != Self::FORMAT_X509 || env.state.support.x509());
+                cfi_assert!(format != Self::FORMAT_X509 || env.state().support.x509());
                 cfi_assert!(format != Self::FORMAT_X509 || context.allow_x509());
-                cfi_assert!(format != Self::FORMAT_CSR || env.state.support.csr());
+                cfi_assert!(format != Self::FORMAT_CSR || env.state().support.csr());
                 cfi_assert_eq(context.locality, locality);
             }
         }
@@ -187,7 +187,7 @@ impl CommandExecution for CertifyKeyCommand<'_> {
             context: profile.key_context(),
             ueid: label,
             dice_extensions_are_critical: env
-                .state
+                .state()
                 .flags
                 .contains(DpeFlags::MARK_DICE_EXTENSIONS_CRITICAL),
         };
@@ -268,7 +268,7 @@ impl CommandExecution for CertifyKeyCommand<'_> {
         let len = response.size()?;
         // Rotate handle if it isn't the default
         dpe.roll_onetime_use_handle(env, idx)?;
-        response.set_handle(env.state.contexts[idx].handle);
+        response.set_handle(env.state().contexts[idx].handle);
 
         Ok(len)
     }
@@ -289,7 +289,7 @@ impl CommandExecution for CertifyKeyP256Cmd {
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode> {
@@ -323,7 +323,7 @@ impl CommandExecution for CertifyKeyP384Cmd {
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode> {
@@ -357,7 +357,7 @@ impl CommandExecution for CertifyKeyMldsa87Cmd {
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode> {

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -189,11 +189,11 @@ impl CommandExecution for DeriveContextCmd {
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode> {
-        let support = env.state.support;
+        let support = env.state().support;
         let DeriveContextCmd {
             ref handle,
             ref data,
@@ -214,15 +214,15 @@ impl CommandExecution for DeriveContextCmd {
             return Err(DpeErrorCode::ArgumentNotSupported);
         }
 
-        let parent_idx = env.state.get_active_context_pos(handle, locality)?;
+        let parent_idx = env.state().get_active_context_pos(handle, locality)?;
 
-        if (!env.state.contexts[parent_idx].allow_x509() && flags.allows_x509())
+        if (!env.state().contexts[parent_idx].allow_x509() && flags.allows_x509())
             || (flags.exports_cdi() && !flags.creates_certificate())
             || (flags.exports_cdi() && flags.is_recursive())
             || (flags.exports_cdi() && flags.changes_locality())
             || (flags.exports_cdi()
-                && env.state.contexts[parent_idx].context_type == ContextType::Simulation)
-            || (flags.exports_cdi() && !env.state.contexts[parent_idx].allow_export_cdi())
+                && env.state().contexts[parent_idx].context_type == ContextType::Simulation)
+            || (flags.exports_cdi() && !env.state().contexts[parent_idx].allow_export_cdi())
             || (flags.is_recursive() && flags.retains_parent())
         {
             return Err(DpeErrorCode::InvalidArgument);
@@ -244,7 +244,7 @@ impl CommandExecution for DeriveContextCmd {
                 cfi_assert!(support.internal_dice() || !flags.uses_internal_dice_input());
                 cfi_assert!(support.retain_parent_context() || !flags.retains_parent());
                 cfi_assert!(support.x509() || !flags.allows_x509());
-                cfi_assert!(env.state.contexts[parent_idx].allow_x509() || !flags.allows_x509());
+                cfi_assert!(env.state().contexts[parent_idx].allow_x509() || !flags.allows_x509());
                 cfi_assert!(!flags.is_recursive() || !flags.retains_parent());
             }
         }
@@ -253,7 +253,7 @@ impl CommandExecution for DeriveContextCmd {
             cfg_if! {
                 if #[cfg(not(feature = "disable_recursive"))] {
                     let response = mutresp::<DeriveContextResp>(dpe.profile, out)?;
-                    let mut tmp_context = env.state.contexts[parent_idx];
+                    let mut tmp_context = env.state().contexts[parent_idx];
                     if tmp_context.tci.tci_type != tci_type {
                         return Err(DpeErrorCode::InvalidArgument);
                     } else {
@@ -270,14 +270,14 @@ impl CommandExecution for DeriveContextCmd {
                     // Rotate the handle if it isn't the default context.
                     dpe.roll_onetime_use_handle(env, parent_idx)?;
 
-                    env.state.contexts[parent_idx] = Context {
-                        handle: env.state.contexts[parent_idx].handle,
+                    env.state().contexts[parent_idx] = Context {
+                        handle: env.state().contexts[parent_idx].handle,
                         ..tmp_context
                     };
 
                     // Return new handle in new_context_handle
                     *response = DeriveContextResp {
-                        handle: env.state.contexts[parent_idx].handle,
+                        handle: env.state().contexts[parent_idx].handle,
                         // Should be ignored since retain_parent cannot be true
                         parent_handle: ContextHandle::default(),
                         resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
@@ -290,7 +290,7 @@ impl CommandExecution for DeriveContextCmd {
         }
 
         // Copy the parent context to mutate so that we avoid mutating internal state upon an error.
-        let mut tmp_parent_context = env.state.contexts[parent_idx];
+        let mut tmp_parent_context = env.state().contexts[parent_idx];
         if flags.retains_parent() {
             if !tmp_parent_context.handle.is_default() {
                 tmp_parent_context.handle = dpe.generate_new_handle(env)?;
@@ -313,7 +313,7 @@ impl CommandExecution for DeriveContextCmd {
             cfg_if! {
                 if #[cfg(not(feature = "disable_export_cdi"))] {
                     let response = mutresp::<DeriveContextExportedCdiResp>(dpe.profile, out)?;
-                    let ueid = &env.platform.get_ueid()?;
+                    let ueid = &env.platform().get_ueid()?;
                     let ueid = ueid.get()?;
                     let args = CreateDpeCertArgs {
                         handle,
@@ -322,7 +322,7 @@ impl CommandExecution for DeriveContextCmd {
                         key_label: b"Exported ECC",
                         context: b"Exported ECC",
                         ueid,
-                        dice_extensions_are_critical: env.state.flags.contains(DpeFlags::MARK_DICE_EXTENSIONS_CRITICAL),
+                        dice_extensions_are_critical: env.state().flags.contains(DpeFlags::MARK_DICE_EXTENSIONS_CRITICAL),
                     };
                     let result = create_exported_dpe_cert(
                         &args,
@@ -332,19 +332,19 @@ impl CommandExecution for DeriveContextCmd {
                     );
                     let CreateDpeCertResult { cert_size, exported_cdi_handle, .. } = okref(&result)?;
 
-                    if !flags.retains_parent() && !env.state.contexts[parent_idx].has_children() {
+                    if !flags.retains_parent() && !env.state().contexts[parent_idx].has_children() {
                         // When the parent is not retained and there are no other children,
                         // destroy it.
-                        destroy_context::destroy_context(handle, env.state, locality)?;
+                        destroy_context::destroy_context(handle, env.state(), locality)?;
                     } else {
                         // We either retained the parent or it has other children, so retire it and
                         // make it's handle invalid.
                         // At this point we cannot error out anymore, so it is safe to set the parent context.
-                        env.state.contexts[parent_idx] = tmp_parent_context;
+                        env.state().contexts[parent_idx] = tmp_parent_context;
                     }
 
                     response.handle = ContextHandle::new_invalid();
-                    response.parent_handle = env.state.contexts[parent_idx].handle;
+                    response.parent_handle = env.state().contexts[parent_idx].handle;
                     response.resp_hdr = dpe.response_hdr(DpeErrorCode::NoError);
                     response.exported_cdi = *exported_cdi_handle;
                     response.certificate_size = *cert_size;
@@ -358,11 +358,12 @@ impl CommandExecution for DeriveContextCmd {
         let response = mutresp::<DeriveContextResp>(dpe.profile, out)?;
 
         let child_idx = env
-            .state
+            .state()
             .get_next_inactive_context_pos()
             .ok_or(DpeErrorCode::MaxTcis)?;
 
-        let safe_to_make_child = self.safe_to_make_child(env.state, parent_idx, target_locality)?;
+        let safe_to_make_child =
+            self.safe_to_make_child(env.state(), parent_idx, target_locality)?;
         if !safe_to_make_child {
             return Err(DpeErrorCode::InvalidArgument);
         } else {
@@ -387,7 +388,7 @@ impl CommandExecution for DeriveContextCmd {
         // Create a temporary context to mutate so that we avoid mutating internal state upon an error.
         let mut tmp_child_context = Context::new();
         tmp_child_context.activate(&ActiveContextArgs {
-            context_type: env.state.contexts[parent_idx].context_type,
+            context_type: env.state().contexts[parent_idx].context_type,
             locality: target_locality,
             handle: &child_handle,
             tci_type,
@@ -407,12 +408,12 @@ impl CommandExecution for DeriveContextCmd {
         tmp_parent_context.children = children_with_child_idx;
 
         // At this point we cannot error out anymore, so it is safe to set the updated child and parent contexts.
-        env.state.contexts[child_idx] = tmp_child_context;
-        env.state.contexts[parent_idx] = tmp_parent_context;
+        env.state().contexts[child_idx] = tmp_child_context;
+        env.state().contexts[parent_idx] = tmp_parent_context;
 
         *response = DeriveContextResp {
             handle: child_handle,
-            parent_handle: env.state.contexts[parent_idx].handle,
+            parent_handle: env.state().contexts[parent_idx].handle,
             resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
         };
         Ok(size_of_val(response))
@@ -448,9 +449,7 @@ mod tests {
             CertifyKeyCommand, CertifyKeyFlags, Command, CommandHdr, InitCtxCmd, SignFlags,
         },
         context::ContextType,
-        dpe_instance::tests::{
-            new_crypto, DPE_PROFILE, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_LOCALITIES,
-        },
+        dpe_instance::tests::{DPE_PROFILE, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_LOCALITIES},
         response::{NewHandleResp, Response, SignResp},
         support::Support,
         test_env,
@@ -1776,7 +1775,7 @@ mod tests {
 
     fn derive_context_and_check_active_child_count(
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         cmd: DeriveContextCmd,
         expected_active_child_count: usize,
     ) -> (ContextHandle, ContextHandle) {
@@ -1792,7 +1791,7 @@ mod tests {
                 ..
             })) => {
                 assert_eq!(
-                    env.state
+                    env.state()
                         .count_contexts(|context: &Context| context.state == ContextState::Active),
                     Ok(expected_active_child_count)
                 );

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -90,12 +90,12 @@ impl CommandExecution for DestroyCtxCmd {
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode> {
         let response = mutresp::<ResponseHdr>(dpe.profile, out)?;
-        destroy_context(&self.handle, env.state, locality)?;
+        destroy_context(&self.handle, env.state(), locality)?;
         *response = dpe.response_hdr(DpeErrorCode::NoError);
         Ok(size_of_val(response))
     }

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -30,7 +30,7 @@ impl CommandExecution for GetCertificateChainCmd {
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         _locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode> {
@@ -42,7 +42,7 @@ impl CommandExecution for GetCertificateChainCmd {
 
         let mut cert_chunk = [0u8; MAX_CHUNK_SIZE];
         let len = env
-            .platform
+            .platform()
             .get_certificate_chain(self.offset, self.size, &mut cert_chunk)?;
         *response = GetCertificateChainResp {
             certificate_chain: cert_chunk,

--- a/dpe/src/commands/get_profile.rs
+++ b/dpe/src/commands/get_profile.rs
@@ -28,12 +28,13 @@ impl CommandExecution for GetProfileCmd {
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         _locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode> {
         let response = mutresp::<GetProfileResp>(dpe.profile, out)?;
-        *response = dpe.get_profile(env.platform, env.state.support)?;
+        let support = env.state().support;
+        *response = dpe.get_profile(env.platform(), support)?;
 
         Ok(size_of_val(response))
     }

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -56,15 +56,15 @@ impl CommandExecution for InitCtxCmd {
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode> {
         let response = mutresp::<NewHandleResp>(dpe.profile, out)?;
 
         // This function can only be called once for non-simulation contexts.
-        if (self.flag_is_default() && env.state.has_initialized())
-            || (self.flag_is_simulation() && !env.state.support.simulation())
+        if (self.flag_is_default() && env.state().has_initialized())
+            || (self.flag_is_simulation() && !env.state().support.simulation())
         {
             return Err(DpeErrorCode::ArgumentNotSupported);
         }
@@ -78,25 +78,25 @@ impl CommandExecution for InitCtxCmd {
 
         cfg_if! {
             if #[cfg(feature = "cfi")] {
-                cfi_assert!(!self.flag_is_default() || !env.state.has_initialized());
-                cfi_assert!(!self.flag_is_simulation() || env.state.support.simulation());
+                cfi_assert!(!self.flag_is_default() || !env.state().has_initialized());
+                cfi_assert!(!self.flag_is_simulation() || env.state().support.simulation());
                 cfi_assert!(self.flag_is_default() ^ self.flag_is_simulation());
             }
         }
 
         let idx = env
-            .state
+            .state()
             .get_next_inactive_context_pos()
             .ok_or(DpeErrorCode::MaxTcis)?;
         let (context_type, handle) = if self.flag_is_default() {
-            env.state.has_initialized = true.into();
+            env.state().has_initialized = true.into();
             (ContextType::Normal, ContextHandle::default())
         } else {
             // Simulation.
             (ContextType::Simulation, dpe.generate_new_handle(env)?)
         };
 
-        env.state.contexts[idx].activate(&ActiveContextArgs {
+        env.state().contexts[idx].activate(&ActiveContextArgs {
             context_type,
             locality,
             handle: &handle,

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -277,7 +277,7 @@ impl CommandExecution for Command<'_> {
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode> {
@@ -299,7 +299,7 @@ pub trait CommandExecution {
     fn execute<'a>(
         &'a self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         locality: u32,
     ) -> Result<Response, DpeErrorCode>
     where
@@ -318,7 +318,7 @@ pub trait CommandExecution {
     fn __cfi_execute<'a>(
         &'a self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         locality: u32,
     ) -> Result<Response, DpeErrorCode>
     where
@@ -332,7 +332,7 @@ pub trait CommandExecution {
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode>;
@@ -345,7 +345,7 @@ pub trait CommandExecution {
     fn __cfi_execute_serialized(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode>;

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -84,26 +84,26 @@ impl CommandExecution for RotateCtxCmd {
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode> {
-        if !env.state.support.rotate_context() {
+        if !env.state().support.rotate_context() {
             return Err(DpeErrorCode::InvalidCommand);
         } else {
             #[cfg(feature = "cfi")]
-            cfi_assert!(env.state.support.rotate_context());
+            cfi_assert!(env.state().support.rotate_context());
         }
         let response = mutresp::<NewHandleResp>(dpe.profile, out)?;
-        let idx = env.state.get_active_context_pos(&self.handle, locality)?;
+        let idx = env.state().get_active_context_pos(&self.handle, locality)?;
 
         // Make sure caller's locality does not already have a default context.
         if self.uses_target_is_default() {
             let default_context_idx = env
-                .state
+                .state()
                 .get_active_context_pos(&ContextHandle::default(), locality);
             let non_default_valid_handles_exist =
-                self.non_default_valid_handles_exist(env.state, locality, idx);
+                self.non_default_valid_handles_exist(env.state(), locality, idx);
             if default_context_idx.is_ok() || cfi_launder(non_default_valid_handles_exist) {
                 return Err(DpeErrorCode::InvalidArgument);
             } else {
@@ -120,7 +120,7 @@ impl CommandExecution for RotateCtxCmd {
         } else {
             dpe.generate_new_handle(env)?
         };
-        env.state.contexts[idx].handle = new_handle;
+        env.state().contexts[idx].handle = new_handle;
 
         *response = NewHandleResp {
             handle: new_handle,

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -138,7 +138,7 @@ impl CommandExecution for SignCommand<'_> {
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode> {
@@ -172,8 +172,8 @@ impl CommandExecution for SignCommand<'_> {
                 ),
             ),
         };
-        let idx = env.state.get_active_context_pos(handle, locality)?;
-        let context = &env.state.contexts[idx];
+        let idx = env.state().get_active_context_pos(handle, locality)?;
+        let context = &env.state().contexts[idx];
 
         if context.context_type == ContextType::Simulation {
             return Err(DpeErrorCode::InvalidArgument);
@@ -196,7 +196,7 @@ impl CommandExecution for SignCommand<'_> {
                 dpe.roll_onetime_use_handle(env, idx)?;
                 let (&sig_r, &sig_s) = sig.as_slice();
                 *response = SignP256Resp {
-                    new_context_handle: env.state.contexts[idx].handle,
+                    new_context_handle: env.state().contexts[idx].handle,
                     sig_r,
                     sig_s,
                     resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
@@ -212,7 +212,7 @@ impl CommandExecution for SignCommand<'_> {
                 dpe.roll_onetime_use_handle(env, idx)?;
                 let (&sig_r, &sig_s) = sig.as_slice();
                 *response = SignP384Resp {
-                    new_context_handle: env.state.contexts[idx].handle,
+                    new_context_handle: env.state().contexts[idx].handle,
                     sig_r,
                     sig_s,
                     resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
@@ -227,7 +227,7 @@ impl CommandExecution for SignCommand<'_> {
                 // Rotate the handle if it isn't the default context.
                 dpe.roll_onetime_use_handle(env, idx)?;
                 *response = SignMlDsaResp {
-                    new_context_handle: env.state.contexts[idx].handle,
+                    new_context_handle: env.state().contexts[idx].handle,
                     sig: *sig,
                     _padding: [0; 1],
                     resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
@@ -249,13 +249,13 @@ impl CommandExecution for SignCommand<'_> {
 /// * `digest` - The data to be signed
 fn sign(
     dpe: &mut DpeInstance,
-    env: &mut DpeEnv,
+    env: &mut dyn DpeEnv,
     idx: usize,
     label: &[u8],
     data: &SignData,
 ) -> Result<Signature, DpeErrorCode> {
     let cdi_digest = dpe.compute_measurement_hash(env, idx)?;
-    let cdi = env.crypto.derive_cdi(&cdi_digest, b"DPE")?;
+    let cdi = env.crypto().derive_cdi(&cdi_digest, b"DPE")?;
     let profile = dpe.profile;
     let context = profile.key_context();
     let key_pair = cdi.derive_key_pair(label, context);
@@ -285,7 +285,7 @@ impl CommandExecution for SignP256Cmd {
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode> {
@@ -308,7 +308,7 @@ impl CommandExecution for SignP384Cmd {
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode> {
@@ -331,7 +331,7 @@ impl CommandExecution for SignMldsa87Cmd {
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode> {
@@ -345,7 +345,7 @@ impl CommandExecution for SignMldsa87RawCmd {
     fn execute_serialized(
         &self,
         dpe: &mut DpeInstance,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode> {

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -26,10 +26,32 @@ use caliptra_dpe_platform::MAX_CHUNK_SIZE;
 use cfg_if::cfg_if;
 use zerocopy::IntoBytes;
 
-pub struct DpeEnv<'a> {
+pub trait DpeEnv {
+    fn crypto(&mut self) -> &mut dyn CryptoSuite;
+    fn platform(&mut self) -> &mut dyn Platform;
+    fn state(&mut self) -> &mut State;
+    fn get(&mut self) -> (&mut dyn CryptoSuite, &mut dyn Platform, &mut State);
+}
+
+pub struct DpeEnvImpl<'a> {
     pub crypto: &'a mut dyn CryptoSuite,
     pub platform: &'a mut dyn Platform,
     pub state: &'a mut State,
+}
+
+impl DpeEnv for DpeEnvImpl<'_> {
+    fn crypto(&mut self) -> &mut dyn CryptoSuite {
+        self.crypto
+    }
+    fn platform(&mut self) -> &mut dyn Platform {
+        self.platform
+    }
+    fn state(&mut self) -> &mut State {
+        self.state
+    }
+    fn get(&mut self) -> (&mut dyn CryptoSuite, &mut dyn Platform, &mut State) {
+        (self.crypto, self.platform, self.state)
+    }
 }
 
 pub struct DpeInstance {
@@ -52,15 +74,15 @@ impl DpeInstance {
     /// * `support` - optional functionality the instance supports
     /// * `flags` - configures `Self` behaviors.
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
-    pub fn new(env: &mut DpeEnv, profile: DpeProfile) -> Result<Self, DpeErrorCode> {
+    pub fn new(env: &mut dyn DpeEnv, profile: DpeProfile) -> Result<Self, DpeErrorCode> {
         let mut dpe = Self::initialized(profile);
 
-        if env.state.support.auto_init() {
-            let locality = env.platform.get_auto_init_locality()?;
+        if env.state().support.auto_init() {
+            let locality = env.platform().get_auto_init_locality()?;
             InitCtxCmd::new_use_default().execute(&mut dpe, env, locality)?;
         } else {
             #[cfg(feature = "cfi")]
-            cfi_assert!(!env.state.support.auto_init());
+            cfi_assert!(!env.state().support.auto_init());
         }
         Ok(dpe)
     }
@@ -77,29 +99,29 @@ impl DpeInstance {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[cfg(not(feature = "disable_auto_init"))]
     pub fn new_auto_init(
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         profile: DpeProfile,
         tci_type: u32,
         auto_init_measurement: &TciMeasurement,
     ) -> Result<Self, DpeErrorCode> {
         // auto-init must be supported to add an auto init measurement
-        if !env.state.support.auto_init() {
+        if !env.state().support.auto_init() {
             return Err(DpeErrorCode::ArgumentNotSupported);
         } else {
             #[cfg(feature = "cfi")]
-            cfi_assert!(env.state.support.auto_init());
+            cfi_assert!(env.state().support.auto_init());
         }
         let dpe = Self::new(env, profile)?;
 
-        let locality = env.platform.get_auto_init_locality()?;
+        let locality = env.platform().get_auto_init_locality()?;
         let idx = env
-            .state
+            .state()
             .get_active_context_pos(&ContextHandle::default(), locality)?;
-        let mut tmp_context = env.state.contexts[idx];
+        let mut tmp_context = env.state().contexts[idx];
         // add measurement to auto-initialized context
         dpe.add_tci_measurement(env, &mut tmp_context, auto_init_measurement, locality)?;
-        env.state.contexts[idx] = tmp_context;
-        env.state.contexts[idx].tci.tci_type = tci_type;
+        env.state().contexts[idx] = tmp_context;
+        env.state().contexts[idx].tci.tci_type = tci_type;
         Ok(dpe)
     }
 
@@ -128,7 +150,7 @@ impl DpeInstance {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     pub fn execute_serialized_command(
         &mut self,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         locality: u32,
         cmd: &[u8],
     ) -> Result<Response, DpeErrorCode> {
@@ -172,12 +194,17 @@ impl DpeInstance {
     /// * `env` - DPE environment containing Crypto and Platform implementations
     pub(crate) fn generate_new_handle(
         &self,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
     ) -> Result<ContextHandle, DpeErrorCode> {
         for _ in 0..Self::MAX_NEW_HANDLE_ATTEMPTS {
             let mut handle = ContextHandle::default();
-            env.crypto.rand_bytes(&mut handle.0)?;
-            if !handle.is_default() && !env.state.contexts.iter().any(|c| c.handle.equals(&handle))
+            env.crypto().rand_bytes(&mut handle.0)?;
+            if !handle.is_default()
+                && !env
+                    .state()
+                    .contexts
+                    .iter()
+                    .any(|c| c.handle.equals(&handle))
             {
                 return Ok(handle);
             }
@@ -193,17 +220,17 @@ impl DpeInstance {
     /// * `idx` - the index of the context
     pub fn roll_onetime_use_handle(
         &mut self,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         idx: usize,
     ) -> Result<(), DpeErrorCode> {
         if idx >= MAX_HANDLES {
             return Err(DpeErrorCode::MaxTcis);
         }
-        if !env.state.contexts[idx].handle.is_default() {
-            env.state.contexts[idx].handle = self.generate_new_handle(env)?;
+        if !env.state().contexts[idx].handle.is_default() {
+            env.state().contexts[idx].handle = self.generate_new_handle(env)?;
         } else {
             #[cfg(feature = "cfi")]
-            cfi_assert!(env.state.contexts[idx].handle.is_default());
+            cfi_assert!(env.state().contexts[idx].handle.is_default());
         }
         Ok(())
     }
@@ -220,7 +247,7 @@ impl DpeInstance {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     pub(crate) fn add_tci_measurement(
         &self,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         context: &mut Context,
         measurement: &TciMeasurement,
         locality: u32,
@@ -240,7 +267,7 @@ impl DpeInstance {
 
         // Derive the new TCI as HASH(TCI_CUMULATIVE || INPUT_DATA).
         let digest = env
-            .crypto
+            .crypto()
             .hash_all(&[&context.tci.tci_cumulative.0, &measurement.0])?;
 
         let digest_bytes = digest.as_slice();
@@ -294,17 +321,18 @@ impl DpeInstance {
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     pub(crate) fn compute_measurement_hash(
         &mut self,
-        env: &mut DpeEnv,
+        env: &mut dyn DpeEnv,
         start_idx: usize,
     ) -> Result<Digest, DpeErrorCode> {
-        let hasher = env.crypto.hasher()?;
+        let (crypto, platform, state) = env.get();
+        let hasher = crypto.hasher()?;
         hasher.initialize()?;
 
         let mut uses_internal_input_info = false;
         let mut uses_internal_input_dice = false;
 
         // Hash each node.
-        for status in ChildToRootIter::new(start_idx, &env.state.contexts) {
+        for status in ChildToRootIter::new(start_idx, &state.contexts) {
             let context = status?;
 
             hasher.update(context.tci.as_bytes())?;
@@ -323,11 +351,7 @@ impl DpeInstance {
         #[cfg(not(feature = "disable_internal_info"))]
         if cfi_launder(uses_internal_input_info) {
             let mut internal_input_info = [0u8; INTERNAL_INPUT_INFO_SIZE];
-            self.serialize_internal_input_info(
-                env.platform,
-                env.state.support,
-                &mut internal_input_info,
-            )?;
+            self.serialize_internal_input_info(platform, state.support, &mut internal_input_info)?;
             hasher.update(&internal_input_info[..INTERNAL_INPUT_INFO_SIZE])?;
         }
 
@@ -337,8 +361,7 @@ impl DpeInstance {
             let mut offset = 0;
             let mut cert_chunk = [0u8; MAX_CHUNK_SIZE];
             while let Ok(len) =
-                env.platform
-                    .get_certificate_chain(offset, MAX_CHUNK_SIZE as u32, &mut cert_chunk)
+                platform.get_certificate_chain(offset, MAX_CHUNK_SIZE as u32, &mut cert_chunk)
             {
                 hasher.update(&cert_chunk[..len as usize])?;
                 offset += len;
@@ -431,7 +454,7 @@ pub mod tests {
         ($env_name:ident, $state:expr) => {
             let mut crypto = $crate::dpe_instance::tests::new_crypto();
             let mut platform = $crate::commands::tests::DEFAULT_PLATFORM;
-            let mut $env_name = $crate::dpe_instance::DpeEnv {
+            let mut $env_name = $crate::dpe_instance::DpeEnvImpl {
                 crypto: &mut crypto,
                 platform: &mut platform,
                 state: $state,
@@ -588,10 +611,10 @@ pub mod tests {
             .get_active_context_pos(&ContextHandle::default(), TEST_LOCALITIES[0])
             .unwrap();
 
-        let digest = env
-            .crypto
+        let (crypto, _platform, state) = env.get();
+        let digest = crypto
             .with_hasher(&|hasher| {
-                for result in ChildToRootIter::new(leaf_idx, &env.state.contexts) {
+                for result in ChildToRootIter::new(leaf_idx, &state.contexts) {
                     let context = result.unwrap();
                     hasher.update(context.tci.as_bytes()).unwrap();
                     hasher
@@ -602,8 +625,7 @@ pub mod tests {
             })
             .unwrap();
 
-        let answer = env
-            .crypto
+        let answer = crypto
             .derive_cdi(&digest, b"DPE")
             .unwrap()
             .as_slice()

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -19,7 +19,7 @@ use caliptra_cfi_lib::cfi_launder;
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool};
 use caliptra_dpe_crypto::{
     ecdsa::{EcdsaPubKey, EcdsaSignature},
-    CryptoError, Digest, PubKey, SignData, Signature, MAX_EXPORTED_CDI_SIZE,
+    CryptoError, CryptoSuite, Digest, PubKey, SignData, Signature, MAX_EXPORTED_CDI_SIZE,
 };
 #[cfg(not(feature = "disable_x509"))]
 use caliptra_dpe_platform::CertValidity;
@@ -2721,22 +2721,22 @@ pub(crate) struct CreateDpeCertResult {
 
 fn get_dpe_measurement_digest(
     dpe: &mut DpeInstance,
-    env: &mut DpeEnv,
+    env: &mut dyn DpeEnv,
     handle: &ContextHandle,
     locality: u32,
 ) -> Result<Digest, DpeErrorCode> {
-    let parent_idx = env.state.get_active_context_pos(handle, locality)?;
+    let parent_idx = env.state().get_active_context_pos(handle, locality)?;
     let digest = dpe.compute_measurement_hash(env, parent_idx)?;
     Ok(digest)
 }
 
 fn get_subject_name<'a>(
-    env: &mut DpeEnv,
+    crypto: &mut dyn CryptoSuite,
     cert_type: &CertificateType,
     pub_key: &'a PubKey,
     subj_serial: &'a mut [u8],
 ) -> Result<Name<'a>, DpeErrorCode> {
-    env.crypto.get_pubkey_serial(pub_key, subj_serial)?;
+    crypto.get_pubkey_serial(pub_key, subj_serial)?;
 
     // The serial number of the subject can be at most 64 bytes
     let truncated_subj_serial = &subj_serial[..64];
@@ -2768,7 +2768,7 @@ fn get_tci_nodes<'a>(
 }
 
 fn get_subject_key_identifier(
-    env: &mut DpeEnv,
+    crypto: &mut dyn CryptoSuite,
     pub_key: &PubKey,
     subject_key_identifier: &mut [u8],
 ) -> Result<(), DpeErrorCode> {
@@ -2776,10 +2776,10 @@ fn get_subject_key_identifier(
     let hashed_pub_key = match pub_key {
         PubKey::Ecdsa(pub_key) => {
             let (x, y) = pub_key.as_slice();
-            env.crypto.hash_all(&[&[0x04], &x, &y])?
+            crypto.hash_all(&[&[0x04], &x, &y])?
         }
         #[cfg(feature = "ml-dsa")]
-        PubKey::Mldsa(pub_key) => env.crypto.hash(pub_key.as_slice())?,
+        PubKey::Mldsa(pub_key) => crypto.hash(pub_key.as_slice())?,
     };
     if hashed_pub_key.size() < MAX_KEY_IDENTIFIER_SIZE {
         return Err(DpeErrorCode::InternalError);
@@ -2792,7 +2792,7 @@ fn get_subject_key_identifier(
 pub(crate) fn create_exported_dpe_cert(
     args: &CreateDpeCertArgs,
     dpe: &mut DpeInstance,
-    env: &mut DpeEnv,
+    env: &mut dyn DpeEnv,
     cert: &mut [u8],
 ) -> Result<CreateDpeCertResult, DpeErrorCode> {
     create_dpe_cert_or_csr(
@@ -2808,7 +2808,7 @@ pub(crate) fn create_exported_dpe_cert(
 pub(crate) fn create_dpe_cert(
     args: &CreateDpeCertArgs,
     dpe: &mut DpeInstance,
-    env: &mut DpeEnv,
+    env: &mut dyn DpeEnv,
     cert: &mut [u8],
 ) -> Result<CreateDpeCertResult, DpeErrorCode> {
     create_dpe_cert_or_csr(
@@ -2825,7 +2825,7 @@ pub(crate) fn create_dpe_cert(
 pub(crate) fn create_dpe_csr(
     args: &CreateDpeCertArgs,
     dpe: &mut DpeInstance,
-    env: &mut DpeEnv,
+    env: &mut dyn DpeEnv,
     csr: &mut [u8],
 ) -> Result<CreateDpeCertResult, DpeErrorCode> {
     create_dpe_cert_or_csr(
@@ -2915,26 +2915,26 @@ fn generate_cert_or_csr(
 fn create_dpe_cert_or_csr(
     args: &CreateDpeCertArgs,
     dpe: &mut DpeInstance,
-    env: &mut DpeEnv,
+    env: &mut dyn DpeEnv,
     cert_format: CertificateFormat,
     cert_type: CertificateType,
     output_cert_or_csr: &mut [u8],
 ) -> Result<CreateDpeCertResult, DpeErrorCode> {
     let digest = get_dpe_measurement_digest(dpe, env, args.handle, args.locality)?;
+    let (crypto, platform, state) = env.get();
 
     let mut exported_cdi_handle = None;
 
     let pub_key = match cert_type {
         CertificateType::Exported => {
-            let exported_handle = env.crypto.derive_exported_cdi(&digest, args.cdi_label)?;
+            let exported_handle = crypto.derive_exported_cdi(&digest, args.cdi_label)?;
             exported_cdi_handle = Some(exported_handle);
-            env.crypto
+            crypto
                 .derive_key_pair_exported(&exported_handle, args.key_label, args.context)?
                 .public_key()
         }
         CertificateType::Leaf => {
-            env.crypto
-                .derive_pub_key(&digest, args.cdi_label, args.key_label, args.context)
+            crypto.derive_pub_key(&digest, args.cdi_label, args.key_label, args.context)
         }
     };
     if cfi_launder(pub_key.is_ok()) {
@@ -2946,20 +2946,19 @@ fn create_dpe_cert_or_csr(
     }
     let pub_key = okref(&pub_key)?;
     let mut subj_serial = [0u8; MAX_HASH_SIZE * 2];
-    let subject_name = get_subject_name(env, &cert_type, pub_key, &mut subj_serial)?;
+    let subject_name = get_subject_name(crypto, &cert_type, pub_key, &mut subj_serial)?;
 
     const INITIALIZER: TciNodeData = TciNodeData::new();
     let mut nodes = [INITIALIZER; MAX_HANDLES];
-    let tci_nodes = get_tci_nodes(env.state, args.handle, args.locality, &mut nodes)?;
+    let tci_nodes = get_tci_nodes(state, args.handle, args.locality, &mut nodes)?;
 
     let mut subject_key_identifier = [0u8; MAX_KEY_IDENTIFIER_SIZE];
-    get_subject_key_identifier(env, pub_key, &mut subject_key_identifier)?;
+    get_subject_key_identifier(crypto, pub_key, &mut subject_key_identifier)?;
 
     let mut authority_key_identifier = [0u8; MAX_KEY_IDENTIFIER_SIZE];
-    env.platform
-        .get_issuer_key_identifier(&mut authority_key_identifier)?;
+    platform.get_issuer_key_identifier(&mut authority_key_identifier)?;
 
-    let subject_alt_name = match env.platform.get_subject_alternative_name() {
+    let subject_alt_name = match platform.get_subject_alternative_name() {
         Ok(subject_alt_name) => Some(subject_alt_name),
         Err(PlatformError::NotImplemented) => None,
         Err(e) => Err(DpeErrorCode::Platform(e))?,
@@ -2971,7 +2970,7 @@ fn create_dpe_cert_or_csr(
     };
 
     let supports_recursive = match cert_type {
-        CertificateType::Leaf => env.state.support.recursive(),
+        CertificateType::Leaf => state.support.recursive(),
         CertificateType::Exported => false,
     };
 
@@ -2991,11 +2990,11 @@ fn create_dpe_cert_or_csr(
                 CertificateType::Exported => {
                     let exported_handle =
                         exported_cdi_handle.ok_or(CryptoError::CryptoLibError(0))?;
-                    env.crypto
+                    crypto
                         .derive_key_pair_exported(&exported_handle, args.key_label, args.context)?
                         .sign(&SignData::Raw(data))
                 }
-                CertificateType::Leaf => env.crypto.sign_with_derived(
+                CertificateType::Leaf => crypto.sign_with_derived(
                     &digest,
                     args.cdi_label,
                     args.key_label,
@@ -3004,17 +3003,17 @@ fn create_dpe_cert_or_csr(
                 ),
             }
         } else {
-            env.crypto.sign_with_alias(&SignData::Raw(data))
+            crypto.sign_with_alias(&SignData::Raw(data))
         }
     };
 
     let mut issuer_name = [0u8; MAX_ISSUER_NAME_SIZE];
-    let cert_validity = env.platform.get_cert_validity()?;
-    let signer_identifier = env.platform.get_signer_identifier()?;
+    let cert_validity = platform.get_cert_validity()?;
+    let signer_identifier = platform.get_signer_identifier()?;
     let format_specific_args = match cert_format {
         CertificateFormat::X509 => {
             let issuer_name = {
-                let issuer_len = env.platform.get_issuer_name(&mut issuer_name)?;
+                let issuer_len = platform.get_issuer_name(&mut issuer_name)?;
                 if issuer_len > MAX_ISSUER_NAME_SIZE {
                     return Err(DpeErrorCode::InternalError);
                 }

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -3,6 +3,7 @@
 #[cfg(not(feature = "rustcrypto"))]
 compile_error!("must provide a crypto implementation");
 
+use caliptra_dpe::dpe_instance::DpeEnvImpl;
 use caliptra_dpe::DpeFlags;
 use caliptra_dpe::{dpe_instance::DpeEnv, response::Response, support::Support, DpeInstance};
 use caliptra_dpe_platform::default::{DefaultPlatform, DefaultPlatformProfile};
@@ -47,7 +48,7 @@ mod profile {
 
 const SOCKET_PATH: &str = "/tmp/dpe-sim.socket";
 
-fn handle_request(dpe: &mut DpeInstance, env: &mut DpeEnv, stream: &mut UnixStream) {
+fn handle_request(dpe: &mut DpeInstance, env: &mut dyn DpeEnv, stream: &mut UnixStream) {
     let mut buf = [0u8; 4096];
     let (locality, cmd) = {
         let len = stream.read(&mut buf).unwrap();
@@ -184,7 +185,7 @@ fn main() -> std::io::Result<()> {
     let mut crypto = profile::new_crypto();
     let mut platform = DefaultPlatform(PLATFORM_PROFILE);
     let mut state = caliptra_dpe::State::new(support, flags);
-    let mut env = DpeEnv {
+    let mut env = DpeEnvImpl {
         crypto: &mut crypto,
         platform: &mut platform,
         state: &mut state,

--- a/tools/src/cert_size.rs
+++ b/tools/src/cert_size.rs
@@ -1,6 +1,7 @@
 // Licensed under the Apache-2.0 license
 
 use anyhow::{anyhow, Result};
+use caliptra_dpe::dpe_instance::DpeEnvImpl;
 use caliptra_dpe::{
     commands::{CertifyKeyCommand, CommandExecution, DeriveContextCmd, DeriveContextFlags},
     DpeFlags, DpeProfile, MAX_HANDLES,
@@ -90,7 +91,7 @@ struct Args {
     cert: bool,
 }
 
-fn send_certify_key(dpe: &mut DpeInstance, env: &mut DpeEnv, args: &Args) -> Result<Response> {
+fn send_certify_key(dpe: &mut DpeInstance, env: &mut dyn DpeEnv, args: &Args) -> Result<Response> {
     let format = if args.cert {
         CertifyKeyCommand::FORMAT_X509
     } else {
@@ -116,7 +117,7 @@ fn send_certify_key(dpe: &mut DpeInstance, env: &mut DpeEnv, args: &Args) -> Res
     }
 }
 
-fn run(env: &mut DpeEnv, args: &Args) -> Result<()> {
+fn run(env: &mut dyn DpeEnv, args: &Args) -> Result<()> {
     let mut dpe = DpeInstance::new(env, args.algorithm.into())
         .map_err(|e| anyhow!("DPE error creating instance: {e:?}"))?;
 
@@ -176,7 +177,7 @@ fn main() -> Result<()> {
     match args.algorithm {
         #[cfg(any(feature = "p256", feature = "p384"))]
         Algorithm::Ec => run(
-            &mut DpeEnv {
+            &mut DpeEnvImpl {
                 crypto: &mut ec::new_crypto(),
                 platform: &mut DefaultPlatform(args.algorithm.into()),
                 state: &mut state,
@@ -185,7 +186,7 @@ fn main() -> Result<()> {
         ),
         #[cfg(feature = "ml-dsa")]
         Algorithm::Mldsa => run(
-            &mut DpeEnv {
+            &mut DpeEnvImpl {
                 crypto: &mut caliptra_dpe_crypto::RustCryptoImpl::new_mldsa87(),
                 platform: &mut DefaultPlatform(DefaultPlatformProfile::Mldsa87),
                 state: &mut state,

--- a/tools/src/sample_dpe_cert.rs
+++ b/tools/src/sample_dpe_cert.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use caliptra_dpe::{tci::TciMeasurement, DpeFlags};
+use caliptra_dpe::{dpe_instance::DpeEnvImpl, tci::TciMeasurement, DpeFlags};
 use caliptra_dpe_platform::default::DefaultPlatformProfile;
 use clap::{Parser, ValueEnum};
 use profile::*;
@@ -54,7 +54,7 @@ pub struct TestTypes {}
 // TcbInfo populated.
 fn add_tcb_info(
     dpe: &mut DpeInstance,
-    env: &mut DpeEnv,
+    env: &mut dyn DpeEnv,
     data: &TciMeasurement,
     tci_type: u32,
     svn: u32,
@@ -85,7 +85,7 @@ fn add_tcb_info(
     };
 }
 
-fn certify_key(dpe: &mut DpeInstance, env: &mut DpeEnv, format: u32) -> Vec<u8> {
+fn certify_key(dpe: &mut DpeInstance, env: &mut dyn DpeEnv, format: u32) -> Vec<u8> {
     let certify_key_cmd = CertifyKeyCmd {
         handle: ContextHandle::default(),
         flags: CertifyKeyFlags::empty(),
@@ -143,7 +143,7 @@ fn main() {
         DpeFlags::empty()
     };
 
-    let mut env = DpeEnv {
+    let mut env = DpeEnvImpl {
         crypto: &mut profile::new_crypto(),
         platform: &mut DefaultPlatform(PLATFORM_PROFILE),
         state: &mut caliptra_dpe::State::new(support, flags),


### PR DESCRIPTION
This makes the environment more generic by allowing different struct types to implement the intended behavior. This is helpful for the `caliptra-sw` implementation because it uses a function create the environment so it can store the `crypto` and `platform` objects internally instead of a reference where lifetimes can be challenging.