### PR TITLE
lint: Fix lifetimes for new lint

### DIFF
--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -60,7 +60,7 @@ impl Command<'_> {
     /// # Arguments
     ///
     /// * `bytes` - serialized command
-    pub fn deserialize(bytes: &[u8]) -> Result<Command, DpeErrorCode> {
+    pub fn deserialize(bytes: &[u8]) -> Result<Command<'_>, DpeErrorCode> {
         let header = CommandHdr::try_from(bytes)?;
         let bytes = &bytes[size_of::<CommandHdr>()..];
 

--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -206,7 +206,7 @@ pub(crate) struct ChildToRootIter<'a> {
 
 impl ChildToRootIter<'_> {
     /// Create a new iterator that will start at the leaf and go to the root node.
-    pub fn new(leaf_idx: usize, contexts: &[Context]) -> ChildToRootIter {
+    pub fn new(leaf_idx: usize, contexts: &[Context]) -> ChildToRootIter<'_> {
         ChildToRootIter {
             idx: leaf_idx,
             contexts,

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -189,7 +189,7 @@ impl CertWriter<'_> {
     ///
     /// If `crit_dice`, all tcg-dice-* extensions will be marked as critical.
     /// Else they will be marked as non-critical.
-    pub fn new(cert: &mut [u8], crit_dice: bool) -> CertWriter {
+    pub fn new(cert: &mut [u8], crit_dice: bool) -> CertWriter<'_> {
         CertWriter {
             certificate: cert,
             offset: 0,


### PR DESCRIPTION
In preparation for supporting the compiler version 1.95 patch some lifetime statements to be more clear.