### PR TITLE
dpe: Mark types as FromZero

### DIFF
--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -10,14 +10,14 @@ use caliptra_cfi_derive::Launder;
 #[cfg(feature = "cfi")]
 use caliptra_cfi_lib::cfi_launder;
 use constant_time_eq::constant_time_eq_16;
-use zerocopy::{little_endian::U64, FromBytes, Immutable, IntoBytes, KnownLayout, TryFromBytes};
+use zerocopy::{little_endian::U64, FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
 #[cfg(test)]
 use std::fmt::Debug;
 
 #[repr(C, align(4))]
-#[derive(IntoBytes, TryFromBytes, KnownLayout, Immutable, Copy, Clone, PartialEq, Eq, Zeroize)]
+#[derive(IntoBytes, FromZeros, KnownLayout, Immutable, Copy, Clone, PartialEq, Eq, Zeroize)]
 pub struct Context {
     pub handle: ContextHandle,
     pub tci: TciNodeData,
@@ -209,7 +209,7 @@ impl ContextHandle {
 
 #[repr(C, align(4))]
 #[derive(
-    Default, Debug, IntoBytes, TryFromBytes, KnownLayout, Immutable, Copy, Clone, PartialEq, Eq,
+    Default, Debug, IntoBytes, FromZeros, KnownLayout, Immutable, Copy, Clone, PartialEq, Eq,
 )]
 pub struct Children(U64);
 
@@ -292,7 +292,7 @@ impl From<u64> for Children {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, IntoBytes, TryFromBytes, KnownLayout, Immutable, Copy, Clone, Zeroize)]
+#[derive(Debug, PartialEq, Eq, IntoBytes, FromZeros, KnownLayout, Immutable, Copy, Clone, Zeroize)]
 #[cfg_attr(feature = "cfi", derive(Launder))]
 #[repr(u8, align(1))]
 #[rustfmt::skip]
@@ -308,7 +308,7 @@ pub enum ContextState {
     Retired,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, IntoBytes, TryFromBytes, KnownLayout, Immutable, Zeroize)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, IntoBytes, FromZeros, KnownLayout, Immutable, Zeroize)]
 #[cfg_attr(feature = "cfi", derive(Launder))]
 #[repr(u8, align(1))]
 #[rustfmt::skip]

--- a/dpe/src/state.rs
+++ b/dpe/src/state.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use bitflags::bitflags;
 use core::mem::align_of;
-use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, TryFromBytes};
+use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
 
 #[cfg(feature = "cfi")]
@@ -26,7 +26,7 @@ bitflags! {
 }
 
 #[repr(C, align(4))]
-#[derive(IntoBytes, TryFromBytes, KnownLayout, Immutable, Zeroize)]
+#[derive(IntoBytes, FromZeros, KnownLayout, Immutable, Zeroize)]
 pub struct State {
     /// Magic marker indicating the data is a DPE state. This is just a quick sanity check.
     pub marker: u32,


### PR DESCRIPTION
Mark types inherited by PersistentData as FromZero.  This trait shows the structures can be constructed from all 0s, and implies the TryFrom trait.  This can be used by the caliptra-sw to optimize zeroize implementations, saving ~2.5Kb in instruction memory.