### PR TITLE
dpe: store profile as a raw u32

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -178,7 +178,7 @@ impl CommandExecution for CertifyKeyCommand<'_> {
             }
         }
 
-        let profile = dpe.profile;
+        let profile = dpe.profile()?;
         let args = CreateDpeCertArgs {
             handle,
             locality,
@@ -192,7 +192,7 @@ impl CommandExecution for CertifyKeyCommand<'_> {
                 .contains(DpeFlags::MARK_DICE_EXTENSIONS_CRITICAL),
         };
 
-        let mut response = self.response_bytes(dpe.profile, out)?;
+        let mut response = self.response_bytes(dpe.profile()?, out)?;
         let cert = response.cert_mut();
 
         let result = match format {
@@ -238,7 +238,7 @@ impl CommandExecution for CertifyKeyCommand<'_> {
                 resp.derived_pubkey_x = *x;
                 resp.derived_pubkey_y = *y;
                 resp.cert_size = cert_size;
-                resp.resp_hdr = dpe.response_hdr(DpeErrorCode::NoError);
+                resp.resp_hdr = dpe.response_hdr(DpeErrorCode::NoError)?;
             }
             #[cfg(feature = "p384")]
             (
@@ -250,7 +250,7 @@ impl CommandExecution for CertifyKeyCommand<'_> {
                 resp.derived_pubkey_x = *x;
                 resp.derived_pubkey_y = *y;
                 resp.cert_size = cert_size;
-                resp.resp_hdr = dpe.response_hdr(DpeErrorCode::NoError);
+                resp.resp_hdr = dpe.response_hdr(DpeErrorCode::NoError)?;
             }
             #[cfg(feature = "ml-dsa")]
             (
@@ -260,7 +260,7 @@ impl CommandExecution for CertifyKeyCommand<'_> {
                 resp.new_context_handle = ContextHandle::new_invalid();
                 resp.pubkey = *pubkey;
                 resp.cert_size = cert_size;
-                resp.resp_hdr = dpe.response_hdr(DpeErrorCode::NoError);
+                resp.resp_hdr = dpe.response_hdr(DpeErrorCode::NoError)?;
             }
             _ => Err(DpeErrorCode::InvalidArgument)?,
         };

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -291,7 +291,7 @@ impl CommandExecution for DeriveContextCmd {
         if flags.is_recursive() {
             cfg_if! {
                 if #[cfg(not(feature = "disable_recursive"))] {
-                    let response = mutresp::<DeriveContextResp>(dpe.profile, out)?;
+                    let response = mutresp::<DeriveContextResp>(dpe.profile()?, out)?;
                     let mut tmp_context = env.state().contexts[parent_idx];
                     if tmp_context.tci.tci_type != tci_type {
                         return Err(DpeErrorCode::InvalidArgument);
@@ -319,7 +319,7 @@ impl CommandExecution for DeriveContextCmd {
                         handle: env.state().contexts[parent_idx].handle,
                         // Should be ignored since retain_parent cannot be true
                         parent_handle: ContextHandle::default(),
-                        resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+                        resp_hdr: dpe.response_hdr(DpeErrorCode::NoError)?,
                     };
                     return Ok(size_of_val(response));
                 } else {
@@ -356,10 +356,10 @@ impl CommandExecution for DeriveContextCmd {
         if flags.creates_certificate() && flags.exports_cdi() {
             cfg_if! {
                 if #[cfg(not(feature = "disable_export_cdi"))] {
-                    let response = mutresp::<DeriveContextExportedCdiResp>(dpe.profile, out)?;
+                    let response = mutresp::<DeriveContextExportedCdiResp>(dpe.profile()?, out)?;
                     let ueid = &env.platform().get_ueid()?;
                     let ueid = ueid.get()?;
-                    let profile_descriptor = match dpe.profile {
+                    let profile_descriptor = match dpe.profile()? {
                         crate::DpeProfile::P256Sha256 => b"Exported ECC".as_slice(),
                         crate::DpeProfile::P384Sha384 => b"Exported ECC".as_slice(),
                         #[cfg(feature = "ml-dsa")]
@@ -395,7 +395,7 @@ impl CommandExecution for DeriveContextCmd {
 
                     response.handle = ContextHandle::new_invalid();
                     response.parent_handle = env.state().contexts[parent_idx].handle;
-                    response.resp_hdr = dpe.response_hdr(DpeErrorCode::NoError);
+                    response.resp_hdr = dpe.response_hdr(DpeErrorCode::NoError)?;
                     response.exported_cdi = *exported_cdi_handle;
                     response.certificate_size = *cert_size;
                     let response_size = size_of_val(response) - size_of_val(&response.new_certificate) + *cert_size as usize;
@@ -405,7 +405,7 @@ impl CommandExecution for DeriveContextCmd {
                 }
             }
         }
-        let response = mutresp::<DeriveContextResp>(dpe.profile, out)?;
+        let response = mutresp::<DeriveContextResp>(dpe.profile()?, out)?;
 
         let child_idx = env
             .state()
@@ -468,7 +468,7 @@ impl CommandExecution for DeriveContextCmd {
         *response = DeriveContextResp {
             handle: child_handle,
             parent_handle: env.state().contexts[parent_idx].handle,
-            resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+            resp_hdr: dpe.response_hdr(DpeErrorCode::NoError)?,
         };
         Ok(size_of_val(response))
     }
@@ -713,7 +713,7 @@ mod tests {
             Ok(Response::DeriveContext(DeriveContextResp {
                 handle: ContextHandle::default(),
                 parent_handle: ContextHandle([0xff; ContextHandle::SIZE]),
-                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError).unwrap(),
             })),
             DeriveContextCmd {
                 flags: DeriveContextFlags::MAKE_DEFAULT,
@@ -728,7 +728,7 @@ mod tests {
             Ok(Response::DeriveContext(DeriveContextResp {
                 handle: RANDOM_HANDLE,
                 parent_handle: ContextHandle([0xff; ContextHandle::SIZE]),
-                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError).unwrap(),
             })),
             DeriveContextCmd {
                 handle: ContextHandle::default(),
@@ -899,7 +899,7 @@ mod tests {
             Ok(Response::DeriveContext(DeriveContextResp {
                 handle: ContextHandle::default(),
                 parent_handle: ContextHandle([0xff; ContextHandle::SIZE]),
-                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError).unwrap(),
             })),
             DeriveContextCmd {
                 flags: DeriveContextFlags::MAKE_DEFAULT,
@@ -914,7 +914,7 @@ mod tests {
             Ok(Response::DeriveContext(DeriveContextResp {
                 handle: ContextHandle::default(),
                 parent_handle: ContextHandle::default(),
-                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError).unwrap(),
             })),
             DeriveContextCmd {
                 flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT
@@ -965,7 +965,7 @@ mod tests {
         assert_eq!(parent_handle, RANDOM_HANDLE);
         assert_eq!(handle, next_random_handle);
         assert_ne!(parent_handle, ContextHandle::default());
-        assert_eq!(resp_hdr, dpe.response_hdr(DpeErrorCode::NoError));
+        assert_eq!(resp_hdr, dpe.response_hdr(DpeErrorCode::NoError).unwrap());
     }
 
     #[test]
@@ -1089,7 +1089,7 @@ mod tests {
             Ok(Response::DeriveContext(DeriveContextResp {
                 handle: ContextHandle::default(),
                 parent_handle: ContextHandle::default(),
-                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError).unwrap(),
             })),
             DeriveContextCmd {
                 handle: ContextHandle::default(),

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -94,9 +94,9 @@ impl CommandExecution for DestroyCtxCmd {
         locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode> {
-        let response = mutresp::<ResponseHdr>(dpe.profile, out)?;
+        let response = mutresp::<ResponseHdr>(dpe.profile()?, out)?;
         destroy_context(&self.handle, env.state(), locality)?;
-        *response = dpe.response_hdr(DpeErrorCode::NoError);
+        *response = dpe.response_hdr(DpeErrorCode::NoError)?;
         Ok(size_of_val(response))
     }
 }
@@ -163,7 +163,7 @@ mod tests {
         // destroy context[1]
         assert_eq!(
             Ok(Response::DestroyCtx(
-                dpe.response_hdr(DpeErrorCode::NoError)
+                dpe.response_hdr(DpeErrorCode::NoError).unwrap()
             )),
             DestroyCtxCmd {
                 handle: ContextHandle::default()
@@ -175,7 +175,7 @@ mod tests {
         // destroy context[0]
         assert_eq!(
             Ok(Response::DestroyCtx(
-                dpe.response_hdr(DpeErrorCode::NoError)
+                dpe.response_hdr(DpeErrorCode::NoError).unwrap()
             )),
             DestroyCtxCmd {
                 handle: TEST_HANDLE
@@ -237,7 +237,7 @@ mod tests {
         // destroy context[0] and all descendents
         assert_eq!(
             Ok(Response::DestroyCtx(
-                dpe.response_hdr(DpeErrorCode::NoError)
+                dpe.response_hdr(DpeErrorCode::NoError).unwrap()
             )),
             DestroyCtxCmd {
                 handle: ContextHandle::default()
@@ -280,7 +280,7 @@ mod tests {
         // destroy context[1]
         assert_eq!(
             Ok(Response::DestroyCtx(
-                dpe.response_hdr(DpeErrorCode::NoError)
+                dpe.response_hdr(DpeErrorCode::NoError).unwrap()
             )),
             DestroyCtxCmd {
                 handle: ContextHandle([1; ContextHandle::SIZE])

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -38,7 +38,7 @@ impl CommandExecution for GetCertificateChainCmd {
         if self.size > MAX_CHUNK_SIZE as u32 {
             return Err(DpeErrorCode::InvalidArgument);
         }
-        let response = mutresp::<GetCertificateChainResp>(dpe.profile, out)?;
+        let response = mutresp::<GetCertificateChainResp>(dpe.profile()?, out)?;
 
         let mut cert_chunk = [0u8; MAX_CHUNK_SIZE];
         let len = env
@@ -47,7 +47,7 @@ impl CommandExecution for GetCertificateChainCmd {
         *response = GetCertificateChainResp {
             certificate_chain: cert_chunk,
             certificate_size: len,
-            resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+            resp_hdr: dpe.response_hdr(DpeErrorCode::NoError)?,
         };
         Ok(size_of_val(response))
     }

--- a/dpe/src/commands/get_profile.rs
+++ b/dpe/src/commands/get_profile.rs
@@ -32,7 +32,7 @@ impl CommandExecution for GetProfileCmd {
         _locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode> {
-        let response = mutresp::<GetProfileResp>(dpe.profile, out)?;
+        let response = mutresp::<GetProfileResp>(dpe.profile()?, out)?;
         let support = env.state().support;
         *response = dpe.get_profile(env.platform(), support)?;
 

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -60,7 +60,7 @@ impl CommandExecution for InitCtxCmd {
         locality: u32,
         out: &mut [u8],
     ) -> Result<usize, DpeErrorCode> {
-        let response = mutresp::<NewHandleResp>(dpe.profile, out)?;
+        let response = mutresp::<NewHandleResp>(dpe.profile()?, out)?;
 
         // This function can only be called once for non-simulation contexts.
         if (self.flag_is_default() && env.state().has_initialized())
@@ -121,7 +121,7 @@ impl CommandExecution for InitCtxCmd {
             });
         *response = NewHandleResp {
             handle,
-            resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+            resp_hdr: dpe.response_hdr(DpeErrorCode::NoError)?,
         };
         Ok(size_of_val(response))
     }

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -94,7 +94,7 @@ impl CommandExecution for RotateCtxCmd {
             #[cfg(feature = "cfi")]
             cfi_assert!(env.state().support.rotate_context());
         }
-        let response = mutresp::<NewHandleResp>(dpe.profile, out)?;
+        let response = mutresp::<NewHandleResp>(dpe.profile()?, out)?;
         let idx = env.state().get_active_context_pos(&self.handle, locality)?;
 
         // Make sure caller's locality does not already have a default context.
@@ -124,7 +124,7 @@ impl CommandExecution for RotateCtxCmd {
 
         *response = NewHandleResp {
             handle: new_handle,
-            resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+            resp_hdr: dpe.response_hdr(DpeErrorCode::NoError)?,
         };
         Ok(size_of_val(response))
     }
@@ -222,7 +222,7 @@ mod tests {
         assert_eq!(
             Ok(Response::RotateCtx(NewHandleResp {
                 handle: RANDOM_HANDLE,
-                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError).unwrap(),
             })),
             RotateCtxCmd {
                 handle: ContextHandle::default(),
@@ -250,7 +250,7 @@ mod tests {
         assert_eq!(
             Ok(Response::RotateCtx(NewHandleResp {
                 handle: ContextHandle::default(),
-                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError).unwrap(),
             })),
             RotateCtxCmd {
                 handle: RANDOM_HANDLE,

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -190,7 +190,7 @@ impl CommandExecution for SignCommand<'_> {
             #[cfg(feature = "p256")]
             Signature::Ecdsa(EcdsaSignature::Ecdsa256(sig)) => {
                 use crate::response::SignP256Resp;
-                let response = mutresp::<SignP256Resp>(dpe.profile, out)?;
+                let response = mutresp::<SignP256Resp>(dpe.profile()?, out)?;
 
                 // Rotate the handle if it isn't the default context.
                 dpe.roll_onetime_use_handle(env, idx)?;
@@ -199,14 +199,14 @@ impl CommandExecution for SignCommand<'_> {
                     new_context_handle: env.state().contexts[idx].handle,
                     sig_r,
                     sig_s,
-                    resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+                    resp_hdr: dpe.response_hdr(DpeErrorCode::NoError)?,
                 };
                 Ok(size_of_val(response))
             }
             #[cfg(feature = "p384")]
             Signature::Ecdsa(EcdsaSignature::Ecdsa384(sig)) => {
                 use crate::response::SignP384Resp;
-                let response = mutresp::<SignP384Resp>(dpe.profile, out)?;
+                let response = mutresp::<SignP384Resp>(dpe.profile()?, out)?;
 
                 // Rotate the handle if it isn't the default context.
                 dpe.roll_onetime_use_handle(env, idx)?;
@@ -215,14 +215,14 @@ impl CommandExecution for SignCommand<'_> {
                     new_context_handle: env.state().contexts[idx].handle,
                     sig_r,
                     sig_s,
-                    resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+                    resp_hdr: dpe.response_hdr(DpeErrorCode::NoError)?,
                 };
                 Ok(size_of_val(response))
             }
             #[cfg(feature = "ml-dsa")]
             Signature::Mldsa(caliptra_dpe_crypto::ml_dsa::MldsaSignature(sig)) => {
                 use crate::response::SignMlDsaResp;
-                let response = mutresp::<SignMlDsaResp>(dpe.profile, out)?;
+                let response = mutresp::<SignMlDsaResp>(dpe.profile()?, out)?;
 
                 // Rotate the handle if it isn't the default context.
                 dpe.roll_onetime_use_handle(env, idx)?;
@@ -230,7 +230,7 @@ impl CommandExecution for SignCommand<'_> {
                     new_context_handle: env.state().contexts[idx].handle,
                     sig: *sig,
                     _padding: [0; 1],
-                    resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+                    resp_hdr: dpe.response_hdr(DpeErrorCode::NoError)?,
                 };
                 Ok(size_of_val(response))
             }
@@ -256,7 +256,7 @@ fn sign(
 ) -> Result<Signature, DpeErrorCode> {
     let cdi_digest = dpe.compute_measurement_hash(env, idx)?;
     let cdi = env.crypto().derive_cdi(&cdi_digest, b"DPE")?;
-    let profile = dpe.profile;
+    let profile = dpe.profile()?;
     let context = profile.key_context();
     let key_pair = cdi.derive_key_pair(label, context);
     if cfi_launder(key_pair.is_ok()) {

--- a/dpe/src/commands/update_context_measurement.rs
+++ b/dpe/src/commands/update_context_measurement.rs
@@ -80,7 +80,7 @@ impl CommandExecution for UpdateContextMeasurementCmd {
             })
             .ok_or(DpeErrorCode::InvalidArgument)?;
 
-        let response = mutresp::<UpdateContextMeasurementResp>(dpe.profile, out)?;
+        let response = mutresp::<UpdateContextMeasurementResp>(dpe.profile()?, out)?;
 
         // Copy the child context for mutation to avoid touching internal state on error.
         let mut tmp_child = env.state().contexts[child_idx];
@@ -103,7 +103,7 @@ impl CommandExecution for UpdateContextMeasurementCmd {
         };
 
         *response = UpdateContextMeasurementResp {
-            resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+            resp_hdr: dpe.response_hdr(DpeErrorCode::NoError)?,
             new_context_handle: env.state().contexts[child_idx].handle,
             new_parent_context_handle: env.state().contexts[parent_idx].handle,
         };

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -4,8 +4,6 @@ Licensed under the Apache-2.0 license.
 Abstract:
     Defines an instance of DPE and all of its contexts.
 --*/
-#[cfg(feature = "ml-dsa")]
-use crate::DPE_PROFILE_MLDSA87;
 #[cfg(not(feature = "disable_internal_info"))]
 use crate::INTERNAL_INPUT_INFO_SIZE;
 use crate::{
@@ -14,7 +12,7 @@ use crate::{
     response::{DpeErrorCode, GetProfileResp, Response, ResponseHdr},
     support::Support,
     tci::TciMeasurement,
-    DpeProfile, State, DPE_PROFILE_SHA256, DPE_PROFILE_SHA384, MAX_HANDLES,
+    DpeProfile, State, MAX_HANDLES,
 };
 #[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
@@ -72,13 +70,7 @@ impl DpeInstance {
     }
 
     pub fn profile(&self) -> Result<DpeProfile, DpeErrorCode> {
-        match self.profile {
-            DPE_PROFILE_SHA256 => Ok(DpeProfile::P256Sha256),
-            DPE_PROFILE_SHA384 => Ok(DpeProfile::P384Sha384),
-            #[cfg(feature = "ml-dsa")]
-            DPE_PROFILE_MLDSA87 => Ok(DpeProfile::Mldsa87),
-            _ => Err(DpeErrorCode::InvalideProfile),
-        }
+        self.profile.try_into()
     }
 
     /// Create a new DPE instance.

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -4,6 +4,8 @@ Licensed under the Apache-2.0 license.
 Abstract:
     Defines an instance of DPE and all of its contexts.
 --*/
+#[cfg(feature = "ml-dsa")]
+use crate::DPE_PROFILE_MLDSA87;
 #[cfg(not(feature = "disable_internal_info"))]
 use crate::INTERNAL_INPUT_INFO_SIZE;
 use crate::{
@@ -12,7 +14,7 @@ use crate::{
     response::{DpeErrorCode, GetProfileResp, Response, ResponseHdr},
     support::Support,
     tci::TciMeasurement,
-    DpeProfile, State, MAX_HANDLES,
+    DpeProfile, State, DPE_PROFILE_SHA256, DPE_PROFILE_SHA384, MAX_HANDLES,
 };
 #[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
@@ -24,7 +26,7 @@ use caliptra_dpe_platform::Platform;
 #[cfg(not(feature = "disable_internal_dice"))]
 use caliptra_dpe_platform::MAX_CHUNK_SIZE;
 use cfg_if::cfg_if;
-use zerocopy::IntoBytes;
+use zerocopy::{FromZeros, IntoBytes};
 
 pub trait DpeEnv {
     fn crypto(&mut self) -> &mut dyn CryptoSuite;
@@ -54,8 +56,9 @@ impl DpeEnv for DpeEnvImpl<'_> {
     }
 }
 
+#[derive(FromZeros, IntoBytes)]
 pub struct DpeInstance {
-    pub profile: DpeProfile,
+    profile: u32,
 }
 
 impl DpeInstance {
@@ -63,7 +66,19 @@ impl DpeInstance {
 
     /// Create a new DPE instance without initializing.
     pub const fn initialized(profile: DpeProfile) -> Self {
-        Self { profile }
+        Self {
+            profile: profile as u32,
+        }
+    }
+
+    pub fn profile(&self) -> Result<DpeProfile, DpeErrorCode> {
+        match self.profile {
+            DPE_PROFILE_SHA256 => Ok(DpeProfile::P256Sha256),
+            DPE_PROFILE_SHA384 => Ok(DpeProfile::P384Sha384),
+            #[cfg(feature = "ml-dsa")]
+            DPE_PROFILE_MLDSA87 => Ok(DpeProfile::Mldsa87),
+            _ => Err(DpeErrorCode::InvalideProfile),
+        }
     }
 
     /// Create a new DPE instance.
@@ -133,7 +148,7 @@ impl DpeInstance {
         let vendor_id = platform.get_vendor_id()?;
         let vendor_sku = platform.get_vendor_sku()?;
         Ok(GetProfileResp::new(
-            self.profile,
+            self.profile()?,
             support.bits(),
             vendor_id,
             vendor_sku,
@@ -172,20 +187,20 @@ impl DpeInstance {
 
         match resp {
             Ok(resp) => Ok(resp),
-            Err(err_code) => Ok(Response::Error(self.response_hdr(err_code))),
+            Err(err_code) => Ok(Response::Error(self.response_hdr(err_code)?)),
         }
     }
 
-    pub fn response_hdr(&self, err_code: DpeErrorCode) -> ResponseHdr {
-        ResponseHdr::new(self.profile, err_code)
+    pub fn response_hdr(&self, err_code: DpeErrorCode) -> Result<ResponseHdr, DpeErrorCode> {
+        Ok(ResponseHdr::new(self.profile()?, err_code))
     }
 
-    pub fn command_hdr(&self, cmd_id: u32) -> CommandHdr {
-        CommandHdr::new(self.profile, cmd_id)
+    pub fn command_hdr(&self, cmd_id: u32) -> Result<CommandHdr, DpeErrorCode> {
+        Ok(CommandHdr::new(self.profile()?, cmd_id))
     }
 
     pub fn deserialize_command<'a>(&self, cmd: &'a [u8]) -> Result<Command<'a>, DpeErrorCode> {
-        Command::deserialize(self.profile, cmd)
+        Command::deserialize(self.profile()?, cmd)
     }
 
     /// Generates a random context handle that is unique from all other context handles
@@ -306,7 +321,7 @@ impl DpeInstance {
         internal_input_info
             .get_mut(profile_bytes.len()..)
             .ok_or(DpeErrorCode::InternalError)?
-            .copy_from_slice(&(u32::from(self.profile)).to_le_bytes());
+            .copy_from_slice(&(u32::from(self.profile()?)).to_le_bytes());
 
         Ok(())
     }
@@ -480,7 +495,7 @@ pub mod tests {
 
         assert_eq!(
             Response::GetProfile(GetProfileResp::new(
-                dpe.profile,
+                dpe.profile().unwrap(),
                 SUPPORT.bits(),
                 env.platform.get_vendor_id().unwrap(),
                 env.platform.get_vendor_sku().unwrap()
@@ -488,7 +503,7 @@ pub mod tests {
             dpe.execute_serialized_command(
                 &mut env,
                 TEST_LOCALITIES[0],
-                dpe.command_hdr(Command::GET_PROFILE).as_bytes(),
+                dpe.command_hdr(Command::GET_PROFILE).unwrap().as_bytes(),
             )
             .unwrap()
         );
@@ -497,13 +512,14 @@ pub mod tests {
         // simulation context.
         let mut command = dpe
             .command_hdr(Command::INITIALIZE_CONTEXT)
+            .unwrap()
             .as_bytes()
             .to_vec();
         command.extend(InitCtxCmd::new_simulation().as_bytes());
         assert_eq!(
             Response::InitCtx(NewHandleResp {
                 handle: RANDOM_HANDLE,
-                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+                resp_hdr: dpe.response_hdr(DpeErrorCode::NoError).unwrap(),
             }),
             dpe.execute_serialized_command(&mut env, TEST_LOCALITIES[0], &command)
                 .unwrap()

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -83,17 +83,22 @@ impl From<bool> for U8Bool {
     }
 }
 
+pub const DPE_PROFILE_SHA256: u32 = 3;
+pub const DPE_PROFILE_SHA384: u32 = 4;
+#[cfg(feature = "ml-dsa")]
+pub const DPE_PROFILE_MLDSA87: u32 = 5;
+
 #[derive(
     Copy, Clone, Debug, PartialEq, Eq, IntoBytes, TryFromBytes, KnownLayout, Immutable, Zeroize,
 )]
 #[repr(u32)]
 pub enum DpeProfile {
     // Note: Min profiles (1 & 2) are not supported by this implementation
-    P256Sha256 = 3,
-    P384Sha384 = 4,
+    P256Sha256 = DPE_PROFILE_SHA256,
+    P384Sha384 = DPE_PROFILE_SHA384,
     #[cfg(feature = "ml-dsa")]
-    Mldsa87 = 5, // TODO(clundin): Added this to get past compiler / feature flags. We
-                 // will want a real solution here.
+    Mldsa87 = DPE_PROFILE_MLDSA87, // TODO(clundin): Added this to get past compiler / feature flags. We
+                                   // will want a real solution here.
 }
 
 impl DpeProfile {

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -145,6 +145,20 @@ impl From<DpeProfile> for u32 {
     }
 }
 
+impl TryFrom<u32> for DpeProfile {
+    type Error = DpeErrorCode;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            DPE_PROFILE_SHA256 => Ok(Self::P256Sha256),
+            DPE_PROFILE_SHA384 => Ok(Self::P384Sha384),
+            #[cfg(feature = "ml-dsa")]
+            DPE_PROFILE_MLDSA87 => Ok(Self::Mldsa87),
+            _ => Err(Self::Error::InvalideProfile),
+        }
+    }
+}
+
 #[cfg(feature = "p256")]
 pub const TCI_SIZE: usize = 32;
 

--- a/dpe/src/response.rs
+++ b/dpe/src/response.rs
@@ -521,6 +521,7 @@ pub enum DpeErrorCode {
     Platform(PlatformError) = 0x01000000,
     Crypto(CryptoError) = 0x02000000,
     Validation(ValidationError) = 0x03000000,
+    InvalideProfile = 0x04000000,
 }
 
 impl From<PlatformError> for DpeErrorCode {

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -2963,7 +2963,7 @@ fn create_dpe_cert_or_csr(
 
     let cert_size = generate_cert_or_csr(
         format_specific_args,
-        dpe.profile,
+        dpe.profile()?,
         args.dice_extensions_are_critical,
         &subject_name,
         pub_key,

--- a/tools/src/sample_dpe_cert.rs
+++ b/tools/src/sample_dpe_cert.rs
@@ -70,6 +70,7 @@ fn add_tcb_info(
     let cmd_body = cmd.as_bytes().to_vec();
     let cmd_hdr = dpe
         .command_hdr(caliptra_dpe::commands::Command::DERIVE_CONTEXT)
+        .unwrap_or_else(|e| panic!("Error building command header {:?}", e))
         .as_bytes()
         .to_vec();
     let mut command = cmd_hdr;
@@ -95,6 +96,7 @@ fn certify_key(dpe: &mut DpeInstance, env: &mut dyn DpeEnv, format: u32) -> Vec<
     let cmd_body = certify_key_cmd.as_bytes().to_vec();
     let cmd_hdr = dpe
         .command_hdr(caliptra_dpe::commands::Command::CERTIFY_KEY)
+        .unwrap_or_else(|e| panic!("Error building command header {:?}", e))
         .as_bytes()
         .to_vec();
     let mut command = cmd_hdr;


### PR DESCRIPTION
caliptra-sw stores DpeInstance inside the PersistentData, which is expected to be FromZeros. However, the only member of DpeInstance, profile, refers to a DpeProfile, which is an enum for which 0 is not a valid variant.

This commit stores the DPE profile as a raw u32 instead of the DpeProfile enum, so that we can derive FromZeros on it. It also adds a `profile` method as the public interface to fetch the profile, which will return an error if the raw u32 value doesn't represent a valid profile.