### PR TITLE
Disallow multiple of the same TCI type

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -891,9 +891,10 @@ mod tests {
         let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         // Derive context MAX_HANDLES times. The first was already created by auto-init.
-        for _ in 0..MAX_HANDLES - 1 {
+        for i in 0..MAX_HANDLES - 1 {
             let derive_cmd = DeriveContextCmd {
                 flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INPUT_ALLOW_X509,
+                tci_type: i as u32 + 1,
                 ..Default::default()
             };
 
@@ -924,9 +925,9 @@ mod tests {
             asn1::parse_single::<asn1::SequenceOf<TcbInfo>>(multi_tcb_info.value).unwrap();
 
         // Verify we have MAX_HANDLES TCB infos
-        for _ in 0..MAX_HANDLES {
+        for i in 0..MAX_HANDLES {
             let tcb_info = parsed_tcb_infos.next().unwrap();
-            assert_eq!(tcb_info.tci_type.unwrap(), &(0 as u32).to_le_bytes());
+            assert_eq!(tcb_info.tci_type.unwrap(), &(i as u32).to_le_bytes());
         }
         assert!(parsed_tcb_infos.next().is_none());
     }
@@ -942,9 +943,10 @@ mod tests {
         let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         // Derive context MAX_HANDLES times. The first was already created by auto-init.
-        for _ in 0..MAX_HANDLES - 1 {
+        for i in 0..MAX_HANDLES - 1 {
             let derive_cmd = DeriveContextCmd {
                 flags: DeriveContextFlags::MAKE_DEFAULT,
+                tci_type: i as u32 + 1,
                 ..Default::default()
             };
 

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -199,6 +199,13 @@ impl DeriveContextCmd {
             c.state == ContextState::Active && c.locality == target_locality
         })?;
 
+        // check if the typ already exists
+        for c in state.contexts.iter() {
+            if c.state != ContextState::Inactive && c.tci.tci_type == self.tci_type {
+                return Ok(false);
+            }
+        }
+
         Ok(if self.flags.makes_default() {
             self.safe_to_make_default(parent_idx, default_context_idx, num_contexts_in_locality)
         } else {
@@ -608,9 +615,10 @@ mod tests {
         let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         // Fill all contexts with children (minus the auto-init context).
-        for _ in 0..MAX_HANDLES - 1 {
+        for i in 0..MAX_HANDLES - 1 {
             DeriveContextCmd {
                 flags: DeriveContextFlags::MAKE_DEFAULT,
+                tci_type: i as u32 + 1,
                 ..Default::default()
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -703,6 +711,7 @@ mod tests {
             })),
             DeriveContextCmd {
                 flags: DeriveContextFlags::MAKE_DEFAULT,
+                tci_type: 1,
                 ..Default::default()
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -715,7 +724,12 @@ mod tests {
                 parent_handle: ContextHandle([0xff; ContextHandle::SIZE]),
                 resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
             })),
-            DeriveContextCmd::default().execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
+            DeriveContextCmd {
+                handle: ContextHandle::default(),
+                tci_type: 2,
+                ..Default::default()
+            }
+            .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
     }
 
@@ -748,6 +762,7 @@ mod tests {
         let parent_handle = match (DeriveContextCmd {
             handle,
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
+            tci_type: 1,
             ..Default::default()
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -799,10 +814,10 @@ mod tests {
             handle: new_context_handle,
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT
                 | DeriveContextFlags::INTERNAL_INPUT_INFO,
-            // The parent already has one child with tci_type=0 from the first
+            // The parent already has one child with tci_type=1 from the first
             // DeriveContextCmd above; use a distinct tci_type to satisfy the
             // INPUT_TYPE uniqueness constraint among siblings.
-            tci_type: 1,
+            tci_type: 2,
             ..Default::default()
         })
         .execute(&mut dpe, &mut env, 0)
@@ -882,6 +897,7 @@ mod tests {
             })),
             DeriveContextCmd {
                 flags: DeriveContextFlags::MAKE_DEFAULT,
+                tci_type: 1,
                 ..Default::default()
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -899,6 +915,7 @@ mod tests {
                     | DeriveContextFlags::MAKE_DEFAULT
                     | DeriveContextFlags::CHANGE_LOCALITY,
                 target_locality: TEST_LOCALITIES[1],
+                tci_type: 2,
                 ..Default::default()
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -922,10 +939,10 @@ mod tests {
         }) = DeriveContextCmd {
             handle: env.state.contexts[old_default_idx].handle,
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
-            // The parent already has one child with tci_type=0 (created in the
+            // The parent already has one child with tci_type=1 (created in the
             // CHANGE_LOCALITY step above); use a distinct tci_type to satisfy
             // the INPUT_TYPE uniqueness constraint.
-            tci_type: 1,
+            tci_type: 3,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -1280,6 +1297,7 @@ mod tests {
         let Ok(Response::DeriveContext(DeriveContextResp { handle, .. })) = DeriveContextCmd {
             flags: DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT,
             target_locality: TEST_LOCALITIES[0],
+            tci_type: 1,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]) else {
@@ -1327,6 +1345,7 @@ mod tests {
                 | DeriveContextFlags::CREATE_CERTIFICATE
                 | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
             target_locality: TEST_LOCALITIES[0],
+            tci_type: 1,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]);
@@ -1352,6 +1371,7 @@ mod tests {
         let Ok(Response::DeriveContext(res)) = DeriveContextCmd {
             data: TciMeasurement([0xA; TCI_SIZE]),
             target_locality: TEST_LOCALITIES[0],
+            tci_type: 2,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]) else {
@@ -1365,6 +1385,7 @@ mod tests {
             handle: res.handle,
             flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
             target_locality: TEST_LOCALITIES[0],
+            tci_type: 3,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]);
@@ -1382,6 +1403,7 @@ mod tests {
         let Ok(Response::DeriveContext(res)) = DeriveContextCmd {
             data: TciMeasurement([0xA; TCI_SIZE]),
             target_locality: TEST_LOCALITIES[0],
+            tci_type: 4,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]) else {
@@ -1396,6 +1418,7 @@ mod tests {
                 | DeriveContextFlags::CREATE_CERTIFICATE
                 | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT,
             target_locality: TEST_LOCALITIES[0],
+            tci_type: 5,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]);
@@ -1417,6 +1440,7 @@ mod tests {
             flags: DeriveContextFlags::MAKE_DEFAULT
                 | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT,
             target_locality: TEST_LOCALITIES[0],
+            tci_type: 6,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]);
@@ -1437,6 +1461,7 @@ mod tests {
                 | DeriveContextFlags::EXPORT_CDI
                 | DeriveContextFlags::CREATE_CERTIFICATE,
             target_locality: TEST_LOCALITIES[0],
+            tci_type: 7,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]);
@@ -1895,5 +1920,69 @@ mod tests {
             }
             Err(e) => panic!("x509 parsing failed: {:?}", e),
         };
+    }
+
+    #[test]
+    fn test_tci_type_uniqueness_in_locality() {
+        CfiCounter::reset_for_test();
+        let mut state = State::new(
+            Support::AUTO_INIT | Support::ROTATE_CONTEXT,
+            DpeFlags::empty(),
+        );
+        test_env!(env, &mut state);
+        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
+
+        // Rotate the default handle so we have a non-default active context.
+        let handle = match (RotateCtxCmd {
+            handle: ContextHandle::default(),
+            flags: RotateCtxFlags::empty(),
+        })
+        .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
+        .unwrap()
+        {
+            Response::RotateCtx(resp) => resp.handle,
+            _ => panic!("Failed to rotate default handle"),
+        };
+
+        let tci_type = 0x1234;
+
+        // Create first child with tci_type.
+        let child_handle = match (DeriveContextCmd {
+            handle,
+            tci_type,
+            ..Default::default()
+        })
+        .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
+        .unwrap()
+        {
+            Response::DeriveContext(resp) => resp.handle,
+            _ => panic!("Wrong response type"),
+        };
+
+        // Test that creating two contexts in the same locality with the same
+        // type causes an error.
+        assert_eq!(
+            Err(DpeErrorCode::InvalidArgument),
+            DeriveContextCmd {
+                handle: child_handle,
+                tci_type,
+                ..Default::default()
+            }
+            .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
+        );
+
+        // Test having two contexts with the same type in separate localities
+        // also fails.
+        assert_eq!(
+            Err(DpeErrorCode::InvalidArgument),
+            DeriveContextCmd {
+                handle: child_handle,
+                tci_type,
+                target_locality: TEST_LOCALITIES[1],
+                flags: DeriveContextFlags::CHANGE_LOCALITY,
+                ..Default::default()
+            }
+            .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
+        );
     }
 }

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -152,7 +152,7 @@ mod tests {
         assert_eq!(
             Err(DpeErrorCode::InvalidLocality),
             DestroyCtxCmd {
-                handle: ContextHandle::default(),
+                handle: ContextHandle::default()
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])
         );
@@ -166,7 +166,7 @@ mod tests {
                 dpe.response_hdr(DpeErrorCode::NoError)
             )),
             DestroyCtxCmd {
-                handle: ContextHandle::default(),
+                handle: ContextHandle::default()
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -178,7 +178,7 @@ mod tests {
                 dpe.response_hdr(DpeErrorCode::NoError)
             )),
             DestroyCtxCmd {
-                handle: TEST_HANDLE,
+                handle: TEST_HANDLE
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -240,7 +240,7 @@ mod tests {
                 dpe.response_hdr(DpeErrorCode::NoError)
             )),
             DestroyCtxCmd {
-                handle: ContextHandle::default(),
+                handle: ContextHandle::default()
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -283,7 +283,7 @@ mod tests {
                 dpe.response_hdr(DpeErrorCode::NoError)
             )),
             DestroyCtxCmd {
-                handle: ContextHandle([1; ContextHandle::SIZE]),
+                handle: ContextHandle([1; ContextHandle::SIZE])
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -303,6 +303,7 @@ mod tests {
         let handle_1 = match (DeriveContextCmd {
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT | DeriveContextFlags::CHANGE_LOCALITY,
             target_locality: TEST_LOCALITIES[1],
+            tci_type: 1,
             ..Default::default()
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -316,6 +317,7 @@ mod tests {
         let handle_2 = match (DeriveContextCmd {
             handle: handle_1,
             target_locality: TEST_LOCALITIES[1],
+            tci_type: 2,
             ..Default::default()
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])
@@ -329,6 +331,7 @@ mod tests {
         let handle_3 = match (DeriveContextCmd {
             handle: handle_2,
             target_locality: TEST_LOCALITIES[1],
+            tci_type: 3,
             ..Default::default()
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])
@@ -365,6 +368,7 @@ mod tests {
         let parent_handle = match (DeriveContextCmd {
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT | DeriveContextFlags::CHANGE_LOCALITY,
             target_locality: TEST_LOCALITIES[1],
+            tci_type: 1,
             ..Default::default()
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -379,6 +383,7 @@ mod tests {
             handle: parent_handle,
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
             target_locality: TEST_LOCALITIES[1],
+            tci_type: 2,
             ..Default::default()
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])
@@ -393,9 +398,9 @@ mod tests {
             handle: parent_handle,
             target_locality: TEST_LOCALITIES[1],
             // Use a distinct tci_type; the parent already has one child with
-            // tci_type=0 (from the previous DeriveContext), and INPUT_TYPE must
+            // tci_type=1 (from the previous DeriveContext), and INPUT_TYPE must
             // be unique among siblings.
-            tci_type: 1,
+            tci_type: 3,
             ..Default::default()
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -481,7 +481,7 @@ mod tests {
                 handle: ContextHandle::default(),
                 data: TciMeasurement([i; DPE_PROFILE.hash_size()]),
                 flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INPUT_ALLOW_X509,
-                tci_type: i as u32,
+                tci_type: i as u32 + 1,
                 target_locality: 0,
                 svn: 0,
             }

--- a/dpe/src/commands/update_context_measurement.rs
+++ b/dpe/src/commands/update_context_measurement.rs
@@ -118,7 +118,7 @@ mod tests {
     use crate::{
         commands::{
             rotate_context::{RotateCtxCmd, RotateCtxFlags},
-            DeriveContextCmd, DeriveContextFlags, InitCtxCmd,
+            DeriveContextCmd, DeriveContextFlags,
         },
         context::ContextHandle,
         dpe_instance::{tests::TEST_LOCALITIES, DpeInstance},

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -581,7 +581,7 @@ pub mod tests {
                 handle: ContextHandle::default(),
                 data: TciMeasurement([i; DPE_PROFILE.hash_size()]),
                 flags: DeriveContextFlags::MAKE_DEFAULT,
-                tci_type: i as u32,
+                tci_type: i as u32 + 1,
                 target_locality: 0,
                 svn: 0,
             }
@@ -647,6 +647,7 @@ pub mod tests {
             .unwrap();
         DeriveContextCmd {
             flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INTERNAL_INPUT_INFO,
+            tci_type: 1,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -711,6 +712,7 @@ pub mod tests {
             .unwrap();
         DeriveContextCmd {
             flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INTERNAL_INPUT_DICE,
+            tci_type: 1,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])

--- a/verification/testing/deriveContext.go
+++ b/verification/testing/deriveContext.go
@@ -33,7 +33,7 @@ func TestDeriveContext(d client.TestDPEInstance, c client.DPEClient, t *testing.
 	digestLen := profile.GetDigestSize()
 
 	// Child context handle returned will be the default context handle when MakeDefault flag is set
-	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.MakeDefault, 0, 0); err != nil {
+	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.MakeDefault, 1, 0); err != nil {
 		t.Errorf("[ERROR]: Error while creating child context handle: %s", err)
 	}
 	handle = &resp.NewContextHandle
@@ -43,7 +43,7 @@ func TestDeriveContext(d client.TestDPEInstance, c client.DPEClient, t *testing.
 
 	// When there is already a default handle, setting MakeDefault and RetainParentContext will cause error
 	// because there cannot be default *and* non-default handles in a locality
-	if _, err = c.DeriveContext(handle, make([]byte, digestLen), client.MakeDefault|client.RetainParentContext, 0, 0); err == nil {
+	if _, err = c.DeriveContext(handle, make([]byte, digestLen), client.MakeDefault|client.RetainParentContext, 2, 0); err == nil {
 		t.Errorf("[ERROR]: Should return %q, but returned no error", client.StatusInvalidArgument)
 	} else if !errors.Is(err, client.StatusInvalidArgument) {
 		t.Errorf("[ERROR]: Incorrect error type. Should return %q, but returned %q", client.StatusInvalidArgument, err)
@@ -52,14 +52,14 @@ func TestDeriveContext(d client.TestDPEInstance, c client.DPEClient, t *testing.
 	// Retain parent should fail because parent handle is a default handle
 	// and child handle will be a non-default handle.
 	// Default and non-default handle cannot coexist in same locality.
-	if _, err = c.DeriveContext(handle, make([]byte, digestLen), client.RetainParentContext, 0, 0); err == nil {
+	if _, err = c.DeriveContext(handle, make([]byte, digestLen), client.RetainParentContext, 3, 0); err == nil {
 		t.Errorf("[ERROR]: Should return %q, but returned no error", client.StatusInvalidArgument)
 	} else if !errors.Is(err, client.StatusInvalidArgument) {
 		t.Errorf("[ERROR]: Incorrect error type. Should return %q, but returned %q", client.StatusInvalidArgument, err)
 	}
 
 	// Child context handle should be a random handle when MakeDefault flag is NOT used
-	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), 0, 0, 0); err != nil {
+	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), 0, 4, 0); err != nil {
 		t.Errorf("[ERROR]: Error while creating child context handle: %s", err)
 	}
 	handle = &resp.NewContextHandle
@@ -68,7 +68,7 @@ func TestDeriveContext(d client.TestDPEInstance, c client.DPEClient, t *testing.
 	}
 
 	// Now, there is no default handle, setting RetainParentContext flag should succeed
-	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.RetainParentContext, 0, 0); err != nil {
+	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.RetainParentContext, 5, 0); err != nil {
 		t.Errorf("[ERROR]: Error while making child context handle as default handle: %s", err)
 	}
 	handle = &resp.NewContextHandle
@@ -86,7 +86,7 @@ func TestDeriveContextCdiExport(d client.TestDPEInstance, c client.DPEClient, t 
 		t.Fatalf("Could not get profile: %v", err)
 	}
 	digestLen := profile.GetDigestSize()
-	resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.CdiExport|client.CreateCertificate|client.RetainParentContext, 0, 0)
+	resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.CdiExport|client.CreateCertificate|client.RetainParentContext, 1, 0)
 	if err != nil {
 		t.Fatalf("[ERROR]: Error while exporting CdiExport: %s", err)
 	}
@@ -139,7 +139,7 @@ func TestDeriveContextDisallowedChildCdiExport(d client.TestDPEInstance, c clien
 		t.Fatalf("Could not get profile: %v", err)
 	}
 	digestLen := profile.GetDigestSize()
-	res, err := c.DeriveContext(handle, make([]byte, digestLen), 0, 0, 0)
+	res, err := c.DeriveContext(handle, make([]byte, digestLen), 0, 1, 0)
 	if err != nil {
 		t.Fatalf("[ERROR]: Error while making default: %s", err)
 	}
@@ -161,7 +161,7 @@ func TestDeriveContextAllowedChildCdiExport(d client.TestDPEInstance, c client.D
 		t.Fatalf("Could not get profile: %v", err)
 	}
 	digestLen := profile.GetDigestSize()
-	res, err := c.DeriveContext(handle, make([]byte, digestLen), client.AllowNewContextToExport, 0, 0)
+	res, err := c.DeriveContext(handle, make([]byte, digestLen), client.AllowNewContextToExport, 1, 0)
 	if err != nil {
 		t.Fatalf("[ERROR]: Error while making default: %s", err)
 	}
@@ -237,7 +237,7 @@ func TestChangeLocality(d client.TestDPEInstance, c client.DPEClient, t *testing
 	otherLocality := currentLocality + 1
 
 	// Create child context in other locality
-	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.ChangeLocality, 0, otherLocality); err != nil {
+	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.ChangeLocality, 1, otherLocality); err != nil {
 		t.Fatalf("[ERROR]: Error while creating child context handle in other locality: %s", err)
 	}
 	handle = &resp.NewContextHandle
@@ -246,7 +246,7 @@ func TestChangeLocality(d client.TestDPEInstance, c client.DPEClient, t *testing
 	prevLocality := currentLocality
 	d.SetLocality(otherLocality)
 
-	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.ChangeLocality, 0, prevLocality); err != nil {
+	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.ChangeLocality, 2, prevLocality); err != nil {
 		t.Fatalf("[FATAL]: Error while creating child context handle in previous locality: %s", err)
 	}
 	handle = &resp.NewContextHandle
@@ -272,7 +272,7 @@ func TestInternalInputFlags(d client.TestDPEInstance, c client.DPEClient, t *tes
 	digestLen := profile.GetDigestSize()
 	// Internal input flags
 	if d.GetSupport().InternalDice {
-		if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.DeriveContextFlags(client.InternalInputDice), 0, 0); err != nil {
+		if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.DeriveContextFlags(client.InternalInputDice), 1, 0); err != nil {
 			t.Errorf("[ERROR]: Error while making child context handle as default handle: %s", err)
 		}
 		handle = &resp.NewContextHandle
@@ -281,7 +281,7 @@ func TestInternalInputFlags(d client.TestDPEInstance, c client.DPEClient, t *tes
 	}
 
 	if d.GetSupport().InternalInfo {
-		if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.DeriveContextFlags(client.InternalInputInfo), 0, 0); err != nil {
+		if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.DeriveContextFlags(client.InternalInputInfo), 2, 0); err != nil {
 			t.Errorf("[ERROR]: Error while making child context handle as default handle: %s", err)
 		}
 		handle = &resp.NewContextHandle
@@ -309,7 +309,7 @@ func TestPrivilegesEscalation(d client.TestDPEInstance, c client.DPEClient, t *t
 	resp, err := c.DeriveContext(handle,
 		make([]byte, digestLen),
 		client.DeriveContextFlags(0),
-		0, 0)
+		1, 0)
 	if err != nil {
 		t.Fatalf("[FATAL]: Error encountered in getting child context: %v", err)
 	}
@@ -354,7 +354,7 @@ func TestMaxTCIs(d client.TestDPEInstance, c client.DPEClient, t *testing.T) {
 	maxTciCount := int(d.GetMaxTciNodes())
 	allowedTciCount := maxTciCount - 1 // since, a TCI node is already auto-initialized
 	for i := 0; i < allowedTciCount; i++ {
-		resp, err = c.DeriveContext(handle, make([]byte, digestSize), client.InputAllowX509, 0, 0)
+		resp, err = c.DeriveContext(handle, make([]byte, digestSize), client.InputAllowX509, uint32(i+1), 0)
 		if err != nil {
 			t.Fatalf("[FATAL]: Error encountered in executing derive child: %v", err)
 		}
@@ -462,7 +462,7 @@ func TestDeriveContextSimulation(d client.TestDPEInstance, c client.DPEClient, t
 	}
 
 	// Setting RetainParentContext flag should not invalidate the parent handle
-	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.RetainParentContext, 0, 0); err != nil {
+	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.RetainParentContext, 1, 0); err != nil {
 		t.Fatalf("[FATAL]: Error while making child context and retaining parent handle %s", err)
 	}
 	handle = &resp.NewContextHandle
@@ -492,7 +492,7 @@ func TestDeriveContextRecursive(d client.TestDPEInstance, c client.DPEClient, t 
 	// The auto-init root context does not carry AllowRecursive (recursive TCI updates
 	// are opt-in). Derive a child with AllowRecursive so it can be recursively updated.
 	childResp, err := c.DeriveContext(handle, make([]byte, digestLen),
-		client.DeriveContextFlags(client.AllowRecursive|client.InputAllowX509), 0, 0)
+		client.DeriveContextFlags(client.AllowRecursive|client.InputAllowX509), 1, 0)
 	if err != nil {
 		t.Fatalf("[FATAL]: Could not create child context with AllowRecursive: %v", err)
 	}
@@ -508,7 +508,7 @@ func TestDeriveContextRecursive(d client.TestDPEInstance, c client.DPEClient, t 
 	resp, err := c.DeriveContext(childHandle,
 		tciValue,
 		client.DeriveContextFlags(client.Recursive),
-		0, 0)
+		1, 0)
 	if err != nil {
 		t.Fatalf("[FATAL]: Could not set TCI value: %v", err)
 	}
@@ -560,7 +560,7 @@ func TestDeriveContextRecursiveOnDerivedContexts(d client.TestDPEInstance, c cli
 	}()
 
 	// DeriveContext with input data, tag it and check TCI_CUMULATIVE
-	childCtx, err := c.DeriveContext(parentHandle, tciValue, client.DeriveContextFlags(client.RetainParentContext|client.InputAllowX509|client.AllowRecursive), 0, 0)
+	childCtx, err := c.DeriveContext(parentHandle, tciValue, client.DeriveContextFlags(client.RetainParentContext|client.InputAllowX509|client.AllowRecursive), 1, 0)
 	if err != nil {
 		t.Fatalf("[FATAL]: Error while creating default child handle in default context: %s", err)
 	}
@@ -596,7 +596,7 @@ func TestDeriveContextRecursiveOnDerivedContexts(d client.TestDPEInstance, c cli
 	resp, err := c.DeriveContext(childHandle,
 		extendTciValue,
 		client.DeriveContextFlags(client.Recursive),
-		0, 0)
+		1, 0)
 	if err != nil {
 		t.Fatalf("[FATAL]: Could not set TCI value: %v", err)
 	}


### PR DESCRIPTION
This adds a check to make sure before creating a new context that there isn't already a context with the same type. This should help disambiguate measurements.