### PR TITLE
ci: add taplo as toml formatter to xtask

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,12 @@
+# Licensed under the Apache-2.0 license
+include = ["**/Cargo.toml"]
+
+[formatting]
+align_entries = false
+reorder_keys = true
+
+[[rule]]
+include = ["**/Cargo.toml"]
+keys = ["dependencies", "dev-dependencies", "build-dependencies"]
+[rule.formatting]
+reorder_keys = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,42 +4,48 @@
 resolver = "2"
 
 members = [
-    "dpe",
-    "crypto",
-    "platform",
-    "simulator",
-    "tools",
-    "xtask",
-    "test-artifacts",
+  "dpe",
+  "crypto",
+  "platform",
+  "simulator",
+  "tools",
+  "xtask",
+  "test-artifacts",
 ]
 
 [workspace.package]
-version = "0.1.0"
-edition = "2021"
 authors = ["Caliptra DPE Project"]
+edition = "2021"
 license = "Apache-2.0"
 publish = false
+version = "0.1.0"
 
 [workspace.dependencies]
-caliptra-cfi-lib = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-lib", rev = "aa96c53073ce7f298f7482c1ac57f5f65ffc115e", default-features = false }
-caliptra-cfi-derive = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-derive", rev = "aa96c53073ce7f298f7482c1ac57f5f65ffc115e"}
-zerocopy = { version = "0.8.17", features = ["derive"] }
-constant_time_eq = "0.3.0"
-arrayvec = { version = "0.7.4", default-features = false, features = ["zeroize"] }
-x509-cert = "0.2.4"
-caliptra-dpe-platform = { path = "platform", default-features = false }
-caliptra-dpe-crypto = { path = "crypto", default-features = false }
-caliptra-dpe-test-artifacts = { path = "test-artifacts" }
-caliptra-dpe = { path = "dpe", default-features = false }
-cfg-if = "1.0.0"
-ufmt = { git = "https://github.com/korran/ufmt.git", rev = "1d0743c1ffffc68bc05ca8eeb81c166192863f33", features = ["inline"] }
-zeroize = { version = "1.8.2", default-features = false, features = ["zeroize_derive"] }
 anyhow = "1.0.70"
+arrayvec = { version = "0.7.4", default-features = false, features = [
+  "zeroize",
+] }
+caliptra-cfi-derive = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-derive", rev = "aa96c53073ce7f298f7482c1ac57f5f65ffc115e" }
+caliptra-cfi-lib = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-lib", rev = "aa96c53073ce7f298f7482c1ac57f5f65ffc115e", default-features = false }
+caliptra-dpe = { path = "dpe", default-features = false }
+caliptra-dpe-crypto = { path = "crypto", default-features = false }
+caliptra-dpe-platform = { path = "platform", default-features = false }
+caliptra-dpe-test-artifacts = { path = "test-artifacts" }
+cfg-if = "1.0.0"
 clap = { version = "4.3", features = ["derive"] }
+constant_time_eq = "0.3.0"
+ufmt = { git = "https://github.com/korran/ufmt.git", rev = "1d0743c1ffffc68bc05ca8eeb81c166192863f33", features = [
+  "inline",
+] }
+x509-cert = "0.2.4"
+zerocopy = { version = "0.8.17", features = ["derive"] }
+zeroize = { version = "1.8.2", default-features = false, features = [
+  "zeroize_derive",
+] }
 
 [profile.firmware]
+codegen-units = 1
 inherits = "release"
-panic = "abort"
 lto = true
 opt-level = "s"
-codegen-units = 1
+panic = "abort"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,49 +1,73 @@
 # Licensed under the Apache-2.0 license
 
 [package]
-name = "caliptra-dpe-crypto"
-version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+name = "caliptra-dpe-crypto"
 publish.workspace = true
+version.workspace = true
 
 [features]
-default = ["cfi"]
-test-artifacts = ["dep:caliptra-dpe-test-artifacts"]
-rustcrypto = ["dep:hkdf", "dep:p256", "dep:p384", "dep:rand", "dep:sha2", "dep:base64ct", "dep:ecdsa", "dep:sec1", "dep:ml-dsa", "dep:pkcs8", "test-artifacts"]
-ml-dsa = []
-deterministic_rand = ["dep:rand"]
 cfi = ["caliptra-cfi-lib/cfi", "caliptra-cfi-lib/cfi-counter"]
+default = ["cfi"]
+deterministic_rand = ["dep:rand"]
+ml-dsa = []
+rustcrypto = [
+  "dep:hkdf",
+  "dep:p256",
+  "dep:p384",
+  "dep:rand",
+  "dep:sha2",
+  "dep:base64ct",
+  "dep:ecdsa",
+  "dep:sec1",
+  "dep:ml-dsa",
+  "dep:pkcs8",
+  "test-artifacts",
+]
+test-artifacts = ["dep:caliptra-dpe-test-artifacts"]
 
 [dependencies]
-caliptra-dpe-test-artifacts = { workspace = true, optional = true }
 arrayvec.workspace = true
-caliptra-cfi-lib = { workspace = true, default-features = false }
 caliptra-cfi-derive.workspace = true
+caliptra-cfi-lib = { workspace = true, default-features = false }
+caliptra-dpe-test-artifacts = { workspace = true, optional = true }
 constant_time_eq.workspace = true
-ecdsa = { version = "0.16.9", optional = true, features = ["pem"]}
+ecdsa = { version = "0.16.9", optional = true, features = ["pem"] }
 hkdf = { version = "0.12.3", optional = true }
-p256 = {version= "0.13.2", optional = true}
-p384 = {version= "0.13.0", optional = true}
+ml-dsa = { version = "0.1.0-rc.2", optional = true, features = [
+  "pkcs8",
+  "alloc",
+] }
+p256 = { version = "0.13.2", optional = true }
+p384 = { version = "0.13.0", optional = true }
+pkcs8 = { version = "0.11.0-rc.6", optional = true, features = [
+  "pem",
+  "alloc",
+] }
 rand = { version = "0.8.5", optional = true }
-sec1 = {version="0.7.3", optional = true}
+sec1 = { version = "0.7.3", optional = true }
 sha2 = { version = "0.10.6", optional = true }
-zeroize.workspace = true
-ml-dsa = { version = "0.1.0-rc.2", optional = true, features = ["pkcs8", "alloc"]}
-pkcs8 = { version = "0.11.0-rc.6", optional = true, features = ["pem", "alloc"] }
 zerocopy.workspace = true
+zeroize.workspace = true
 
 [dev-dependencies]
 strum = "0.24"
 strum_macros = "0.24"
 
 [build-dependencies]
-ml-dsa = { version = "0.1.0-rc.2", optional = true, features = ["pkcs8", "alloc"]}
-pkcs8 = { version = "0.11.0-rc.6", optional = true, features = ["pem", "alloc"] }
-rand = {version = "0.8.5", optional = true}
-p256 = {version= "0.13.2", optional = true}
-p384 = {version= "0.13.0", optional = true}
-ecdsa = { version = "0.16.9", optional = true, features = ["pem"]}
-base64ct = {version= "1.6.0", optional= true}
-sec1 = {version="0.7.3", optional = true}
+base64ct = { version = "1.6.0", optional = true }
+ecdsa = { version = "0.16.9", optional = true, features = ["pem"] }
+ml-dsa = { version = "0.1.0-rc.2", optional = true, features = [
+  "pkcs8",
+  "alloc",
+] }
+p256 = { version = "0.13.2", optional = true }
+p384 = { version = "0.13.0", optional = true }
+pkcs8 = { version = "0.11.0-rc.6", optional = true, features = [
+  "pem",
+  "alloc",
+] }
+rand = { version = "0.8.5", optional = true }
+sec1 = { version = "0.7.3", optional = true }

--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -1,59 +1,68 @@
 # Licensed under the Apache-2.0 license
 
 [package]
-name = "caliptra-dpe"
-version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+name = "caliptra-dpe"
 publish.workspace = true
+version.workspace = true
 
 [features]
 default = ["p384", "cfi"]
+hybrid = ["p384", "ml-dsa"]
+ml-dsa = ["caliptra-dpe-crypto/ml-dsa"]
 p256 = []
 p384 = []
-ml-dsa = ["caliptra-dpe-crypto/ml-dsa"]
-hybrid = ["p384", "ml-dsa"]
 # Run ARBITRARY_MAX_HANDLES=n cargo build --features arbitrary_max_handles to use this feature
 arbitrary_max_handles = []
-disable_simulation = []
-disable_recursive = []
+cfi = [
+  "caliptra-dpe-crypto/cfi",
+  "caliptra-cfi-lib/cfi",
+  "caliptra-cfi-lib/cfi-counter",
+]
 disable_auto_init = []
-disable_rotate_context = []
-disable_x509 = []
 disable_csr = []
-disable_internal_info = []
-disable_internal_dice = []
-disable_retain_parent_context = []
 disable_export_cdi = []
-cfi = ["caliptra-dpe-crypto/cfi", "caliptra-cfi-lib/cfi", "caliptra-cfi-lib/cfi-counter"]
+disable_internal_dice = []
+disable_internal_info = []
+disable_recursive = []
+disable_retain_parent_context = []
+disable_rotate_context = []
+disable_simulation = []
+disable_x509 = []
 log = ["dep:log"]
 
 [dependencies]
 bitflags = "2.4.0"
-caliptra-cfi-lib = { workspace = true, default-features = false }
 caliptra-cfi-derive.workspace = true
-constant_time_eq.workspace = true
+caliptra-cfi-lib = { workspace = true, default-features = false }
 caliptra-dpe-crypto = { workspace = true, default-features = false }
 caliptra-dpe-platform = { workspace = true, default-features = false }
+cfg-if.workspace = true
+constant_time_eq.workspace = true
+log = { version = "0.4.28", optional = true }
 ufmt.workspace = true
 zerocopy.workspace = true
 zeroize.workspace = true
-cfg-if.workspace = true
-log = { version = "0.4.28", optional = true }
 
 [dev-dependencies]
 asn1 = "0.13.0"
 caliptra-cfi-lib = { workspace = true, features = ["cfi-test"] }
-const-oid = "0.10.2"
-x509-parser = "0.15.1"
-caliptra-dpe-crypto = { workspace = true, features = ["deterministic_rand", "rustcrypto"] }
-caliptra-dpe-platform = { workspace = true, default-features = false, features = ["rustcrypto"] }
+caliptra-dpe-crypto = { workspace = true, features = [
+  "deterministic_rand",
+  "rustcrypto",
+] }
+caliptra-dpe-platform = { workspace = true, default-features = false, features = [
+  "rustcrypto",
+] }
 cms = "0.2.2"
+const-oid = "0.10.2"
 der = "0.7.8"
-spki = "0.7.2"
-rand = "0.8.5"
-openssl = "0.10.64"
-ml-dsa = "0.1.0-rc.2"
-pkcs8 = "0.11.0-rc.6"
 flexi_logger = "0.31.7"
+ml-dsa = "0.1.0-rc.2"
+openssl = "0.10.64"
+pkcs8 = "0.11.0-rc.6"
+rand = "0.8.5"
+spki = "0.7.2"
+x509-parser = "0.15.1"

--- a/dpe/fuzz/Cargo.toml
+++ b/dpe/fuzz/Cargo.toml
@@ -1,17 +1,17 @@
 # Licensed under the Apache-2.0 license
 
 [package]
-name = "dpe-fuzz"
-version = "0.0.0"
-publish = false
 edition = "2021"
+name = "dpe-fuzz"
+publish = false
+version = "0.0.0"
 
 [package.metadata]
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = { version = "0.4.6", optional = true }
 afl = { version = "0.17.0", optional = true }
+libfuzzer-sys = { version = "0.4.6", optional = true }
 log = "0.4.19"
 simplelog = "0.12.1"
 # https://github.com/time-rs/time/issues/681
@@ -19,19 +19,19 @@ simplelog = "0.12.1"
 time = "=0.3.36"
 
 [dependencies.caliptra-dpe]
-path = ".."
 default-features = false
 features = ["p256"]
+path = ".."
 
 [dependencies.caliptra-dpe-crypto]
-path = "../../crypto"
 default-features = false
 features = ["rustcrypto"]
+path = "../../crypto"
 
 [dependencies.caliptra-dpe-platform]
-path = "../../platform"
 default-features = false
 features = ["rustcrypto"]
+path = "../../platform"
 
 # Prevent this from interfering with workspaces
 [workspace]
@@ -41,7 +41,7 @@ members = ["."]
 debug = 1
 
 [[bin]]
+doc = false
 name = "fuzz_target_1"
 path = "src/fuzz_target_1.rs"
 test = false
-doc = false

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
             uv
             openssl
             pkg-config
+            taplo
           ];
 
           shellHook = ''

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -1,12 +1,12 @@
 # Licensed under the Apache-2.0 license
 
 [package]
-name = "caliptra-dpe-platform"
-version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+name = "caliptra-dpe-platform"
 publish.workspace = true
+version.workspace = true
 
 [features]
 default = []
@@ -16,9 +16,9 @@ arbitrary_issuer_name_size = []
 
 [dependencies]
 arrayvec.workspace = true
+caliptra-dpe-crypto = { workspace = true, default-features = false }
 cfg-if.workspace = true
 ufmt.workspace = true
-caliptra-dpe-crypto = { workspace = true, default-features = false }
 x509-cert = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -1,29 +1,31 @@
 # Licensed under the Apache-2.0 license
 
 [package]
-name = "caliptra-dpe-simulator"
-version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+name = "caliptra-dpe-simulator"
 publish.workspace = true
+version.workspace = true
 
 [features]
 default = ["p384", "rustcrypto"]
 p256 = ["caliptra-dpe/p256"]
 p384 = ["caliptra-dpe/p384"]
 # TODO(clundin): Placeholder name until we decide pattern for DPE profiles and feature flags.
+cfi = ["caliptra-dpe/cfi"]
 ml-dsa = ["caliptra-dpe/ml-dsa"]
 rustcrypto = ["caliptra-dpe-crypto/rustcrypto"]
-cfi = ["caliptra-dpe/cfi"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ctrlc = { version = "3.0", features = ["termination"] }
-clap.workspace = true
-log = "0.4.17"
-env_logger = "0.10.0"
 caliptra-dpe = { workspace = true, default-features = false }
 caliptra-dpe-crypto = { workspace = true, default-features = false }
-caliptra-dpe-platform = { workspace = true, default-features = false, features = ["rustcrypto"] }
+caliptra-dpe-platform = { workspace = true, default-features = false, features = [
+  "rustcrypto",
+] }
+clap.workspace = true
+ctrlc = { version = "3.0", features = ["termination"] }
+env_logger = "0.10.0"
+log = "0.4.17"

--- a/test-artifacts/Cargo.toml
+++ b/test-artifacts/Cargo.toml
@@ -1,12 +1,12 @@
 # Licensed under the Apache-2.0 license
 
 [package]
-name = "caliptra-dpe-test-artifacts"
-version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+name = "caliptra-dpe-test-artifacts"
 publish.workspace = true
+version.workspace = true
 
 [features]
 

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,12 +1,12 @@
 # Licensed under the Apache-2.0 license
 
 [package]
-name = "caliptra-dpe-tools"
-version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+name = "caliptra-dpe-tools"
 publish.workspace = true
+version.workspace = true
 
 [features]
 default = ["p384"]
@@ -15,19 +15,22 @@ arbitrary_max_handles = ["caliptra-dpe/arbitrary_max_handles"]
 p256 = ["caliptra-dpe/p256"]
 p384 = ["caliptra-dpe/p384"]
 # TODO(clundin): Placeholder name until we decide pattern for DPE profiles and feature flags.
-ml-dsa = [
-  "caliptra-dpe/ml-dsa"
-]
-hybrid = ["p384", "ml-dsa"]
 cfi = ["caliptra-dpe/cfi"]
+hybrid = ["p384", "ml-dsa"]
+ml-dsa = ["caliptra-dpe/ml-dsa"]
 
 [dependencies]
 anyhow.workspace = true
 caliptra-dpe = { workspace = true, default-features = false }
+caliptra-dpe-crypto = { workspace = true, default-features = false, features = [
+  "deterministic_rand",
+  "rustcrypto",
+] }
+caliptra-dpe-platform = { workspace = true, default-features = false, features = [
+  "rustcrypto",
+] }
 clap.workspace = true
-caliptra-dpe-crypto = { workspace = true, default-features = false, features = ["deterministic_rand", "rustcrypto"] }
 pem = "2"
-caliptra-dpe-platform = { workspace = true, default-features = false, features = ["rustcrypto"] }
 zerocopy.workspace = true
 
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,12 +1,12 @@
 # Licensed under the Apache-2.0 license
 
 [package]
-name = "xtask"
-version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+name = "xtask"
 publish.workspace = true
+version.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -303,8 +303,6 @@ fn format_rust_targets() -> Result<()> {
 }
 
 fn format_toml_targets() -> Result<()> {
-    println!("Installing taplo");
-    cargo().args(["install", "taplo-cli", "--locked"]).run()?;
     let res = Cmd::new("taplo")
         .args(["format", "--check", "--diff"])
         .output()?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -144,6 +144,7 @@ fn run_precheckin() -> Result<()> {
 fn run_format() -> Result<()> {
     format_rust_targets()?;
     format_go_targets()?;
+    format_toml_targets()?;
     Ok(())
 }
 
@@ -298,6 +299,28 @@ fn format_rust_targets() -> Result<()> {
             .args(["fmt", "--manifest-path", manifest, "--check"])
             .run()?;
     }
+    Ok(())
+}
+
+fn format_toml_targets() -> Result<()> {
+    println!("Installing taplo");
+    cargo().args(["install", "taplo-cli", "--locked"]).run()?;
+    let res = Cmd::new("taplo")
+        .args(["format", "--check", "--diff"])
+        .output()?;
+
+    if !res.status.success() {
+        if !res.stderr.is_empty() {
+            let err = String::from_utf8(res.stdout).unwrap();
+            eprintln!("{}", err);
+            return Err(anyhow!(
+                "Toml files have format errors. To fix, run 'taplo format'"
+            ));
+        } else {
+            return Err(anyhow!("Could not parse topl output."));
+        }
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
As discussed in #563 there is no enforcement for toml formatting yet. This PR adds toml format checking to `cargo xtask precheckin` that throws an error when non-conforming changes are detected and prints the command to automatically fix the issues.