### PR TITLE
dpe: Update cfi library dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,20 +168,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "caliptra-cfi-derive-git"
+name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
+source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=aa96c53073ce7f298f7482c1ac57f5f65ffc115e#aa96c53073ce7f298f7482c1ac57f5f65ffc115e"
 dependencies = [
- "paste",
+ "pastey",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
 ]
 
 [[package]]
-name = "caliptra-cfi-lib-git"
+name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
+source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=aa96c53073ce7f298f7482c1ac57f5f65ffc115e#aa96c53073ce7f298f7482c1ac57f5f65ffc115e"
 
 [[package]]
 name = "cc"
@@ -292,8 +292,8 @@ version = "0.1.0"
 dependencies = [
  "arrayvec",
  "base64ct",
- "caliptra-cfi-derive-git",
- "caliptra-cfi-lib-git",
+ "caliptra-cfi-derive",
+ "caliptra-cfi-lib",
  "ecdsa",
  "hkdf",
  "openssl",
@@ -421,8 +421,8 @@ version = "0.1.0"
 dependencies = [
  "asn1",
  "bitflags",
- "caliptra-cfi-derive-git",
- "caliptra-cfi-lib-git",
+ "caliptra-cfi-derive",
+ "caliptra-cfi-lib",
  "cfg-if",
  "cms",
  "constant_time_eq",
@@ -784,10 +784,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.14"
+name = "pastey"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "pem"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ members = [
 ]
 
 [workspace.dependencies]
-caliptra-cfi-lib-git = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-lib-git", rev = "a98e499d279e81ae85881991b1e9eee354151189", default-features = false, features = ["cfi", "cfi-counter" ] }
-caliptra-cfi-derive-git = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-derive-git", rev = "a98e499d279e81ae85881991b1e9eee354151189"}
+caliptra-cfi-lib = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-lib", rev = "aa96c53073ce7f298f7482c1ac57f5f65ffc115e", default-features = false, features = ["cfi", "cfi-counter"] }
+caliptra-cfi-derive = { git = "https://github.com/chipsalliance/caliptra-cfi.git", package = "caliptra-cfi-derive", rev = "aa96c53073ce7f298f7482c1ac57f5f65ffc115e" }
 zerocopy = { version = "0.8.17", features = ["derive"] }
 openssl = "0.10.64"
 

--- a/ci.sh
+++ b/ci.sh
@@ -7,7 +7,7 @@ set -ex
 function build_rust_targets() {
   profile=$1
 
-  cargo build --release --manifest-path dpe/Cargo.toml --features=$profile,no-cfi --no-default-features
+  cargo build --release --manifest-path dpe/Cargo.toml --features=$profile --no-default-features
 
   cargo build --release --manifest-path crypto/Cargo.toml --no-default-features
   cargo build --release --manifest-path platform/Cargo.toml --features=$profile --no-default-features

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 openssl = ["dep:openssl", "dep:hkdf", "dep:sha2"]
 rustcrypto = ["dep:hkdf", "dep:p256", "dep:p384", "dep:rand", "dep:sha2", "dep:base64ct", "dep:ecdsa", "dep:sec1"]
 deterministic_rand = ["dep:rand"]
-no-cfi = []
+cfi = []
 
 [dependencies]
 arrayvec = { version = "0.7.4", default-features = false, features = ["zeroize"] }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -13,8 +13,8 @@ no-cfi = []
 
 [dependencies]
 arrayvec = { version = "0.7.4", default-features = false, features = ["zeroize"] }
-caliptra-cfi-lib-git = { workspace = true, default-features = false, features = ["cfi", "cfi-counter" ] }
-caliptra-cfi-derive-git.workspace = true
+caliptra-cfi-lib = { workspace = true, default-features = false, features = ["cfi", "cfi-counter"] }
+caliptra-cfi-derive.workspace = true
 ecdsa = { version = "0.16.9", optional = true, features = ["pem"]}
 hkdf = { version = "0.12.3", optional = true }
 openssl = {workspace = true, optional = true}

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -197,7 +197,7 @@ pub trait Crypto {
     ///
     /// To implement this function, you need to add the
     /// cfi_impl_fn proc_macro to derive_cdi.
-    #[cfg(not(feature = "no-cfi"))]
+    #[cfg(feature = "cfi")]
     fn __cfi_derive_cdi(
         &mut self,
         algs: AlgLen,
@@ -209,7 +209,7 @@ pub trait Crypto {
     ///
     /// To implement this function, you need to add the
     /// cfi_impl_fn proc_macro to derive_exported_cdi.
-    #[cfg(not(feature = "no-cfi"))]
+    #[cfg(feature = "cfi")]
     fn __cfi_derive_exported_cdi(
         &mut self,
         algs: AlgLen,
@@ -256,7 +256,7 @@ pub trait Crypto {
     ///
     /// To implement this function, you need to add the
     /// cfi_impl_fn proc_macro to derive_key_pair.
-    #[cfg(not(feature = "no-cfi"))]
+    #[cfg(feature = "cfi")]
     fn __cfi_derive_key_pair(
         &mut self,
         algs: AlgLen,
@@ -269,7 +269,7 @@ pub trait Crypto {
     ///
     /// To implement this function, you need to add the
     /// cfi_impl_fn proc_macro to derive_key_pair.
-    #[cfg(not(feature = "no-cfi"))]
+    #[cfg(feature = "cfi")]
     fn __cfi_derive_key_pair_exported(
         &mut self,
         algs: AlgLen,

--- a/crypto/src/openssl.rs
+++ b/crypto/src/openssl.rs
@@ -5,7 +5,7 @@ use crate::{
     MAX_EXPORTED_CDI_SIZE,
 };
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 use openssl::{
     bn::{BigNum, BigNumContext},
     ec::{EcGroup, EcKey, EcPoint},

--- a/crypto/src/openssl.rs
+++ b/crypto/src/openssl.rs
@@ -4,7 +4,7 @@ use crate::{
     hkdf::*, AlgLen, Crypto, CryptoBuf, CryptoError, Digest, EcdsaPub, ExportedCdiHandle, Hasher,
     MAX_EXPORTED_CDI_SIZE,
 };
-#[cfg(not(feature = "no-cfi"))]
+#[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
 use openssl::{
     bn::{BigNum, BigNumContext},
@@ -171,7 +171,7 @@ impl Crypto for OpensslCrypto {
         Ok(OpensslHasher(openssl::hash::Hasher::new(md)?))
     }
 
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn derive_cdi(
         &mut self,
         algs: AlgLen,
@@ -182,7 +182,7 @@ impl Crypto for OpensslCrypto {
         Ok(cdi)
     }
 
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn derive_exported_cdi(
         &mut self,
         algs: AlgLen,
@@ -207,7 +207,7 @@ impl Crypto for OpensslCrypto {
         Ok(exported_cdi_handle)
     }
 
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn derive_key_pair(
         &mut self,
         algs: AlgLen,
@@ -218,7 +218,7 @@ impl Crypto for OpensslCrypto {
         self.derive_key_pair_inner(algs, cdi, label, info)
     }
 
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn derive_key_pair_exported(
         &mut self,
         algs: AlgLen,

--- a/crypto/src/rustcrypto.rs
+++ b/crypto/src/rustcrypto.rs
@@ -134,7 +134,7 @@ impl Crypto for RustCryptoImpl {
         Ok(())
     }
 
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn derive_cdi(
         &mut self,
         algs: AlgLen,
@@ -144,7 +144,7 @@ impl Crypto for RustCryptoImpl {
         hkdf_derive_cdi(algs, measurement, info)
     }
 
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn derive_exported_cdi(
         &mut self,
         algs: AlgLen,
@@ -169,7 +169,7 @@ impl Crypto for RustCryptoImpl {
         Ok(exported_cdi_handle)
     }
 
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn derive_key_pair(
         &mut self,
         algs: AlgLen,
@@ -180,7 +180,7 @@ impl Crypto for RustCryptoImpl {
         self.derive_key_pair_inner(algs, cdi, label, info)
     }
 
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn derive_key_pair_exported(
         &mut self,
         algs: AlgLen,

--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["dpe_profile_p256_sha256", "no-cfi"]
+default = ["dpe_profile_p256_sha256"]
 dpe_profile_p256_sha256 = ["platform/dpe_profile_p256_sha256"]
 dpe_profile_p384_sha384 = ["platform/dpe_profile_p384_sha384"]
 # Run ARBITRARY_MAX_HANDLES=n cargo build --features arbitrary_max_handles to use this feature
@@ -21,7 +21,7 @@ disable_internal_info = []
 disable_internal_dice = []
 disable_retain_parent_context = []
 disable_export_cdi = []
-no-cfi = ["crypto/no-cfi"]
+cfi = ["crypto/cfi"]
 
 [dependencies]
 bitflags = "2.4.0"

--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -25,8 +25,8 @@ no-cfi = ["crypto/no-cfi"]
 
 [dependencies]
 bitflags = "2.4.0"
-caliptra-cfi-lib-git = { workspace = true, default-features = false, features = ["cfi", "cfi-counter" ] }
-caliptra-cfi-derive-git.workspace = true
+caliptra-cfi-lib = { workspace = true, default-features = false, features = ["cfi", "cfi-counter"] }
+caliptra-cfi-derive.workspace = true
 constant_time_eq = "0.3.0"
 crypto = {path = "../crypto", default-features = false}
 platform = {path = "../platform", default-features = false}
@@ -37,7 +37,7 @@ cfg-if = "1.0.0"
 
 [dev-dependencies]
 asn1 = "0.13.0"
-caliptra-cfi-lib-git = { workspace = true, features = ["cfi-test"] }
+caliptra-cfi-lib = { workspace = true, features = ["cfi-test"] }
 openssl.workspace = true
 x509-parser = "0.15.1"
 crypto = {path = "../crypto", features = ["deterministic_rand", "openssl"]}

--- a/dpe/fuzz/Cargo.lock
+++ b/dpe/fuzz/Cargo.lock
@@ -51,20 +51,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "caliptra-cfi-derive-git"
+name = "caliptra-cfi-derive"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
+source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=aa96c53073ce7f298f7482c1ac57f5f65ffc115e#aa96c53073ce7f298f7482c1ac57f5f65ffc115e"
 dependencies = [
- "paste",
+ "pastey",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
 ]
 
 [[package]]
-name = "caliptra-cfi-lib-git"
+name = "caliptra-cfi-lib"
 version = "0.1.0"
-source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=a98e499d279e81ae85881991b1e9eee354151189#a98e499d279e81ae85881991b1e9eee354151189"
+source = "git+https://github.com/chipsalliance/caliptra-cfi.git?rev=aa96c53073ce7f298f7482c1ac57f5f65ffc115e#aa96c53073ce7f298f7482c1ac57f5f65ffc115e"
 
 [[package]]
 name = "cc"
@@ -108,8 +108,8 @@ name = "crypto"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
- "caliptra-cfi-derive-git",
- "caliptra-cfi-lib-git",
+ "caliptra-cfi-derive",
+ "caliptra-cfi-lib",
  "hkdf",
  "openssl",
  "sha2",
@@ -175,8 +175,8 @@ name = "dpe"
 version = "0.1.0"
 dependencies = [
  "bitflags",
- "caliptra-cfi-derive-git",
- "caliptra-cfi-lib-git",
+ "caliptra-cfi-derive",
+ "caliptra-cfi-lib",
  "cfg-if",
  "constant_time_eq",
  "crypto",
@@ -356,10 +356,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.14"
+name = "pastey"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pem-rfc7468"

--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -8,9 +8,9 @@ use crate::{
     DPE_PROFILE, MAX_CERT_SIZE,
 };
 use bitflags::bitflags;
-#[cfg(not(feature = "no-cfi"))]
+#[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
-#[cfg(not(feature = "no-cfi"))]
+#[cfg(feature = "cfi")]
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_assert_eq};
 use cfg_if::cfg_if;
 #[cfg(not(feature = "disable_x509"))]
@@ -53,7 +53,7 @@ impl CertifyKeyCmd {
 }
 
 impl CommandExecution for CertifyKeyCmd {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn execute(
         &self,
         dpe: &mut DpeInstance,
@@ -80,7 +80,7 @@ impl CommandExecution for CertifyKeyCmd {
         }
 
         cfg_if! {
-            if #[cfg(not(feature = "no-cfi"))] {
+            if #[cfg(feature = "cfi")] {
                 cfi_assert!(self.format != Self::FORMAT_X509 || dpe.support.x509());
                 cfi_assert!(self.format != Self::FORMAT_X509 || context.allow_x509());
                 cfi_assert!(self.format != Self::FORMAT_CSR || dpe.support.csr());
@@ -107,7 +107,7 @@ impl CommandExecution for CertifyKeyCmd {
             Self::FORMAT_X509 => {
                 cfg_if! {
                     if #[cfg(not(feature = "disable_x509"))] {
-                        #[cfg(not(feature = "no-cfi"))]
+                        #[cfg(feature = "cfi")]
                         cfi_assert_eq(self.format, Self::FORMAT_X509);
                         create_dpe_cert(&args, dpe, env, &mut cert)
                     } else {
@@ -118,7 +118,7 @@ impl CommandExecution for CertifyKeyCmd {
             Self::FORMAT_CSR => {
                 cfg_if! {
                     if #[cfg(not(feature = "disable_csr"))] {
-                        #[cfg(not(feature = "no-cfi"))]
+                        #[cfg(feature = "cfi")]
                         cfi_assert_eq(self.format, Self::FORMAT_CSR);
                         create_dpe_csr(&args, dpe, env, &mut cert)
                     } else {

--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -9,9 +9,9 @@ use crate::{
 };
 use bitflags::bitflags;
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_assert_eq};
 use cfg_if::cfg_if;
 #[cfg(not(feature = "disable_x509"))]
 #[repr(C)]
@@ -165,7 +165,7 @@ mod tests {
         support::Support,
         x509::{tests::TcbInfo, DirectoryString, Name},
     };
-    use caliptra_cfi_lib_git::CfiCounter;
+    use caliptra_cfi_lib::CfiCounter;
     use cms::{
         content_info::{CmsVersion, ContentInfo},
         signed_data::{SignedData, SignerIdentifier},

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -13,9 +13,9 @@ use crate::{
 };
 use bitflags::bitflags;
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_assert_eq};
 use cfg_if::cfg_if;
 
 use platform::Platform;
@@ -432,7 +432,7 @@ mod tests {
         validation::DpeValidator,
         DpeProfile, MAX_EXPORTED_CDI_SIZE, MAX_HANDLES,
     };
-    use caliptra_cfi_lib_git::CfiCounter;
+    use caliptra_cfi_lib::CfiCounter;
     use crypto::{Crypto, Hasher, OpensslCrypto};
     use openssl::{
         bn::BigNum,

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -12,9 +12,9 @@ use crate::{
     DPE_PROFILE, MAX_CERT_SIZE,
 };
 use bitflags::bitflags;
-#[cfg(not(feature = "no-cfi"))]
+#[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
-#[cfg(not(feature = "no-cfi"))]
+#[cfg(feature = "cfi")]
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_assert_eq};
 use cfg_if::cfg_if;
 
@@ -197,7 +197,7 @@ impl DeriveContextCmd {
 }
 
 impl CommandExecution for DeriveContextCmd {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn execute(
         &self,
         dpe: &mut DpeInstance,
@@ -228,17 +228,17 @@ impl CommandExecution for DeriveContextCmd {
         }
 
         let target_locality = if !self.changes_locality() {
-            #[cfg(not(feature = "no-cfi"))]
+            #[cfg(feature = "cfi")]
             cfi_assert!(!self.changes_locality());
             locality
         } else {
-            #[cfg(not(feature = "no-cfi"))]
+            #[cfg(feature = "cfi")]
             cfi_assert!(self.changes_locality());
             self.target_locality
         };
 
         cfg_if! {
-            if #[cfg(not(feature = "no-cfi"))] {
+            if #[cfg(feature = "cfi")] {
                 cfi_assert!(dpe.support.internal_info() || !self.uses_internal_info_input());
                 cfi_assert!(dpe.support.internal_dice() || !self.uses_internal_dice_input());
                 cfi_assert!(dpe.support.retain_parent_context() || !self.retains_parent());
@@ -255,7 +255,7 @@ impl CommandExecution for DeriveContextCmd {
                     if tmp_context.tci.tci_type != self.tci_type {
                         return Err(DpeErrorCode::InvalidArgument);
                     } else {
-                        #[cfg(not(feature = "no-cfi"))]
+                        #[cfg(feature = "cfi")]
                         cfi_assert_eq(tmp_context.tci.tci_type, self.tci_type);
                     }
                     dpe.add_tci_measurement(
@@ -293,14 +293,14 @@ impl CommandExecution for DeriveContextCmd {
                 tmp_parent_context.handle = dpe.generate_new_handle(env)?;
             } else {
                 cfg_if! {
-                    if #[cfg(not(feature = "no-cfi"))] {
+                    if #[cfg(feature = "cfi")] {
                         cfi_assert!(self.retains_parent());
                         cfi_assert!(tmp_parent_context.handle.is_default());
                     }
                 }
             }
         } else {
-            #[cfg(not(feature = "no-cfi"))]
+            #[cfg(feature = "cfi")]
             cfi_assert!(!self.retains_parent());
             tmp_parent_context.state = ContextState::Retired;
             tmp_parent_context.handle = ContextHandle::new_invalid();
@@ -362,16 +362,16 @@ impl CommandExecution for DeriveContextCmd {
         if !safe_to_make_child {
             return Err(DpeErrorCode::InvalidArgument);
         } else {
-            #[cfg(not(feature = "no-cfi"))]
+            #[cfg(feature = "cfi")]
             cfi_assert!(safe_to_make_child);
         }
 
         let child_handle = if self.makes_default() {
-            #[cfg(not(feature = "no-cfi"))]
+            #[cfg(feature = "cfi")]
             cfi_assert!(self.makes_default());
             ContextHandle::default()
         } else {
-            #[cfg(not(feature = "no-cfi"))]
+            #[cfg(feature = "cfi")]
             cfi_assert!(!self.makes_default());
             dpe.generate_new_handle(env)?
         };

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -6,10 +6,10 @@ use crate::{
     response::{DpeErrorCode, Response, ResponseHdr},
     MAX_HANDLES,
 };
-#[cfg(not(feature = "no-cfi"))]
+#[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_cfi_lib::cfi_launder;
-#[cfg(not(feature = "no-cfi"))]
+#[cfg(feature = "cfi")]
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_assert_eq};
 
 #[repr(C)]
@@ -37,7 +37,7 @@ pub(crate) fn destroy_context(
     if context.locality != locality {
         return Err(DpeErrorCode::InvalidLocality);
     } else {
-        #[cfg(not(feature = "no-cfi"))]
+        #[cfg(feature = "cfi")]
         cfi_assert_eq(context.locality, locality);
     }
 
@@ -56,7 +56,7 @@ pub(crate) fn destroy_context(
         if parent_context.state == ContextState::Retired && cfi_launder(child_context_count) == 1 {
             retired_contexts |= 1 << parent_idx;
         } else {
-            #[cfg(not(feature = "no-cfi"))]
+            #[cfg(feature = "cfi")]
             cfi_assert!(parent_context.state != ContextState::Retired || child_context_count != 1);
             break;
         }
@@ -74,7 +74,7 @@ pub(crate) fn destroy_context(
         if to_destroy & (1 << idx) != 0 {
             c.destroy();
         } else {
-            #[cfg(not(feature = "no-cfi"))]
+            #[cfg(feature = "cfi")]
             cfi_assert_eq(to_destroy & (1 << idx), 0);
         }
     }
@@ -82,7 +82,7 @@ pub(crate) fn destroy_context(
 }
 
 impl CommandExecution for DestroyCtxCmd {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn execute(
         &self,
         dpe: &mut DpeInstance,

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -7,10 +7,10 @@ use crate::{
     MAX_HANDLES,
 };
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
-use caliptra_cfi_lib_git::cfi_launder;
+use caliptra_cfi_derive::cfi_impl_fn;
+use caliptra_cfi_lib::cfi_launder;
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_assert_eq};
 
 #[repr(C)]
 #[derive(
@@ -109,7 +109,7 @@ mod tests {
         support::{test::SUPPORT, Support},
         DPE_PROFILE,
     };
-    use caliptra_cfi_lib_git::CfiCounter;
+    use caliptra_cfi_lib::CfiCounter;
     use crypto::OpensslCrypto;
     use platform::default::DefaultPlatform;
     use zerocopy::IntoBytes;

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -5,7 +5,7 @@ use crate::{
     response::{DpeErrorCode, GetCertificateChainResp, Response, ResponseHdr},
 };
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 use platform::{Platform, MAX_CHUNK_SIZE};
 
 #[repr(C)]
@@ -59,7 +59,7 @@ mod tests {
         },
         support::test::SUPPORT,
     };
-    use caliptra_cfi_lib_git::CfiCounter;
+    use caliptra_cfi_lib::CfiCounter;
     use crypto::OpensslCrypto;
     use platform::default::DefaultPlatform;
     use zerocopy::IntoBytes;

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -4,7 +4,7 @@ use crate::{
     dpe_instance::{DpeEnv, DpeInstance, DpeTypes},
     response::{DpeErrorCode, GetCertificateChainResp, Response, ResponseHdr},
 };
-#[cfg(not(feature = "no-cfi"))]
+#[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
 use platform::{Platform, MAX_CHUNK_SIZE};
 
@@ -24,7 +24,7 @@ pub struct GetCertificateChainCmd {
 }
 
 impl CommandExecution for GetCertificateChainCmd {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn execute(
         &self,
         _dpe: &mut DpeInstance,

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -6,9 +6,9 @@ use crate::{
     response::{DpeErrorCode, NewHandleResp, Response, ResponseHdr},
 };
 use bitflags::bitflags;
-#[cfg(not(feature = "no-cfi"))]
+#[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
-#[cfg(not(feature = "no-cfi"))]
+#[cfg(feature = "cfi")]
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool};
 use cfg_if::cfg_if;
 
@@ -50,7 +50,7 @@ impl InitCtxCmd {
 }
 
 impl CommandExecution for InitCtxCmd {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn execute(
         &self,
         dpe: &mut DpeInstance,
@@ -72,7 +72,7 @@ impl CommandExecution for InitCtxCmd {
         }
 
         cfg_if! {
-            if #[cfg(not(feature = "no-cfi"))] {
+            if #[cfg(feature = "cfi")] {
                 cfi_assert!(!self.flag_is_default() || !dpe.has_initialized());
                 cfi_assert!(!self.flag_is_simulation() || dpe.support.simulation());
                 cfi_assert!(self.flag_is_default() ^ self.flag_is_simulation());

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -7,9 +7,9 @@ use crate::{
 };
 use bitflags::bitflags;
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
+use caliptra_cfi_derive::cfi_impl_fn;
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool};
 use cfg_if::cfg_if;
 
 #[repr(C)]
@@ -119,7 +119,7 @@ mod tests {
         },
         support::Support,
     };
-    use caliptra_cfi_lib_git::CfiCounter;
+    use caliptra_cfi_lib::CfiCounter;
     use crypto::OpensslCrypto;
     use platform::default::DefaultPlatform;
     use zerocopy::IntoBytes;

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -32,7 +32,7 @@ mod rotate_context;
 mod sign;
 
 #[derive(Debug, PartialEq, Eq)]
-#[cfg_attr(not(feature = "no-cfi"), derive(caliptra_cfi_derive::Launder))]
+#[cfg_attr(feature = "cfi", derive(caliptra_cfi_derive::Launder))]
 pub enum Command<'a> {
     GetProfile,
     InitCtx(&'a InitCtxCmd),
@@ -119,7 +119,7 @@ pub trait CommandExecution {
     ///
     /// To implement this function, you need to add the
     /// cfi_impl_fn proc_macro to execute.
-    #[cfg(not(feature = "no-cfi"))]
+    #[cfg(feature = "cfi")]
     fn __cfi_execute(
         &self,
         dpe: &mut DpeInstance,

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -32,6 +32,7 @@ mod rotate_context;
 mod sign;
 
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(not(feature = "no-cfi"), derive(caliptra_cfi_derive::Launder))]
 pub enum Command<'a> {
     GetProfile,
     InitCtx(&'a InitCtxCmd),
@@ -179,7 +180,7 @@ impl TryFrom<&[u8]> for CommandHdr {
 pub mod tests {
     use super::*;
     use crate::{DpeProfile, DPE_PROFILE};
-    use caliptra_cfi_lib_git::CfiCounter;
+    use caliptra_cfi_lib::CfiCounter;
     use zerocopy::IntoBytes;
 
     #[cfg(feature = "dpe_profile_p256_sha256")]

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -6,10 +6,10 @@ use crate::{
     response::{DpeErrorCode, NewHandleResp, Response, ResponseHdr},
 };
 use bitflags::bitflags;
-#[cfg(not(feature = "no-cfi"))]
+#[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_cfi_lib::cfi_launder;
-#[cfg(not(feature = "no-cfi"))]
+#[cfg(feature = "cfi")]
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool};
 
 #[repr(C)]
@@ -77,7 +77,7 @@ impl RotateCtxCmd {
 }
 
 impl CommandExecution for RotateCtxCmd {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn execute(
         &self,
         dpe: &mut DpeInstance,
@@ -87,7 +87,7 @@ impl CommandExecution for RotateCtxCmd {
         if !dpe.support.rotate_context() {
             return Err(DpeErrorCode::InvalidCommand);
         } else {
-            #[cfg(not(feature = "no-cfi"))]
+            #[cfg(feature = "cfi")]
             cfi_assert!(dpe.support.rotate_context());
         }
         let idx = dpe.get_active_context_pos(&self.handle, locality)?;
@@ -101,11 +101,11 @@ impl CommandExecution for RotateCtxCmd {
             if default_context_idx.is_ok() || cfi_launder(non_default_valid_handles_exist) {
                 return Err(DpeErrorCode::InvalidArgument);
             } else {
-                #[cfg(not(feature = "no-cfi"))]
+                #[cfg(feature = "cfi")]
                 cfi_assert!(default_context_idx.is_err() && !non_default_valid_handles_exist);
             }
         } else {
-            #[cfg(not(feature = "no-cfi"))]
+            #[cfg(feature = "cfi")]
             cfi_assert!(!self.uses_target_is_default());
         }
 

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -7,10 +7,10 @@ use crate::{
 };
 use bitflags::bitflags;
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
-use caliptra_cfi_lib_git::cfi_launder;
+use caliptra_cfi_derive::cfi_impl_fn;
+use caliptra_cfi_lib::cfi_launder;
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool};
 
 #[repr(C)]
 #[derive(
@@ -134,7 +134,7 @@ mod tests {
         },
         support::Support,
     };
-    use caliptra_cfi_lib_git::CfiCounter;
+    use caliptra_cfi_lib::CfiCounter;
     use crypto::OpensslCrypto;
     use platform::default::DefaultPlatform;
     use zerocopy::IntoBytes;

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -7,10 +7,10 @@ use crate::{
     DPE_PROFILE,
 };
 use bitflags::bitflags;
-#[cfg(not(feature = "no-cfi"))]
+#[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_cfi_lib::cfi_launder;
-#[cfg(not(feature = "no-cfi"))]
+#[cfg(feature = "cfi")]
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_assert_ne};
 use cfg_if::cfg_if;
 use crypto::{Crypto, Digest, EcdsaSig};
@@ -57,7 +57,7 @@ impl SignCmd {
     /// * `env` - DPE environment containing Crypto and Platform implementations
     /// * `idx` - The index of the context where the measurement hash is computed from
     /// * `digest` - The data to be signed
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn ecdsa_sign(
         &self,
         dpe: &mut DpeInstance,
@@ -72,10 +72,10 @@ impl SignCmd {
             .derive_cdi(DPE_PROFILE.alg_len(), &cdi_digest, b"DPE")?;
         let key_pair = env.crypto.derive_key_pair(algs, &cdi, &self.label, b"ECC");
         if cfi_launder(key_pair.is_ok()) {
-            #[cfg(not(feature = "no-cfi"))]
+            #[cfg(feature = "cfi")]
             cfi_assert!(key_pair.is_ok());
         } else {
-            #[cfg(not(feature = "no-cfi"))]
+            #[cfg(feature = "cfi")]
             cfi_assert!(key_pair.is_err());
         }
         let (priv_key, pub_key) = key_pair?;
@@ -89,7 +89,7 @@ impl SignCmd {
 }
 
 impl CommandExecution for SignCmd {
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     fn execute(
         &self,
         dpe: &mut DpeInstance,
@@ -104,7 +104,7 @@ impl CommandExecution for SignCmd {
         }
 
         cfg_if! {
-            if #[cfg(not(feature = "no-cfi"))] {
+            if #[cfg(feature = "cfi")] {
                 cfi_assert_ne(context.context_type, ContextType::Simulation);
             }
         }

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -8,10 +8,10 @@ use crate::{
 };
 use bitflags::bitflags;
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
-use caliptra_cfi_lib_git::cfi_launder;
+use caliptra_cfi_derive::cfi_impl_fn;
+use caliptra_cfi_lib::cfi_launder;
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq, cfi_assert_ne};
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_assert_ne};
 use cfg_if::cfg_if;
 use crypto::{Crypto, Digest, EcdsaSig};
 
@@ -150,7 +150,7 @@ mod tests {
         },
         support::test::SUPPORT,
     };
-    use caliptra_cfi_lib_git::CfiCounter;
+    use caliptra_cfi_lib::CfiCounter;
     use crypto::OpensslCrypto;
     use openssl::x509::X509;
     use openssl::{bn::BigNum, ecdsa::EcdsaSig};

--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -164,6 +164,7 @@ impl ContextHandle {
 #[derive(Debug, PartialEq, Eq, IntoBytes, FromZeros, KnownLayout, Immutable, Copy, Clone, Zeroize)]
 #[repr(u8, align(1))]
 #[rustfmt::skip]
+#[cfg_attr(not(feature = "no-cfi"), derive(caliptra_cfi_derive::Launder))]
 pub enum ContextState {
     /// Inactive or uninitialized.
     Inactive,
@@ -179,6 +180,7 @@ pub enum ContextState {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, IntoBytes, FromZeros, KnownLayout, Immutable, Zeroize)]
 #[repr(u8, align(1))]
 #[rustfmt::skip]
+#[cfg_attr(not(feature = "no-cfi"), derive(caliptra_cfi_derive::Launder))]
 pub enum ContextType {
     /// Typical context.
     Normal,

--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -164,7 +164,7 @@ impl ContextHandle {
 #[derive(Debug, PartialEq, Eq, IntoBytes, FromZeros, KnownLayout, Immutable, Copy, Clone, Zeroize)]
 #[repr(u8, align(1))]
 #[rustfmt::skip]
-#[cfg_attr(not(feature = "no-cfi"), derive(caliptra_cfi_derive::Launder))]
+#[cfg_attr(feature = "cfi", derive(caliptra_cfi_derive::Launder))]
 pub enum ContextState {
     /// Inactive or uninitialized.
     Inactive,
@@ -180,7 +180,7 @@ pub enum ContextState {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, IntoBytes, FromZeros, KnownLayout, Immutable, Zeroize)]
 #[repr(u8, align(1))]
 #[rustfmt::skip]
-#[cfg_attr(not(feature = "no-cfi"), derive(caliptra_cfi_derive::Launder))]
+#[cfg_attr(feature = "cfi", derive(caliptra_cfi_derive::Launder))]
 pub enum ContextType {
     /// Typical context.
     Normal,

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -16,10 +16,10 @@ use crate::{
 };
 use bitflags::bitflags;
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_derive_git::cfi_impl_fn;
-use caliptra_cfi_lib_git::cfi_launder;
+use caliptra_cfi_derive::cfi_impl_fn;
+use caliptra_cfi_lib::cfi_launder;
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_assert_eq};
 use cfg_if::cfg_if;
 use core::mem::align_of;
 use crypto::{Crypto, Digest, Hasher};
@@ -188,7 +188,9 @@ impl DpeInstance {
         cmd: &[u8],
     ) -> Result<Response, DpeErrorCode> {
         let command = Command::deserialize(cmd)?;
-        let resp = match cfi_launder(command) {
+        #[cfg(not(feature = "no-cfi"))]
+        let command = cfi_launder(command);
+        let resp = match command {
             Command::GetProfile => Ok(Response::GetProfile(self.get_profile(&mut env.platform)?)),
             Command::InitCtx(cmd) => cmd.execute(self, env, locality),
             Command::DeriveContext(cmd) => cmd.execute(self, env, locality),
@@ -552,7 +554,7 @@ pub mod tests {
     use crate::response::NewHandleResp;
     use crate::support::test::SUPPORT;
     use crate::{commands::CommandHdr, CURRENT_PROFILE_MAJOR_VERSION};
-    use caliptra_cfi_lib_git::CfiCounter;
+    use caliptra_cfi_lib::CfiCounter;
     use crypto::OpensslCrypto;
     use platform::default::{DefaultPlatform, AUTO_INIT_LOCALITY, TEST_CERT_CHAIN};
     use zerocopy::IntoBytes;

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -15,10 +15,10 @@ use crate::{
     U8Bool, DPE_PROFILE, MAX_HANDLES,
 };
 use bitflags::bitflags;
-#[cfg(not(feature = "no-cfi"))]
+#[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_cfi_lib::cfi_launder;
-#[cfg(not(feature = "no-cfi"))]
+#[cfg(feature = "cfi")]
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_assert_eq};
 use cfg_if::cfg_if;
 use core::mem::align_of;
@@ -87,7 +87,7 @@ impl DpeInstance {
     /// * `env` - DPE environment containing Crypto and Platform implementations
     /// * `support` - optional functionality the instance supports
     /// * `flags` - configures `Self` behaviors.
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     pub fn new(
         env: &mut DpeEnv<impl DpeTypes>,
         support: Support,
@@ -107,7 +107,7 @@ impl DpeInstance {
             let locality = env.platform.get_auto_init_locality()?;
             InitCtxCmd::new_use_default().execute(&mut dpe, env, locality)?;
         } else {
-            #[cfg(not(feature = "no-cfi"))]
+            #[cfg(feature = "cfi")]
             cfi_assert!(!dpe.support.auto_init());
         }
         Ok(dpe)
@@ -122,7 +122,7 @@ impl DpeInstance {
     /// * `tci_type`- tci_type of initialized context
     /// * `auto_init_measurement` - TCI data of initialized context
     /// * `flags` - configures `Self` behaviors.
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     #[cfg(not(feature = "disable_auto_init"))]
     pub fn new_auto_init(
         env: &mut DpeEnv<impl DpeTypes>,
@@ -136,7 +136,7 @@ impl DpeInstance {
         if !updated_support.auto_init() {
             return Err(DpeErrorCode::ArgumentNotSupported);
         } else {
-            #[cfg(not(feature = "no-cfi"))]
+            #[cfg(feature = "cfi")]
             cfi_assert!(updated_support.auto_init());
         }
         let mut dpe = Self::new(env, updated_support, flags)?;
@@ -180,7 +180,7 @@ impl DpeInstance {
     /// * `env` - DPE environment containing Crypto and Platform implementations
     /// * `locality` - which hardware locality is making the request
     /// * `cmd` - serialized command
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     pub fn execute_serialized_command(
         &mut self,
         env: &mut DpeEnv<impl DpeTypes>,
@@ -188,7 +188,7 @@ impl DpeInstance {
         cmd: &[u8],
     ) -> Result<Response, DpeErrorCode> {
         let command = Command::deserialize(cmd)?;
-        #[cfg(not(feature = "no-cfi"))]
+        #[cfg(feature = "cfi")]
         let command = cfi_launder(command);
         let resp = match command {
             Command::GetProfile => Ok(Response::GetProfile(self.get_profile(&mut env.platform)?)),
@@ -329,7 +329,7 @@ impl DpeInstance {
         if !self.contexts[idx].handle.is_default() {
             self.contexts[idx].handle = self.generate_new_handle(env)?;
         } else {
-            #[cfg(not(feature = "no-cfi"))]
+            #[cfg(feature = "cfi")]
             cfi_assert!(self.contexts[idx].handle.is_default());
         }
         Ok(())
@@ -345,7 +345,7 @@ impl DpeInstance {
     /// * `nodes` - Array to write TCI nodes to
     ///
     /// Returns the number of TCIs written to `nodes`
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     pub(crate) fn get_tcb_nodes(
         &self,
         start_idx: usize,
@@ -380,7 +380,7 @@ impl DpeInstance {
     /// * `context` - context to add `measurement`` to
     /// * `measurement` - measurement to add to `context``
     /// * `locality` - locality that `context`'s locality must match
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     pub(crate) fn add_tci_measurement(
         &self,
         env: &mut DpeEnv<impl DpeTypes>,
@@ -395,7 +395,7 @@ impl DpeInstance {
             return Err(DpeErrorCode::InvalidLocality);
         }
         cfg_if! {
-            if #[cfg(not(feature = "no-cfi"))] {
+            if #[cfg(feature = "cfi")] {
                 cfi_assert_eq(context.state, ContextState::Active);
                 cfi_assert_eq(context.locality, locality);
             }
@@ -454,7 +454,7 @@ impl DpeInstance {
     ///
     /// * `env` - DPE environment containing Crypto and Platform implementations
     /// * `start_idx` - index of the leaf context
-    #[cfg_attr(not(feature = "no-cfi"), cfi_impl_fn)]
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     pub(crate) fn compute_measurement_hash(
         &mut self,
         env: &mut DpeEnv<impl DpeTypes>,

--- a/dpe/src/validation.rs
+++ b/dpe/src/validation.rs
@@ -280,7 +280,7 @@ impl DpeValidator<'_> {
 
 #[cfg(test)]
 pub mod tests {
-    use caliptra_cfi_lib_git::CfiCounter;
+    use caliptra_cfi_lib::CfiCounter;
     use crypto::OpensslCrypto;
     use platform::default::DefaultPlatform;
 

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -13,9 +13,9 @@ use crate::{
     DpeInstance, DpeProfile, DPE_PROFILE, MAX_CERT_SIZE, MAX_HANDLES,
 };
 use bitflags::bitflags;
-use caliptra_cfi_lib_git::cfi_launder;
+use caliptra_cfi_lib::cfi_launder;
 #[cfg(not(feature = "no-cfi"))]
-use caliptra_cfi_lib_git::{cfi_assert, cfi_assert_eq};
+use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool};
 use crypto::{Crypto, Digest, EcdsaPub, EcdsaSig, Hasher, MAX_EXPORTED_CDI_SIZE};
 #[cfg(not(feature = "disable_x509"))]
 use platform::CertValidity;

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use bitflags::bitflags;
 use caliptra_cfi_lib::cfi_launder;
-#[cfg(not(feature = "no-cfi"))]
+#[cfg(feature = "cfi")]
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool};
 use crypto::{Crypto, Digest, EcdsaPub, EcdsaSig, Hasher, MAX_EXPORTED_CDI_SIZE};
 #[cfg(not(feature = "disable_x509"))]
@@ -2383,10 +2383,10 @@ fn create_dpe_cert_or_csr(
         }
     };
     if cfi_launder(key_pair.is_ok()) {
-        #[cfg(not(feature = "no-cfi"))]
+        #[cfg(feature = "cfi")]
         cfi_assert!(key_pair.is_ok());
     } else {
-        #[cfg(not(feature = "no-cfi"))]
+        #[cfg(feature = "cfi")]
         cfi_assert!(key_pair.is_err());
     }
     let (priv_key, pub_key) = key_pair?;

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -20,6 +20,6 @@ openssl = { workspace = true, optional = true}
 clap = { version = "4.1.8", features = ["derive"] }
 log = "0.4.17"
 env_logger = "0.10.0"
-dpe = { path = "../dpe", default-features = false, features = ["no-cfi"] }
+dpe = { path = "../dpe", default-features = false }
 crypto = { path = "../crypto", default-features = false }
 platform = { path = "../platform", default-features = false}

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -17,7 +17,7 @@ dpe_profile_p384_sha384 = [
 ]
 
 [dependencies]
-dpe = {path = "../dpe", default-features = false, features = ["no-cfi"]}
+dpe = {path = "../dpe", default-features = false}
 crypto = {path = "../crypto", default-features = false, features = ["deterministic_rand", "openssl"]}
 pem = "2"
 platform = {path = "../platform", default-features = false, features = ["openssl"]}


### PR DESCRIPTION
Update the CFI library dependency to the most recent main.  This can then be updated in the calling `caliptra-1.x` branch to allow the same CFI symbols to be used throughout the code base, reducing overall code usage.