### PR TITLE
dpe: optimize stack usage

### DIFF
--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -300,7 +300,7 @@ impl CommandExecution for DeriveContextCmd {
                         cfi_assert_eq(tmp_context.tci.tci_type, tci_type);
                     }
                     dpe.add_tci_measurement(
-                        env,
+                        env.crypto(),
                         &mut tmp_context,
                         data,
                         target_locality,
@@ -455,7 +455,7 @@ impl CommandExecution for DeriveContextCmd {
             allow_recursive: flags.allows_recursive() & tmp_parent_context.allow_recursive(),
         });
 
-        dpe.add_tci_measurement(env, &mut tmp_child_context, data, target_locality)?;
+        dpe.add_tci_measurement(env.crypto(), &mut tmp_child_context, data, target_locality)?;
 
         // Add child to the parent's list of children.
         let children_with_child_idx = tmp_parent_context.add_child(child_idx)?;

--- a/dpe/src/commands/update_context_measurement.rs
+++ b/dpe/src/commands/update_context_measurement.rs
@@ -88,7 +88,7 @@ impl CommandExecution for UpdateContextMeasurementCmd {
         let child_locality = tmp_child.locality;
 
         // Extend the child's TCI: tci_cumulative = HASH(tci_cumulative || INPUT_DATA).
-        dpe.add_tci_measurement(env, &mut tmp_child, &self.data, child_locality)?;
+        dpe.add_tci_measurement(env.crypto(), &mut tmp_child, &self.data, child_locality)?;
 
         // Rotate the parent handle; parent is always retained (as if RETAIN_PARENT_CONTEXT).
         dpe.roll_onetime_use_handle(env, parent_idx)?;

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -9,7 +9,7 @@ use crate::INTERNAL_INPUT_INFO_SIZE;
 use crate::{
     commands::{Command, CommandExecution, CommandHdr, InitCtxCmd},
     context::{ChildToRootIter, Context, ContextHandle, ContextState},
-    response::{DpeErrorCode, GetProfileResp, Response, ResponseHdr},
+    response::{DpeErrorCode, GetProfileResp, NewHandleResp, Response, ResponseHdr},
     support::Support,
     tci::TciMeasurement,
     DpeProfile, State, MAX_HANDLES,
@@ -79,7 +79,8 @@ impl DpeInstance {
 
         if env.state().support.auto_init() {
             let locality = env.platform().get_auto_init_locality()?;
-            InitCtxCmd::new_use_default().execute(&mut dpe, env, locality)?;
+            let mut buf = [0u8; size_of::<NewHandleResp>()];
+            InitCtxCmd::new_use_default().execute_serialized(&mut dpe, env, locality, &mut buf)?;
         } else {
             #[cfg(feature = "cfi")]
             cfi_assert!(!env.state().support.auto_init());
@@ -114,14 +115,16 @@ impl DpeInstance {
         let dpe = Self::new(env, profile)?;
 
         let locality = env.platform().get_auto_init_locality()?;
-        let idx = env
-            .state()
-            .get_active_context_pos(&ContextHandle::default(), locality)?;
-        let mut tmp_context = env.state().contexts[idx];
+        let (crypto, _, state) = env.get();
+        let idx = state.get_active_context_pos(&ContextHandle::default(), locality)?;
         // add measurement to auto-initialized context
-        dpe.add_tci_measurement(env, &mut tmp_context, auto_init_measurement, locality)?;
-        env.state().contexts[idx] = tmp_context;
-        env.state().contexts[idx].tci.tci_type = tci_type;
+        dpe.add_tci_measurement(
+            crypto,
+            &mut state.contexts[idx],
+            auto_init_measurement,
+            locality,
+        )?;
+        state.contexts[idx].tci.tci_type = tci_type;
         Ok(dpe)
     }
 
@@ -241,14 +244,14 @@ impl DpeInstance {
     ///
     /// # Arguments
     ///
-    /// * `env` - DPE environment containing Crypto and Platform implementations
+    /// * `crypto` - crypto implementation used by the DPE
     /// * `context` - context to add `measurement`` to
     /// * `measurement` - measurement to add to `context``
     /// * `locality` - locality that `context`'s locality must match
     #[cfg_attr(feature = "cfi", cfi_impl_fn)]
     pub(crate) fn add_tci_measurement(
         &self,
-        env: &mut dyn DpeEnv,
+        crypto: &mut dyn CryptoSuite,
         context: &mut Context,
         measurement: &TciMeasurement,
         locality: u32,
@@ -267,9 +270,7 @@ impl DpeInstance {
         }
 
         // Derive the new TCI as HASH(TCI_CUMULATIVE || INPUT_DATA).
-        let digest = env
-            .crypto()
-            .hash_all(&[&context.tci.tci_cumulative.0, &measurement.0])?;
+        let digest = crypto.hash_all(&[&context.tci.tci_cumulative.0, &measurement.0])?;
 
         let digest_bytes = digest.as_slice();
 
@@ -532,7 +533,7 @@ pub mod tests {
         let data = [1; DPE_PROFILE.hash_size()];
         let mut context = env.state.contexts[0];
         dpe.add_tci_measurement(
-            &mut env,
+            env.crypto(),
             &mut context,
             &TciMeasurement(data),
             TEST_LOCALITIES[0],
@@ -552,7 +553,7 @@ pub mod tests {
 
         let data = [2; DPE_PROFILE.hash_size()];
         dpe.add_tci_measurement(
-            &mut env,
+            env.crypto(),
             &mut context,
             &TciMeasurement(data),
             TEST_LOCALITIES[0],


### PR DESCRIPTION
This commit introduces two optimizations to reduce stack usage:

1. In `DpeInstance::new`, call `execute_serialized` instead of `execute` on the mailbox command, to avoid creating a big stack frame for `execute`, since `execute` will create a on-stack buffer to hold a generic `Response`, which is much bigger than the response we need - a `NewHandleResp`.

2. In `DpeInstance::new_auto_init`, avoid creating a mutable `Context` on the stack, but passing a `&mut Context` to have `dpe.add_tci_measurement` modify the context in-place. Changes are made on the interface of `add_tci_measurement` as well to avoid hitting compile errors.