### PR TITLE
dpe: Mark types as FromZero

### DIFF
--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -1,14 +1,14 @@
 // Licensed under the Apache-2.0 license.
 use crate::{response::DpeErrorCode, tci::TciNodeData, U8Bool, MAX_HANDLES};
 use constant_time_eq::constant_time_eq_16;
-use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, TryFromBytes};
+use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
 #[cfg(test)]
 use std::fmt::Debug;
 
 #[repr(C, align(4))]
-#[derive(IntoBytes, TryFromBytes, KnownLayout, Immutable, Copy, Clone, PartialEq, Eq, Zeroize)]
+#[derive(IntoBytes, FromZeros, KnownLayout, Immutable, Copy, Clone, PartialEq, Eq, Zeroize)]
 pub struct Context {
     pub handle: ContextHandle,
     pub tci: TciNodeData,
@@ -161,7 +161,7 @@ impl ContextHandle {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, IntoBytes, TryFromBytes, KnownLayout, Immutable, Copy, Clone, Zeroize)]
+#[derive(Debug, PartialEq, Eq, IntoBytes, FromZeros, KnownLayout, Immutable, Copy, Clone, Zeroize)]
 #[repr(u8, align(1))]
 #[rustfmt::skip]
 pub enum ContextState {
@@ -176,7 +176,7 @@ pub enum ContextState {
     Retired,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, IntoBytes, TryFromBytes, KnownLayout, Immutable, Zeroize)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, IntoBytes, FromZeros, KnownLayout, Immutable, Zeroize)]
 #[repr(u8, align(1))]
 #[rustfmt::skip]
 pub enum ContextType {

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -26,7 +26,7 @@ use crypto::{Crypto, Digest, Hasher};
 use platform::Platform;
 #[cfg(not(feature = "disable_internal_dice"))]
 use platform::MAX_CHUNK_SIZE;
-use zerocopy::{Immutable, IntoBytes, KnownLayout, TryFromBytes};
+use zerocopy::{FromZeros, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
 pub trait DpeTypes {
@@ -64,7 +64,7 @@ bitflags! {
 }
 
 #[repr(C, align(4))]
-#[derive(IntoBytes, TryFromBytes, KnownLayout, Immutable, Zeroize)]
+#[derive(IntoBytes, FromZeros, KnownLayout, Immutable, Zeroize)]
 pub struct DpeInstance {
     pub contexts: [Context; MAX_HANDLES],
     pub support: Support,


### PR DESCRIPTION
Mark types inherited by PersistentData as FromZero.  This trait shows the structures can be constructed from all 0s, and implies the TryFrom trait.  This can be used by the caliptra-sw to optimize zeroize implementations, saving ~2Kb in instruction memory.