### PR TITLE
Add static C header files for the DPE ABI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +185,12 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -226,7 +243,7 @@ name = "caliptra-dpe"
 version = "0.1.0"
 dependencies = [
  "asn1",
- "bitflags",
+ "bitflags 2.4.1",
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
  "caliptra-dpe-crypto",
@@ -292,7 +309,7 @@ dependencies = [
  "caliptra-dpe",
  "caliptra-dpe-crypto",
  "caliptra-dpe-platform",
- "clap",
+ "clap 4.5.51",
  "ctrlc",
  "env_logger",
  "log",
@@ -310,9 +327,28 @@ dependencies = [
  "caliptra-dpe",
  "caliptra-dpe-crypto",
  "caliptra-dpe-platform",
- "clap",
+ "clap 4.5.51",
  "pem",
  "zerocopy",
+]
+
+[[package]]
+name = "cbindgen"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da6bc11b07529f16944307272d5bd9b22530bc7d05751717c9d416586cedab49"
+dependencies = [
+ "clap 3.2.25",
+ "heck 0.4.1",
+ "indexmap 1.9.3",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 1.0.109",
+ "tempfile",
+ "toml",
 ]
 
 [[package]]
@@ -344,6 +380,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "atty",
+ "bitflags 1.3.2",
+ "clap_lex 0.2.4",
+ "indexmap 1.9.3",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap"
 version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
@@ -360,8 +411,8 @@ checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex",
- "strsim",
+ "clap_lex 0.7.6",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -374,6 +425,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -620,14 +680,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.7"
+name = "equivalent"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -657,6 +729,12 @@ dependencies = [
  "regex",
  "thiserror 2.0.17",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -696,6 +774,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +796,27 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -717,6 +829,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -782,13 +903,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi",
- "rustix",
+ "hermit-abi 0.3.3",
+ "rustix 0.38.24",
  "windows-sys 0.48.0",
 ]
 
@@ -830,6 +979,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +995,12 @@ name = "linux-raw-sys"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -880,7 +1041,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.1",
  "cfg-if",
  "libc",
 ]
@@ -967,7 +1128,7 @@ version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -998,6 +1159,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "p256"
@@ -1096,6 +1263,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.108",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,6 +1298,12 @@ checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1149,7 +1332,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.11",
 ]
 
 [[package]]
@@ -1212,11 +1395,24 @@ version = "0.38.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ad981d6c340a49cdc40a1028d9c6084ec7e9fa33fcb839cab656a267071e234"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.11",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.4.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1240,23 +1436,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.192"
+name = "semver"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1328,6 +1553,12 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -1392,6 +1623,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,6 +1643,12 @@ checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thiserror"
@@ -1472,6 +1722,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,6 +1797,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,6 +1857,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.4.1",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver",
 ]
 
 [[package]]
@@ -1822,6 +2133,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn 2.0.108",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.4.1",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "x509-cert"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,7 +2259,8 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap",
+ "cbindgen",
+ "clap 4.5.51",
 ]
 
 [[package]]
@@ -1896,3 +2302,9 @@ dependencies = [
  "quote",
  "syn 2.0.108",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ caliptra-dpe = { path = "dpe", default-features = false }
 caliptra-dpe-crypto = { path = "crypto", default-features = false }
 caliptra-dpe-platform = { path = "platform", default-features = false }
 caliptra-dpe-test-artifacts = { path = "test-artifacts" }
+cbindgen = "0.26.0"
 cfg-if = "1.0.0"
 clap = { version = "4.3", features = ["derive"] }
 constant_time_eq = "0.3.0"

--- a/dpe/cbindgen.toml
+++ b/dpe/cbindgen.toml
@@ -1,0 +1,76 @@
+# Licensed under the Apache-2.0 license
+
+language = "C"
+cpp_compat = true
+
+header = """// Licensed under the Apache-2.0 license
+
+#ifndef MAX_CERT_SIZE
+#ifdef DPE_PROFILE_HYBRID
+#define MAX_CERT_SIZE (22 * 1024)
+#else
+#define MAX_CERT_SIZE (11 * 1024)
+#endif
+#endif
+
+#ifndef MAX_EXPORTED_CDI_SIZE
+#define MAX_EXPORTED_CDI_SIZE 32
+#endif
+
+#ifndef MAX_CHUNK_SIZE
+#define MAX_CHUNK_SIZE 2048
+#endif
+
+#ifndef SIZE
+#define SIZE 16
+#endif
+"""
+
+after_includes = """
+#ifdef __cplusplus
+extern "C" {
+#endif
+"""
+
+trailer = """
+#ifdef __cplusplus
+} // extern "C"
+#endif
+"""
+
+[parse]
+parse_deps = true
+include = ["caliptra-dpe-platform", "caliptra-dpe-crypto"]
+
+[enum]
+prefix_with_name = true
+
+[export]
+include = [
+    "CommandHdr",
+    "InitCtxCmd",
+    "DeriveContextCmd",
+    "CertifyKeyP256Cmd",
+    "CertifyKeyP384Cmd",
+    "SignP256Cmd",
+    "SignP384Cmd",
+    "DestroyCtxCmd",
+    "GetCertificateChainCmd",
+    "UpdateContextMeasurementCmd",
+    "ResponseHdr",
+    "GetProfileResp",
+    "NewHandleResp",
+    "DeriveContextResp",
+    "UpdateContextMeasurementResp",
+    "DeriveContextExportedCdiResp",
+    "CertifyKeyP256Resp",
+    "CertifyKeyP384Resp",
+    "SignP256Resp",
+    "SignP384Resp",
+    "GetCertificateChainResp",
+    "DpeProfile",
+    "DpeErrorCode",
+    "ContextHandle",
+    "PlatformError",
+    "CryptoError"
+]

--- a/dpe/dpe_abi_hybrid.h
+++ b/dpe/dpe_abi_hybrid.h
@@ -1,0 +1,450 @@
+// Licensed under the Apache-2.0 license
+
+#define DPE_PROFILE_HYBRID
+
+#ifndef MAX_CERT_SIZE
+#ifdef DPE_PROFILE_HYBRID
+#define MAX_CERT_SIZE (22 * 1024)
+#else
+#define MAX_CERT_SIZE (11 * 1024)
+#endif
+#endif
+
+#ifndef MAX_EXPORTED_CDI_SIZE
+#define MAX_EXPORTED_CDI_SIZE 32
+#endif
+
+#ifndef MAX_CHUNK_SIZE
+#define MAX_CHUNK_SIZE 2048
+#endif
+
+#ifndef SIZE
+#define SIZE 16
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#define MAX_HANDLES 64
+
+
+
+#define TCI_SIZE 48
+
+#define Command_GET_PROFILE 1
+
+#define Command_INITIALIZE_CONTEXT 7
+
+#define Command_DERIVE_CONTEXT 8
+
+#define Command_CERTIFY_KEY 9
+
+#define Command_SIGN 10
+
+#define Command_ROTATE_CONTEXT_HANDLE 14
+
+#define Command_DESTROY_CONTEXT 15
+
+#define Command_GET_CERTIFICATE_CHAIN 16
+
+/**
+ * Vendor command: UpdateContextMeasurement (first vendor slot per the iROT profile spec).
+ */
+#define Command_UPDATE_CONTEXT_MEASUREMENT 2147483648
+
+#define CertifyKeyCommand_FORMAT_X509 0
+
+#define CertifyKeyCommand_FORMAT_CSR 1
+
+#define Context_ROOT_INDEX 255
+
+#define State_VERSION 1
+
+enum DpeProfile
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  DpeProfile_P256Sha256 = 3,
+  DpeProfile_P384Sha384 = 4,
+  DpeProfile_Mldsa87 = 5,
+};
+#ifndef __cplusplus
+typedef uint32_t DpeProfile;
+#endif // __cplusplus
+
+/**
+ * It is possible that there are multiple issues with the DPE state. At most one will be found.
+ * There is no priority on which error will be found first if there are multiple.
+ */
+enum ValidationError
+#ifdef __cplusplus
+  : uint16_t
+#endif // __cplusplus
+ {
+  ValidationError_MultipleNormalConnectedComponents = 0,
+  ValidationError_CyclesInTree = 1,
+  ValidationError_InactiveContextInvalidParent = 2,
+  ValidationError_InactiveContextWithChildren = 3,
+  ValidationError_BadContextState = 4,
+  ValidationError_BadContextType = 5,
+  ValidationError_InactiveContextWithMeasurement = 6,
+  ValidationError_MixedContextLocality = 7,
+  ValidationError_MultipleDefaultContexts = 8,
+  ValidationError_SimulationNotSupported = 9,
+  ValidationError_ParentDoesNotExist = 10,
+  ValidationError_InternalDiceNotSupported = 11,
+  ValidationError_InternalInfoNotSupported = 12,
+  ValidationError_ChildDoesNotExist = 13,
+  ValidationError_InactiveContextWithFlagSet = 14,
+  ValidationError_LocalityMismatch = 15,
+  ValidationError_DanglingRetiredContext = 16,
+  ValidationError_MixedContextTypeConnectedComponents = 17,
+  ValidationError_ChildWithMultipleParents = 18,
+  ValidationError_ParentChildLinksCorrupted = 19,
+  ValidationError_AllowCaNotSupported = 20,
+  ValidationError_AllowX509NotSupported = 21,
+  ValidationError_InactiveParent = 22,
+  ValidationError_InactiveChild = 23,
+  ValidationError_DpeNotMarkedInitialized = 24,
+  ValidationError_InvalidMarker = 25,
+  ValidationError_VersionMismatch = 26,
+};
+#ifndef __cplusplus
+typedef uint16_t ValidationError;
+#endif // __cplusplus
+
+typedef struct CertifyKeyP256Resp CertifyKeyP256Resp;
+
+typedef struct CertifyKeyP384Resp CertifyKeyP384Resp;
+
+typedef struct CommandHdr {
+  uint32_t magic;
+  uint32_t cmd_id;
+  uint32_t profile;
+} CommandHdr;
+
+typedef struct InitCtxCmd {
+  uint32_t _0;
+} InitCtxCmd;
+
+typedef struct ContextHandle {
+  uint8_t _0[SIZE];
+} ContextHandle;
+#define ContextHandle_SIZE 16
+
+typedef uint8_t TciMeasurement[TCI_SIZE];
+
+typedef struct DeriveContextFlags {
+  uint32_t _0;
+} DeriveContextFlags;
+
+typedef struct DeriveContextCmd {
+  struct ContextHandle handle;
+  TciMeasurement data;
+  struct DeriveContextFlags flags;
+  uint32_t tci_type;
+  uint32_t target_locality;
+  uint32_t svn;
+} DeriveContextCmd;
+
+typedef struct CertifyKeyFlags {
+  uint32_t _0;
+} CertifyKeyFlags;
+
+typedef struct CertifyKeyP256Cmd {
+  struct ContextHandle handle;
+  struct CertifyKeyFlags flags;
+  uint32_t format;
+  uint8_t label[32];
+} CertifyKeyP256Cmd;
+
+typedef struct CertifyKeyP384Cmd {
+  struct ContextHandle handle;
+  struct CertifyKeyFlags flags;
+  uint32_t format;
+  uint8_t label[48];
+} CertifyKeyP384Cmd;
+
+typedef struct SignFlags {
+  uint32_t _0;
+} SignFlags;
+
+typedef struct SignP256Cmd {
+  struct ContextHandle handle;
+  uint8_t label[32];
+  struct SignFlags flags;
+  uint8_t digest[32];
+} SignP256Cmd;
+
+typedef struct SignP384Cmd {
+  struct ContextHandle handle;
+  uint8_t label[48];
+  struct SignFlags flags;
+  uint8_t digest[48];
+} SignP384Cmd;
+
+typedef struct DestroyCtxCmd {
+  struct ContextHandle handle;
+} DestroyCtxCmd;
+
+typedef struct GetCertificateChainCmd {
+  uint32_t offset;
+  uint32_t size;
+} GetCertificateChainCmd;
+
+/**
+ * ABI input structure for UpdateContextMeasurement.
+ *
+ * Wire layout (after CommandHdr):
+ * | Offset    | Type       | Name              | Description                          |
+ * |-----------|------------|-------------------|--------------------------------------|
+ * | 0x00      | BYTES[16]  | parent_handle     | Handle of the parent context.        |
+ * | 0x10      | HASH       | data              | New TCI measurement data.            |
+ * | 0x10+H    | U32        | reserved          | Reserved; must be zero.              |
+ * | 0x14+H    | U32        | tci_type          | INPUT_TYPE identifying the child.    |
+ * | 0x18+H    | U32        | reserved_svn      | Reserved; ignored by this command.   |
+ */
+typedef struct UpdateContextMeasurementCmd {
+  /**
+   * Handle of the parent context. Must not be the default handle.
+   */
+  struct ContextHandle parent_handle;
+  /**
+   * New TCI measurement to extend into the child context.
+   */
+  TciMeasurement data;
+  /**
+   * Reserved bitfield; must be zero.
+   */
+  uint32_t reserved;
+  /**
+   * Identifies the direct child of parent_handle to update (matched by tci_type).
+   */
+  uint32_t tci_type;
+  /**
+   * Reserved for future use; ignored by this command. SVN is fixed at context creation
+   * via DeriveContext and cannot be updated here.
+   */
+  uint32_t reserved_svn;
+} UpdateContextMeasurementCmd;
+
+typedef struct ResponseHdr {
+  uint32_t magic;
+  uint32_t status;
+  DpeProfile profile;
+} ResponseHdr;
+
+typedef struct GetProfileResp {
+  struct ResponseHdr resp_hdr;
+  uint16_t major_version;
+  uint16_t minor_version;
+  uint32_t vendor_id;
+  uint32_t vendor_sku;
+  uint32_t max_tci_nodes;
+  uint32_t flags;
+} GetProfileResp;
+
+typedef struct NewHandleResp {
+  struct ResponseHdr resp_hdr;
+  struct ContextHandle handle;
+} NewHandleResp;
+
+typedef struct DeriveContextResp {
+  struct ResponseHdr resp_hdr;
+  struct ContextHandle handle;
+  struct ContextHandle parent_handle;
+} DeriveContextResp;
+
+/**
+ * Response for the UpdateContextMeasurement vendor command.
+ */
+typedef struct UpdateContextMeasurementResp {
+  struct ResponseHdr resp_hdr;
+  /**
+   * Rotated handle for the updated child context.
+   */
+  struct ContextHandle new_context_handle;
+  /**
+   * Rotated handle for the parent context (always retained).
+   */
+  struct ContextHandle new_parent_context_handle;
+} UpdateContextMeasurementResp;
+
+typedef struct DeriveContextExportedCdiResp {
+  struct ResponseHdr resp_hdr;
+  struct ContextHandle handle;
+  struct ContextHandle parent_handle;
+  uint8_t exported_cdi[MAX_EXPORTED_CDI_SIZE];
+  uint32_t certificate_size;
+  uint8_t new_certificate[MAX_CERT_SIZE];
+} DeriveContextExportedCdiResp;
+
+typedef struct SignP256Resp {
+  struct ResponseHdr resp_hdr;
+  struct ContextHandle new_context_handle;
+  uint8_t sig_r[32];
+  uint8_t sig_s[32];
+} SignP256Resp;
+
+typedef struct SignP384Resp {
+  struct ResponseHdr resp_hdr;
+  struct ContextHandle new_context_handle;
+  uint8_t sig_r[48];
+  uint8_t sig_s[48];
+} SignP384Resp;
+
+typedef struct GetCertificateChainResp {
+  struct ResponseHdr resp_hdr;
+  uint32_t certificate_size;
+  uint8_t certificate_chain[MAX_CHUNK_SIZE];
+} GetCertificateChainResp;
+
+enum PlatformError_Tag
+#ifdef __cplusplus
+  : uint16_t
+#endif // __cplusplus
+ {
+  PlatformError_CertificateChainError = 1,
+  PlatformError_NotImplemented = 2,
+  PlatformError_IssuerNameError = 3,
+  PlatformError_PrintError = 4,
+  PlatformError_SerialNumberError = 5,
+  PlatformError_SubjectKeyIdentifierError = 6,
+  PlatformError_CertValidityError = 7,
+  PlatformError_IssuerKeyIdentifierError = 8,
+  PlatformError_SubjectAlternativeNameError = 9,
+  PlatformError_MissingUeidError = 10,
+  PlatformError_InvalidUeidError = 11,
+};
+#ifndef __cplusplus
+typedef uint16_t PlatformError_Tag;
+#endif // __cplusplus
+
+typedef union PlatformError {
+  PlatformError_Tag tag;
+  struct {
+    PlatformError_Tag issuer_name_error_tag;
+    uint32_t issuer_name_error;
+  };
+  struct {
+    PlatformError_Tag print_error_tag;
+    uint32_t print_error;
+  };
+  struct {
+    PlatformError_Tag serial_number_error_tag;
+    uint32_t serial_number_error;
+  };
+  struct {
+    PlatformError_Tag subject_key_identifier_error_tag;
+    uint32_t subject_key_identifier_error;
+  };
+  struct {
+    PlatformError_Tag cert_validity_error_tag;
+    uint32_t cert_validity_error;
+  };
+  struct {
+    PlatformError_Tag issuer_key_identifier_error_tag;
+    uint32_t issuer_key_identifier_error;
+  };
+  struct {
+    PlatformError_Tag subject_alternative_name_error_tag;
+    uint32_t subject_alternative_name_error;
+  };
+} PlatformError;
+
+enum CryptoError_Tag
+#ifdef __cplusplus
+  : uint16_t
+#endif // __cplusplus
+ {
+  CryptoError_AbstractionLayer = 1,
+  CryptoError_CryptoLibError = 2,
+  CryptoError_Size = 3,
+  CryptoError_NotImplemented = 4,
+  CryptoError_HashError = 5,
+  CryptoError_InvalidExportedCdiHandle = 6,
+  CryptoError_ExportedCdiHandleDuplicateCdi = 7,
+  CryptoError_ExportedCdiHandleLimitExceeded = 8,
+  CryptoError_MismatchedAlgorithm = 9,
+};
+#ifndef __cplusplus
+typedef uint16_t CryptoError_Tag;
+#endif // __cplusplus
+
+typedef union CryptoError {
+  CryptoError_Tag tag;
+  struct {
+    CryptoError_Tag abstraction_layer_tag;
+    uint32_t abstraction_layer;
+  };
+  struct {
+    CryptoError_Tag crypto_lib_error_tag;
+    uint32_t crypto_lib_error;
+  };
+  struct {
+    CryptoError_Tag hash_error_tag;
+    uint32_t hash_error;
+  };
+} CryptoError;
+
+enum DpeErrorCode_Tag
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  DpeErrorCode_NoError = 0,
+  DpeErrorCode_InternalError = 1,
+  DpeErrorCode_InvalidCommand = 2,
+  DpeErrorCode_InvalidArgument = 3,
+  DpeErrorCode_ArgumentNotSupported = 4,
+  DpeErrorCode_X509CsrUnset = 5,
+  DpeErrorCode_X509InvalidState = 6,
+  DpeErrorCode_X509SkipsExhausted = 7,
+  DpeErrorCode_X509InvalidWidth = 8,
+  DpeErrorCode_X509AlgorithmMismatch = 9,
+  DpeErrorCode_InvalidHandle = 4096,
+  DpeErrorCode_InvalidLocality = 4097,
+  DpeErrorCode_MaxTcis = 4099,
+  DpeErrorCode_InvalidMutRefBuf = 4100,
+  DpeErrorCode_InvalidResponseBuf = 4101,
+  DpeErrorCode_UninitializedResponseHeader = 4102,
+  /**
+   * Returned by UpdateContextMeasurement when PARENT_CONTEXT_HANDLE does not
+   * exist in the caller's locality. Value matches the OCP iROT profile spec (0x85).
+   */
+  DpeErrorCode_InvalidParentLocality = 133,
+  DpeErrorCode_Platform = 16777216,
+  DpeErrorCode_Crypto = 33554432,
+  DpeErrorCode_Validation = 50331648,
+};
+#ifndef __cplusplus
+typedef uint32_t DpeErrorCode_Tag;
+#endif // __cplusplus
+
+typedef union DpeErrorCode {
+  DpeErrorCode_Tag tag;
+  struct {
+    DpeErrorCode_Tag platform_tag;
+    union PlatformError platform;
+  };
+  struct {
+    DpeErrorCode_Tag crypto_tag;
+    union CryptoError crypto;
+  };
+  struct {
+    DpeErrorCode_Tag validation_tag;
+    ValidationError validation;
+  };
+} DpeErrorCode;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/dpe/dpe_abi_p256.h
+++ b/dpe/dpe_abi_p256.h
@@ -1,0 +1,447 @@
+// Licensed under the Apache-2.0 license
+
+#ifndef MAX_CERT_SIZE
+#ifdef DPE_PROFILE_HYBRID
+#define MAX_CERT_SIZE (22 * 1024)
+#else
+#define MAX_CERT_SIZE (11 * 1024)
+#endif
+#endif
+
+#ifndef MAX_EXPORTED_CDI_SIZE
+#define MAX_EXPORTED_CDI_SIZE 32
+#endif
+
+#ifndef MAX_CHUNK_SIZE
+#define MAX_CHUNK_SIZE 2048
+#endif
+
+#ifndef SIZE
+#define SIZE 16
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#define MAX_HANDLES 64
+
+#define TCI_SIZE 32
+
+
+
+#define Command_GET_PROFILE 1
+
+#define Command_INITIALIZE_CONTEXT 7
+
+#define Command_DERIVE_CONTEXT 8
+
+#define Command_CERTIFY_KEY 9
+
+#define Command_SIGN 10
+
+#define Command_ROTATE_CONTEXT_HANDLE 14
+
+#define Command_DESTROY_CONTEXT 15
+
+#define Command_GET_CERTIFICATE_CHAIN 16
+
+/**
+ * Vendor command: UpdateContextMeasurement (first vendor slot per the iROT profile spec).
+ */
+#define Command_UPDATE_CONTEXT_MEASUREMENT 2147483648
+
+#define CertifyKeyCommand_FORMAT_X509 0
+
+#define CertifyKeyCommand_FORMAT_CSR 1
+
+#define Context_ROOT_INDEX 255
+
+#define State_VERSION 1
+
+enum DpeProfile
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  DpeProfile_P256Sha256 = 3,
+  DpeProfile_P384Sha384 = 4,
+};
+#ifndef __cplusplus
+typedef uint32_t DpeProfile;
+#endif // __cplusplus
+
+/**
+ * It is possible that there are multiple issues with the DPE state. At most one will be found.
+ * There is no priority on which error will be found first if there are multiple.
+ */
+enum ValidationError
+#ifdef __cplusplus
+  : uint16_t
+#endif // __cplusplus
+ {
+  ValidationError_MultipleNormalConnectedComponents = 0,
+  ValidationError_CyclesInTree = 1,
+  ValidationError_InactiveContextInvalidParent = 2,
+  ValidationError_InactiveContextWithChildren = 3,
+  ValidationError_BadContextState = 4,
+  ValidationError_BadContextType = 5,
+  ValidationError_InactiveContextWithMeasurement = 6,
+  ValidationError_MixedContextLocality = 7,
+  ValidationError_MultipleDefaultContexts = 8,
+  ValidationError_SimulationNotSupported = 9,
+  ValidationError_ParentDoesNotExist = 10,
+  ValidationError_InternalDiceNotSupported = 11,
+  ValidationError_InternalInfoNotSupported = 12,
+  ValidationError_ChildDoesNotExist = 13,
+  ValidationError_InactiveContextWithFlagSet = 14,
+  ValidationError_LocalityMismatch = 15,
+  ValidationError_DanglingRetiredContext = 16,
+  ValidationError_MixedContextTypeConnectedComponents = 17,
+  ValidationError_ChildWithMultipleParents = 18,
+  ValidationError_ParentChildLinksCorrupted = 19,
+  ValidationError_AllowCaNotSupported = 20,
+  ValidationError_AllowX509NotSupported = 21,
+  ValidationError_InactiveParent = 22,
+  ValidationError_InactiveChild = 23,
+  ValidationError_DpeNotMarkedInitialized = 24,
+  ValidationError_InvalidMarker = 25,
+  ValidationError_VersionMismatch = 26,
+};
+#ifndef __cplusplus
+typedef uint16_t ValidationError;
+#endif // __cplusplus
+
+typedef struct CertifyKeyP256Resp CertifyKeyP256Resp;
+
+typedef struct CertifyKeyP384Resp CertifyKeyP384Resp;
+
+typedef struct CommandHdr {
+  uint32_t magic;
+  uint32_t cmd_id;
+  uint32_t profile;
+} CommandHdr;
+
+typedef struct InitCtxCmd {
+  uint32_t _0;
+} InitCtxCmd;
+
+typedef struct ContextHandle {
+  uint8_t _0[SIZE];
+} ContextHandle;
+#define ContextHandle_SIZE 16
+
+typedef uint8_t TciMeasurement[TCI_SIZE];
+
+typedef struct DeriveContextFlags {
+  uint32_t _0;
+} DeriveContextFlags;
+
+typedef struct DeriveContextCmd {
+  struct ContextHandle handle;
+  TciMeasurement data;
+  struct DeriveContextFlags flags;
+  uint32_t tci_type;
+  uint32_t target_locality;
+  uint32_t svn;
+} DeriveContextCmd;
+
+typedef struct CertifyKeyFlags {
+  uint32_t _0;
+} CertifyKeyFlags;
+
+typedef struct CertifyKeyP256Cmd {
+  struct ContextHandle handle;
+  struct CertifyKeyFlags flags;
+  uint32_t format;
+  uint8_t label[32];
+} CertifyKeyP256Cmd;
+
+typedef struct CertifyKeyP384Cmd {
+  struct ContextHandle handle;
+  struct CertifyKeyFlags flags;
+  uint32_t format;
+  uint8_t label[48];
+} CertifyKeyP384Cmd;
+
+typedef struct SignFlags {
+  uint32_t _0;
+} SignFlags;
+
+typedef struct SignP256Cmd {
+  struct ContextHandle handle;
+  uint8_t label[32];
+  struct SignFlags flags;
+  uint8_t digest[32];
+} SignP256Cmd;
+
+typedef struct SignP384Cmd {
+  struct ContextHandle handle;
+  uint8_t label[48];
+  struct SignFlags flags;
+  uint8_t digest[48];
+} SignP384Cmd;
+
+typedef struct DestroyCtxCmd {
+  struct ContextHandle handle;
+} DestroyCtxCmd;
+
+typedef struct GetCertificateChainCmd {
+  uint32_t offset;
+  uint32_t size;
+} GetCertificateChainCmd;
+
+/**
+ * ABI input structure for UpdateContextMeasurement.
+ *
+ * Wire layout (after CommandHdr):
+ * | Offset    | Type       | Name              | Description                          |
+ * |-----------|------------|-------------------|--------------------------------------|
+ * | 0x00      | BYTES[16]  | parent_handle     | Handle of the parent context.        |
+ * | 0x10      | HASH       | data              | New TCI measurement data.            |
+ * | 0x10+H    | U32        | reserved          | Reserved; must be zero.              |
+ * | 0x14+H    | U32        | tci_type          | INPUT_TYPE identifying the child.    |
+ * | 0x18+H    | U32        | reserved_svn      | Reserved; ignored by this command.   |
+ */
+typedef struct UpdateContextMeasurementCmd {
+  /**
+   * Handle of the parent context. Must not be the default handle.
+   */
+  struct ContextHandle parent_handle;
+  /**
+   * New TCI measurement to extend into the child context.
+   */
+  TciMeasurement data;
+  /**
+   * Reserved bitfield; must be zero.
+   */
+  uint32_t reserved;
+  /**
+   * Identifies the direct child of parent_handle to update (matched by tci_type).
+   */
+  uint32_t tci_type;
+  /**
+   * Reserved for future use; ignored by this command. SVN is fixed at context creation
+   * via DeriveContext and cannot be updated here.
+   */
+  uint32_t reserved_svn;
+} UpdateContextMeasurementCmd;
+
+typedef struct ResponseHdr {
+  uint32_t magic;
+  uint32_t status;
+  DpeProfile profile;
+} ResponseHdr;
+
+typedef struct GetProfileResp {
+  struct ResponseHdr resp_hdr;
+  uint16_t major_version;
+  uint16_t minor_version;
+  uint32_t vendor_id;
+  uint32_t vendor_sku;
+  uint32_t max_tci_nodes;
+  uint32_t flags;
+} GetProfileResp;
+
+typedef struct NewHandleResp {
+  struct ResponseHdr resp_hdr;
+  struct ContextHandle handle;
+} NewHandleResp;
+
+typedef struct DeriveContextResp {
+  struct ResponseHdr resp_hdr;
+  struct ContextHandle handle;
+  struct ContextHandle parent_handle;
+} DeriveContextResp;
+
+/**
+ * Response for the UpdateContextMeasurement vendor command.
+ */
+typedef struct UpdateContextMeasurementResp {
+  struct ResponseHdr resp_hdr;
+  /**
+   * Rotated handle for the updated child context.
+   */
+  struct ContextHandle new_context_handle;
+  /**
+   * Rotated handle for the parent context (always retained).
+   */
+  struct ContextHandle new_parent_context_handle;
+} UpdateContextMeasurementResp;
+
+typedef struct DeriveContextExportedCdiResp {
+  struct ResponseHdr resp_hdr;
+  struct ContextHandle handle;
+  struct ContextHandle parent_handle;
+  uint8_t exported_cdi[MAX_EXPORTED_CDI_SIZE];
+  uint32_t certificate_size;
+  uint8_t new_certificate[MAX_CERT_SIZE];
+} DeriveContextExportedCdiResp;
+
+typedef struct SignP256Resp {
+  struct ResponseHdr resp_hdr;
+  struct ContextHandle new_context_handle;
+  uint8_t sig_r[32];
+  uint8_t sig_s[32];
+} SignP256Resp;
+
+typedef struct SignP384Resp {
+  struct ResponseHdr resp_hdr;
+  struct ContextHandle new_context_handle;
+  uint8_t sig_r[48];
+  uint8_t sig_s[48];
+} SignP384Resp;
+
+typedef struct GetCertificateChainResp {
+  struct ResponseHdr resp_hdr;
+  uint32_t certificate_size;
+  uint8_t certificate_chain[MAX_CHUNK_SIZE];
+} GetCertificateChainResp;
+
+enum PlatformError_Tag
+#ifdef __cplusplus
+  : uint16_t
+#endif // __cplusplus
+ {
+  PlatformError_CertificateChainError = 1,
+  PlatformError_NotImplemented = 2,
+  PlatformError_IssuerNameError = 3,
+  PlatformError_PrintError = 4,
+  PlatformError_SerialNumberError = 5,
+  PlatformError_SubjectKeyIdentifierError = 6,
+  PlatformError_CertValidityError = 7,
+  PlatformError_IssuerKeyIdentifierError = 8,
+  PlatformError_SubjectAlternativeNameError = 9,
+  PlatformError_MissingUeidError = 10,
+  PlatformError_InvalidUeidError = 11,
+};
+#ifndef __cplusplus
+typedef uint16_t PlatformError_Tag;
+#endif // __cplusplus
+
+typedef union PlatformError {
+  PlatformError_Tag tag;
+  struct {
+    PlatformError_Tag issuer_name_error_tag;
+    uint32_t issuer_name_error;
+  };
+  struct {
+    PlatformError_Tag print_error_tag;
+    uint32_t print_error;
+  };
+  struct {
+    PlatformError_Tag serial_number_error_tag;
+    uint32_t serial_number_error;
+  };
+  struct {
+    PlatformError_Tag subject_key_identifier_error_tag;
+    uint32_t subject_key_identifier_error;
+  };
+  struct {
+    PlatformError_Tag cert_validity_error_tag;
+    uint32_t cert_validity_error;
+  };
+  struct {
+    PlatformError_Tag issuer_key_identifier_error_tag;
+    uint32_t issuer_key_identifier_error;
+  };
+  struct {
+    PlatformError_Tag subject_alternative_name_error_tag;
+    uint32_t subject_alternative_name_error;
+  };
+} PlatformError;
+
+enum CryptoError_Tag
+#ifdef __cplusplus
+  : uint16_t
+#endif // __cplusplus
+ {
+  CryptoError_AbstractionLayer = 1,
+  CryptoError_CryptoLibError = 2,
+  CryptoError_Size = 3,
+  CryptoError_NotImplemented = 4,
+  CryptoError_HashError = 5,
+  CryptoError_InvalidExportedCdiHandle = 6,
+  CryptoError_ExportedCdiHandleDuplicateCdi = 7,
+  CryptoError_ExportedCdiHandleLimitExceeded = 8,
+  CryptoError_MismatchedAlgorithm = 9,
+};
+#ifndef __cplusplus
+typedef uint16_t CryptoError_Tag;
+#endif // __cplusplus
+
+typedef union CryptoError {
+  CryptoError_Tag tag;
+  struct {
+    CryptoError_Tag abstraction_layer_tag;
+    uint32_t abstraction_layer;
+  };
+  struct {
+    CryptoError_Tag crypto_lib_error_tag;
+    uint32_t crypto_lib_error;
+  };
+  struct {
+    CryptoError_Tag hash_error_tag;
+    uint32_t hash_error;
+  };
+} CryptoError;
+
+enum DpeErrorCode_Tag
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  DpeErrorCode_NoError = 0,
+  DpeErrorCode_InternalError = 1,
+  DpeErrorCode_InvalidCommand = 2,
+  DpeErrorCode_InvalidArgument = 3,
+  DpeErrorCode_ArgumentNotSupported = 4,
+  DpeErrorCode_X509CsrUnset = 5,
+  DpeErrorCode_X509InvalidState = 6,
+  DpeErrorCode_X509SkipsExhausted = 7,
+  DpeErrorCode_X509InvalidWidth = 8,
+  DpeErrorCode_X509AlgorithmMismatch = 9,
+  DpeErrorCode_InvalidHandle = 4096,
+  DpeErrorCode_InvalidLocality = 4097,
+  DpeErrorCode_MaxTcis = 4099,
+  DpeErrorCode_InvalidMutRefBuf = 4100,
+  DpeErrorCode_InvalidResponseBuf = 4101,
+  DpeErrorCode_UninitializedResponseHeader = 4102,
+  /**
+   * Returned by UpdateContextMeasurement when PARENT_CONTEXT_HANDLE does not
+   * exist in the caller's locality. Value matches the OCP iROT profile spec (0x85).
+   */
+  DpeErrorCode_InvalidParentLocality = 133,
+  DpeErrorCode_Platform = 16777216,
+  DpeErrorCode_Crypto = 33554432,
+  DpeErrorCode_Validation = 50331648,
+};
+#ifndef __cplusplus
+typedef uint32_t DpeErrorCode_Tag;
+#endif // __cplusplus
+
+typedef union DpeErrorCode {
+  DpeErrorCode_Tag tag;
+  struct {
+    DpeErrorCode_Tag platform_tag;
+    union PlatformError platform;
+  };
+  struct {
+    DpeErrorCode_Tag crypto_tag;
+    union CryptoError crypto;
+  };
+  struct {
+    DpeErrorCode_Tag validation_tag;
+    ValidationError validation;
+  };
+} DpeErrorCode;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/dpe/dpe_abi_p384.h
+++ b/dpe/dpe_abi_p384.h
@@ -1,0 +1,447 @@
+// Licensed under the Apache-2.0 license
+
+#ifndef MAX_CERT_SIZE
+#ifdef DPE_PROFILE_HYBRID
+#define MAX_CERT_SIZE (22 * 1024)
+#else
+#define MAX_CERT_SIZE (11 * 1024)
+#endif
+#endif
+
+#ifndef MAX_EXPORTED_CDI_SIZE
+#define MAX_EXPORTED_CDI_SIZE 32
+#endif
+
+#ifndef MAX_CHUNK_SIZE
+#define MAX_CHUNK_SIZE 2048
+#endif
+
+#ifndef SIZE
+#define SIZE 16
+#endif
+
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#define MAX_HANDLES 64
+
+
+
+#define TCI_SIZE 48
+
+#define Command_GET_PROFILE 1
+
+#define Command_INITIALIZE_CONTEXT 7
+
+#define Command_DERIVE_CONTEXT 8
+
+#define Command_CERTIFY_KEY 9
+
+#define Command_SIGN 10
+
+#define Command_ROTATE_CONTEXT_HANDLE 14
+
+#define Command_DESTROY_CONTEXT 15
+
+#define Command_GET_CERTIFICATE_CHAIN 16
+
+/**
+ * Vendor command: UpdateContextMeasurement (first vendor slot per the iROT profile spec).
+ */
+#define Command_UPDATE_CONTEXT_MEASUREMENT 2147483648
+
+#define CertifyKeyCommand_FORMAT_X509 0
+
+#define CertifyKeyCommand_FORMAT_CSR 1
+
+#define Context_ROOT_INDEX 255
+
+#define State_VERSION 1
+
+enum DpeProfile
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  DpeProfile_P256Sha256 = 3,
+  DpeProfile_P384Sha384 = 4,
+};
+#ifndef __cplusplus
+typedef uint32_t DpeProfile;
+#endif // __cplusplus
+
+/**
+ * It is possible that there are multiple issues with the DPE state. At most one will be found.
+ * There is no priority on which error will be found first if there are multiple.
+ */
+enum ValidationError
+#ifdef __cplusplus
+  : uint16_t
+#endif // __cplusplus
+ {
+  ValidationError_MultipleNormalConnectedComponents = 0,
+  ValidationError_CyclesInTree = 1,
+  ValidationError_InactiveContextInvalidParent = 2,
+  ValidationError_InactiveContextWithChildren = 3,
+  ValidationError_BadContextState = 4,
+  ValidationError_BadContextType = 5,
+  ValidationError_InactiveContextWithMeasurement = 6,
+  ValidationError_MixedContextLocality = 7,
+  ValidationError_MultipleDefaultContexts = 8,
+  ValidationError_SimulationNotSupported = 9,
+  ValidationError_ParentDoesNotExist = 10,
+  ValidationError_InternalDiceNotSupported = 11,
+  ValidationError_InternalInfoNotSupported = 12,
+  ValidationError_ChildDoesNotExist = 13,
+  ValidationError_InactiveContextWithFlagSet = 14,
+  ValidationError_LocalityMismatch = 15,
+  ValidationError_DanglingRetiredContext = 16,
+  ValidationError_MixedContextTypeConnectedComponents = 17,
+  ValidationError_ChildWithMultipleParents = 18,
+  ValidationError_ParentChildLinksCorrupted = 19,
+  ValidationError_AllowCaNotSupported = 20,
+  ValidationError_AllowX509NotSupported = 21,
+  ValidationError_InactiveParent = 22,
+  ValidationError_InactiveChild = 23,
+  ValidationError_DpeNotMarkedInitialized = 24,
+  ValidationError_InvalidMarker = 25,
+  ValidationError_VersionMismatch = 26,
+};
+#ifndef __cplusplus
+typedef uint16_t ValidationError;
+#endif // __cplusplus
+
+typedef struct CertifyKeyP256Resp CertifyKeyP256Resp;
+
+typedef struct CertifyKeyP384Resp CertifyKeyP384Resp;
+
+typedef struct CommandHdr {
+  uint32_t magic;
+  uint32_t cmd_id;
+  uint32_t profile;
+} CommandHdr;
+
+typedef struct InitCtxCmd {
+  uint32_t _0;
+} InitCtxCmd;
+
+typedef struct ContextHandle {
+  uint8_t _0[SIZE];
+} ContextHandle;
+#define ContextHandle_SIZE 16
+
+typedef uint8_t TciMeasurement[TCI_SIZE];
+
+typedef struct DeriveContextFlags {
+  uint32_t _0;
+} DeriveContextFlags;
+
+typedef struct DeriveContextCmd {
+  struct ContextHandle handle;
+  TciMeasurement data;
+  struct DeriveContextFlags flags;
+  uint32_t tci_type;
+  uint32_t target_locality;
+  uint32_t svn;
+} DeriveContextCmd;
+
+typedef struct CertifyKeyFlags {
+  uint32_t _0;
+} CertifyKeyFlags;
+
+typedef struct CertifyKeyP256Cmd {
+  struct ContextHandle handle;
+  struct CertifyKeyFlags flags;
+  uint32_t format;
+  uint8_t label[32];
+} CertifyKeyP256Cmd;
+
+typedef struct CertifyKeyP384Cmd {
+  struct ContextHandle handle;
+  struct CertifyKeyFlags flags;
+  uint32_t format;
+  uint8_t label[48];
+} CertifyKeyP384Cmd;
+
+typedef struct SignFlags {
+  uint32_t _0;
+} SignFlags;
+
+typedef struct SignP256Cmd {
+  struct ContextHandle handle;
+  uint8_t label[32];
+  struct SignFlags flags;
+  uint8_t digest[32];
+} SignP256Cmd;
+
+typedef struct SignP384Cmd {
+  struct ContextHandle handle;
+  uint8_t label[48];
+  struct SignFlags flags;
+  uint8_t digest[48];
+} SignP384Cmd;
+
+typedef struct DestroyCtxCmd {
+  struct ContextHandle handle;
+} DestroyCtxCmd;
+
+typedef struct GetCertificateChainCmd {
+  uint32_t offset;
+  uint32_t size;
+} GetCertificateChainCmd;
+
+/**
+ * ABI input structure for UpdateContextMeasurement.
+ *
+ * Wire layout (after CommandHdr):
+ * | Offset    | Type       | Name              | Description                          |
+ * |-----------|------------|-------------------|--------------------------------------|
+ * | 0x00      | BYTES[16]  | parent_handle     | Handle of the parent context.        |
+ * | 0x10      | HASH       | data              | New TCI measurement data.            |
+ * | 0x10+H    | U32        | reserved          | Reserved; must be zero.              |
+ * | 0x14+H    | U32        | tci_type          | INPUT_TYPE identifying the child.    |
+ * | 0x18+H    | U32        | reserved_svn      | Reserved; ignored by this command.   |
+ */
+typedef struct UpdateContextMeasurementCmd {
+  /**
+   * Handle of the parent context. Must not be the default handle.
+   */
+  struct ContextHandle parent_handle;
+  /**
+   * New TCI measurement to extend into the child context.
+   */
+  TciMeasurement data;
+  /**
+   * Reserved bitfield; must be zero.
+   */
+  uint32_t reserved;
+  /**
+   * Identifies the direct child of parent_handle to update (matched by tci_type).
+   */
+  uint32_t tci_type;
+  /**
+   * Reserved for future use; ignored by this command. SVN is fixed at context creation
+   * via DeriveContext and cannot be updated here.
+   */
+  uint32_t reserved_svn;
+} UpdateContextMeasurementCmd;
+
+typedef struct ResponseHdr {
+  uint32_t magic;
+  uint32_t status;
+  DpeProfile profile;
+} ResponseHdr;
+
+typedef struct GetProfileResp {
+  struct ResponseHdr resp_hdr;
+  uint16_t major_version;
+  uint16_t minor_version;
+  uint32_t vendor_id;
+  uint32_t vendor_sku;
+  uint32_t max_tci_nodes;
+  uint32_t flags;
+} GetProfileResp;
+
+typedef struct NewHandleResp {
+  struct ResponseHdr resp_hdr;
+  struct ContextHandle handle;
+} NewHandleResp;
+
+typedef struct DeriveContextResp {
+  struct ResponseHdr resp_hdr;
+  struct ContextHandle handle;
+  struct ContextHandle parent_handle;
+} DeriveContextResp;
+
+/**
+ * Response for the UpdateContextMeasurement vendor command.
+ */
+typedef struct UpdateContextMeasurementResp {
+  struct ResponseHdr resp_hdr;
+  /**
+   * Rotated handle for the updated child context.
+   */
+  struct ContextHandle new_context_handle;
+  /**
+   * Rotated handle for the parent context (always retained).
+   */
+  struct ContextHandle new_parent_context_handle;
+} UpdateContextMeasurementResp;
+
+typedef struct DeriveContextExportedCdiResp {
+  struct ResponseHdr resp_hdr;
+  struct ContextHandle handle;
+  struct ContextHandle parent_handle;
+  uint8_t exported_cdi[MAX_EXPORTED_CDI_SIZE];
+  uint32_t certificate_size;
+  uint8_t new_certificate[MAX_CERT_SIZE];
+} DeriveContextExportedCdiResp;
+
+typedef struct SignP256Resp {
+  struct ResponseHdr resp_hdr;
+  struct ContextHandle new_context_handle;
+  uint8_t sig_r[32];
+  uint8_t sig_s[32];
+} SignP256Resp;
+
+typedef struct SignP384Resp {
+  struct ResponseHdr resp_hdr;
+  struct ContextHandle new_context_handle;
+  uint8_t sig_r[48];
+  uint8_t sig_s[48];
+} SignP384Resp;
+
+typedef struct GetCertificateChainResp {
+  struct ResponseHdr resp_hdr;
+  uint32_t certificate_size;
+  uint8_t certificate_chain[MAX_CHUNK_SIZE];
+} GetCertificateChainResp;
+
+enum PlatformError_Tag
+#ifdef __cplusplus
+  : uint16_t
+#endif // __cplusplus
+ {
+  PlatformError_CertificateChainError = 1,
+  PlatformError_NotImplemented = 2,
+  PlatformError_IssuerNameError = 3,
+  PlatformError_PrintError = 4,
+  PlatformError_SerialNumberError = 5,
+  PlatformError_SubjectKeyIdentifierError = 6,
+  PlatformError_CertValidityError = 7,
+  PlatformError_IssuerKeyIdentifierError = 8,
+  PlatformError_SubjectAlternativeNameError = 9,
+  PlatformError_MissingUeidError = 10,
+  PlatformError_InvalidUeidError = 11,
+};
+#ifndef __cplusplus
+typedef uint16_t PlatformError_Tag;
+#endif // __cplusplus
+
+typedef union PlatformError {
+  PlatformError_Tag tag;
+  struct {
+    PlatformError_Tag issuer_name_error_tag;
+    uint32_t issuer_name_error;
+  };
+  struct {
+    PlatformError_Tag print_error_tag;
+    uint32_t print_error;
+  };
+  struct {
+    PlatformError_Tag serial_number_error_tag;
+    uint32_t serial_number_error;
+  };
+  struct {
+    PlatformError_Tag subject_key_identifier_error_tag;
+    uint32_t subject_key_identifier_error;
+  };
+  struct {
+    PlatformError_Tag cert_validity_error_tag;
+    uint32_t cert_validity_error;
+  };
+  struct {
+    PlatformError_Tag issuer_key_identifier_error_tag;
+    uint32_t issuer_key_identifier_error;
+  };
+  struct {
+    PlatformError_Tag subject_alternative_name_error_tag;
+    uint32_t subject_alternative_name_error;
+  };
+} PlatformError;
+
+enum CryptoError_Tag
+#ifdef __cplusplus
+  : uint16_t
+#endif // __cplusplus
+ {
+  CryptoError_AbstractionLayer = 1,
+  CryptoError_CryptoLibError = 2,
+  CryptoError_Size = 3,
+  CryptoError_NotImplemented = 4,
+  CryptoError_HashError = 5,
+  CryptoError_InvalidExportedCdiHandle = 6,
+  CryptoError_ExportedCdiHandleDuplicateCdi = 7,
+  CryptoError_ExportedCdiHandleLimitExceeded = 8,
+  CryptoError_MismatchedAlgorithm = 9,
+};
+#ifndef __cplusplus
+typedef uint16_t CryptoError_Tag;
+#endif // __cplusplus
+
+typedef union CryptoError {
+  CryptoError_Tag tag;
+  struct {
+    CryptoError_Tag abstraction_layer_tag;
+    uint32_t abstraction_layer;
+  };
+  struct {
+    CryptoError_Tag crypto_lib_error_tag;
+    uint32_t crypto_lib_error;
+  };
+  struct {
+    CryptoError_Tag hash_error_tag;
+    uint32_t hash_error;
+  };
+} CryptoError;
+
+enum DpeErrorCode_Tag
+#ifdef __cplusplus
+  : uint32_t
+#endif // __cplusplus
+ {
+  DpeErrorCode_NoError = 0,
+  DpeErrorCode_InternalError = 1,
+  DpeErrorCode_InvalidCommand = 2,
+  DpeErrorCode_InvalidArgument = 3,
+  DpeErrorCode_ArgumentNotSupported = 4,
+  DpeErrorCode_X509CsrUnset = 5,
+  DpeErrorCode_X509InvalidState = 6,
+  DpeErrorCode_X509SkipsExhausted = 7,
+  DpeErrorCode_X509InvalidWidth = 8,
+  DpeErrorCode_X509AlgorithmMismatch = 9,
+  DpeErrorCode_InvalidHandle = 4096,
+  DpeErrorCode_InvalidLocality = 4097,
+  DpeErrorCode_MaxTcis = 4099,
+  DpeErrorCode_InvalidMutRefBuf = 4100,
+  DpeErrorCode_InvalidResponseBuf = 4101,
+  DpeErrorCode_UninitializedResponseHeader = 4102,
+  /**
+   * Returned by UpdateContextMeasurement when PARENT_CONTEXT_HANDLE does not
+   * exist in the caller's locality. Value matches the OCP iROT profile spec (0x85).
+   */
+  DpeErrorCode_InvalidParentLocality = 133,
+  DpeErrorCode_Platform = 16777216,
+  DpeErrorCode_Crypto = 33554432,
+  DpeErrorCode_Validation = 50331648,
+};
+#ifndef __cplusplus
+typedef uint32_t DpeErrorCode_Tag;
+#endif // __cplusplus
+
+typedef union DpeErrorCode {
+  DpeErrorCode_Tag tag;
+  struct {
+    DpeErrorCode_Tag platform_tag;
+    union PlatformError platform;
+  };
+  struct {
+    DpeErrorCode_Tag crypto_tag;
+    union CryptoError crypto;
+  };
+  struct {
+    DpeErrorCode_Tag validation_tag;
+    ValidationError validation;
+  };
+} DpeErrorCode;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,4 +10,5 @@ version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+cbindgen.workspace = true
 clap.workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -32,6 +32,10 @@ enum Commands {
     Precheckin(PrecheckinArgs),
     /// Run a tool from the tools/ folder
     RunTool(RunToolArgs),
+    /// Generate C header for DPE ABI
+    GenerateAbi,
+    /// Check if generated C headers are up-to-date
+    CheckAbi,
 }
 
 #[derive(Parser)]
@@ -98,6 +102,8 @@ fn main() -> Result<()> {
         Commands::Test(args) => run_test_command(args)?,
         Commands::Precheckin(args) => run_precheckin_command(args)?,
         Commands::RunTool(args) => run_tool_command(args)?,
+        Commands::GenerateAbi => run_generate_abi()?,
+        Commands::CheckAbi => run_check_abi()?,
     }
 
     Ok(())
@@ -106,6 +112,7 @@ fn main() -> Result<()> {
 fn run_ci() -> Result<()> {
     run_precheckin()?;
     run_tests()?;
+    run_check_abi()?;
 
     // Additional checks for specific binaries/tools
     cargo_run(
@@ -192,6 +199,103 @@ fn run_tool_command(args: &RunToolArgs) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn generate_abi_string(profile: &str, base_config: &cbindgen::Config) -> Result<String> {
+    let crate_dir = Path::new("dpe");
+    let mut config = base_config.clone();
+
+    if profile == "hybrid" {
+        if let Some(ref mut header) = config.header {
+            let license = "// Licensed under the Apache-2.0 license";
+            *header = header.replace(
+                license,
+                &format!("{}\n\n#define DPE_PROFILE_HYBRID", license),
+            );
+        }
+    }
+
+    let bindings = cbindgen::Builder::new()
+        .with_crate(crate_dir)
+        .with_config(config)
+        .generate()
+        .map_err(|e| anyhow!("Failed to generate bindings for {}: {:?}", profile, e))?;
+
+    let mut buffer = Vec::new();
+    bindings.write(&mut buffer);
+    let mut content = String::from_utf8(buffer)
+        .map_err(|e| anyhow!("Failed to convert bindings to string: {:?}", e))?;
+
+    // Post-process to fix TCI_SIZE and DpeProfile_Mldsa87
+    if profile == "p256" {
+        content = content.replace("#define TCI_SIZE 48", "");
+        content = content.replace("\n  DpeProfile_Mldsa87 = 5,", "");
+    } else if profile == "p384" {
+        content = content.replace("#define TCI_SIZE 32", "");
+        content = content.replace("\n  DpeProfile_Mldsa87 = 5,", "");
+    } else {
+        content = content.replace("#define TCI_SIZE 32", "");
+    }
+
+    Ok(content)
+}
+
+fn run_generate_abi() -> Result<()> {
+    println!("Generating DPE ABI C headers...");
+    let config_file = Path::new("dpe/cbindgen.toml");
+    let base_config = cbindgen::Config::from_file(config_file)
+        .map_err(|e| anyhow!("Failed to load cbindgen config: {:?}", e))?;
+
+    let profiles = ["p256", "p384", "hybrid"];
+
+    for profile in profiles {
+        let content = generate_abi_string(profile, &base_config)?;
+        let output_file = format!("dpe/dpe_abi_{}.h", profile);
+        let output_path = Path::new(&output_file);
+        println!(
+            "Writing header for profile: {} -> {:?}",
+            profile, output_path
+        );
+        std::fs::write(output_path, content)?;
+    }
+
+    Ok(())
+}
+
+fn run_check_abi() -> Result<()> {
+    println!("Checking DPE ABI C headers...");
+    let config_file = Path::new("dpe/cbindgen.toml");
+    let base_config = cbindgen::Config::from_file(config_file)
+        .map_err(|e| anyhow!("Failed to load cbindgen config: {:?}", e))?;
+
+    let profiles = ["p256", "p384", "hybrid"];
+    let mut stale = false;
+
+    for profile in profiles {
+        let generated = generate_abi_string(profile, &base_config)?;
+        let output_file = format!("dpe/dpe_abi_{}.h", profile);
+        let output_path = Path::new(&output_file);
+
+        if !output_path.exists() {
+            println!("Header for {} does not exist: {:?}", profile, output_path);
+            stale = true;
+            continue;
+        }
+
+        let existing = std::fs::read_to_string(output_path)?;
+
+        if generated != existing {
+            println!("Header for {} is stale!", profile);
+            stale = true;
+        }
+    }
+
+    if stale {
+        Err(anyhow!("DPE ABI C headers are stale. Please run 'cargo xtask generate-abi' to regenerate them."))
+    } else {
+        println!("DPE ABI C headers are up-to-date.");
+        Ok(())
+    }
 }
 
 fn run_unit_tests() -> Result<()> {


### PR DESCRIPTION
This creates two new xtask workflows. One for generating the C header ABI files and one for checking if they need to be updated. The second is added to the CI checks to make sure it doesn't get stale.

The flows create a separate header file for each profile so integrators can reference their given profile directly.