### PR TITLE
Revert "Disallow multiple of the same TCI type (#556)"

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -900,10 +900,9 @@ mod tests {
         let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         // Derive context MAX_HANDLES times. The first was already created by auto-init.
-        for i in 0..MAX_HANDLES - 1 {
+        for _ in 0..MAX_HANDLES - 1 {
             let derive_cmd = DeriveContextCmd {
                 flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INPUT_ALLOW_X509,
-                tci_type: i as u32 + 1,
                 ..Default::default()
             };
 
@@ -934,9 +933,9 @@ mod tests {
             asn1::parse_single::<asn1::SequenceOf<TcbInfo>>(multi_tcb_info.value).unwrap();
 
         // Verify we have MAX_HANDLES TCB infos
-        for i in 0..MAX_HANDLES {
+        for _ in 0..MAX_HANDLES {
             let tcb_info = parsed_tcb_infos.next().unwrap();
-            assert_eq!(tcb_info.tci_type.unwrap(), &(i as u32).to_le_bytes());
+            assert_eq!(tcb_info.tci_type.unwrap(), &(0 as u32).to_le_bytes());
         }
         assert!(parsed_tcb_infos.next().is_none());
     }
@@ -952,10 +951,9 @@ mod tests {
         let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         // Derive context MAX_HANDLES times. The first was already created by auto-init.
-        for i in 0..MAX_HANDLES - 1 {
+        for _ in 0..MAX_HANDLES - 1 {
             let derive_cmd = DeriveContextCmd {
                 flags: DeriveContextFlags::MAKE_DEFAULT,
-                tci_type: i as u32 + 1,
                 ..Default::default()
             };
 

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -203,13 +203,6 @@ impl DeriveContextCmd {
             c.state == ContextState::Active && c.locality == target_locality
         })?;
 
-        // check if the typ already exists
-        for c in state.contexts.iter() {
-            if c.state != ContextState::Inactive && c.tci.tci_type == self.tci_type {
-                return Ok(false);
-            }
-        }
-
         Ok(if self.flags.makes_default() {
             self.safe_to_make_default(parent_idx, default_context_idx, num_contexts_in_locality)
         } else {
@@ -636,10 +629,9 @@ mod tests {
         let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
 
         // Fill all contexts with children (minus the auto-init context).
-        for i in 0..MAX_HANDLES - 1 {
+        for _ in 0..MAX_HANDLES - 1 {
             DeriveContextCmd {
                 flags: DeriveContextFlags::MAKE_DEFAULT,
-                tci_type: i as u32 + 1,
                 ..Default::default()
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -732,7 +724,6 @@ mod tests {
             })),
             DeriveContextCmd {
                 flags: DeriveContextFlags::MAKE_DEFAULT,
-                tci_type: 1,
                 ..Default::default()
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -745,12 +736,7 @@ mod tests {
                 parent_handle: ContextHandle([0xff; ContextHandle::SIZE]),
                 resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
             })),
-            DeriveContextCmd {
-                handle: ContextHandle::default(),
-                tci_type: 2,
-                ..Default::default()
-            }
-            .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
+            DeriveContextCmd::default().execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
     }
 
@@ -783,7 +769,6 @@ mod tests {
         let parent_handle = match (DeriveContextCmd {
             handle,
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
-            tci_type: 1,
             ..Default::default()
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -835,10 +820,10 @@ mod tests {
             handle: new_context_handle,
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT
                 | DeriveContextFlags::INTERNAL_INPUT_INFO,
-            // The parent already has one child with tci_type=1 from the first
+            // The parent already has one child with tci_type=0 from the first
             // DeriveContextCmd above; use a distinct tci_type to satisfy the
             // INPUT_TYPE uniqueness constraint among siblings.
-            tci_type: 2,
+            tci_type: 1,
             ..Default::default()
         })
         .execute(&mut dpe, &mut env, 0)
@@ -918,7 +903,6 @@ mod tests {
             })),
             DeriveContextCmd {
                 flags: DeriveContextFlags::MAKE_DEFAULT,
-                tci_type: 1,
                 ..Default::default()
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -936,7 +920,6 @@ mod tests {
                     | DeriveContextFlags::MAKE_DEFAULT
                     | DeriveContextFlags::CHANGE_LOCALITY,
                 target_locality: TEST_LOCALITIES[1],
-                tci_type: 2,
                 ..Default::default()
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -960,10 +943,10 @@ mod tests {
         }) = DeriveContextCmd {
             handle: env.state.contexts[old_default_idx].handle,
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
-            // The parent already has one child with tci_type=1 (created in the
+            // The parent already has one child with tci_type=0 (created in the
             // CHANGE_LOCALITY step above); use a distinct tci_type to satisfy
             // the INPUT_TYPE uniqueness constraint.
-            tci_type: 3,
+            tci_type: 1,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -1318,7 +1301,6 @@ mod tests {
         let Ok(Response::DeriveContext(DeriveContextResp { handle, .. })) = DeriveContextCmd {
             flags: DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT,
             target_locality: TEST_LOCALITIES[0],
-            tci_type: 1,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]) else {
@@ -1366,7 +1348,6 @@ mod tests {
                 | DeriveContextFlags::CREATE_CERTIFICATE
                 | DeriveContextFlags::RETAIN_PARENT_CONTEXT,
             target_locality: TEST_LOCALITIES[0],
-            tci_type: 1,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]);
@@ -1392,7 +1373,6 @@ mod tests {
         let Ok(Response::DeriveContext(res)) = DeriveContextCmd {
             data: TciMeasurement([0xA; TCI_SIZE]),
             target_locality: TEST_LOCALITIES[0],
-            tci_type: 2,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]) else {
@@ -1406,7 +1386,6 @@ mod tests {
             handle: res.handle,
             flags: DeriveContextFlags::EXPORT_CDI | DeriveContextFlags::CREATE_CERTIFICATE,
             target_locality: TEST_LOCALITIES[0],
-            tci_type: 3,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]);
@@ -1424,7 +1403,6 @@ mod tests {
         let Ok(Response::DeriveContext(res)) = DeriveContextCmd {
             data: TciMeasurement([0xA; TCI_SIZE]),
             target_locality: TEST_LOCALITIES[0],
-            tci_type: 4,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]) else {
@@ -1439,7 +1417,6 @@ mod tests {
                 | DeriveContextFlags::CREATE_CERTIFICATE
                 | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT,
             target_locality: TEST_LOCALITIES[0],
-            tci_type: 5,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]);
@@ -1461,7 +1438,6 @@ mod tests {
             flags: DeriveContextFlags::MAKE_DEFAULT
                 | DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT,
             target_locality: TEST_LOCALITIES[0],
-            tci_type: 6,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]);
@@ -1482,7 +1458,6 @@ mod tests {
                 | DeriveContextFlags::EXPORT_CDI
                 | DeriveContextFlags::CREATE_CERTIFICATE,
             target_locality: TEST_LOCALITIES[0],
-            tci_type: 7,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0]);
@@ -1941,69 +1916,5 @@ mod tests {
             }
             Err(e) => panic!("x509 parsing failed: {:?}", e),
         };
-    }
-
-    #[test]
-    fn test_tci_type_uniqueness_in_locality() {
-        CfiCounter::reset_for_test();
-        let mut state = State::new(
-            Support::AUTO_INIT | Support::ROTATE_CONTEXT,
-            DpeFlags::empty(),
-        );
-        test_env!(env, &mut state);
-        let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).unwrap();
-
-        // Rotate the default handle so we have a non-default active context.
-        let handle = match (RotateCtxCmd {
-            handle: ContextHandle::default(),
-            flags: RotateCtxFlags::empty(),
-        })
-        .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
-        .unwrap()
-        {
-            Response::RotateCtx(resp) => resp.handle,
-            _ => panic!("Failed to rotate default handle"),
-        };
-
-        let tci_type = 0x1234;
-
-        // Create first child with tci_type.
-        let child_handle = match (DeriveContextCmd {
-            handle,
-            tci_type,
-            ..Default::default()
-        })
-        .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
-        .unwrap()
-        {
-            Response::DeriveContext(resp) => resp.handle,
-            _ => panic!("Wrong response type"),
-        };
-
-        // Test that creating two contexts in the same locality with the same
-        // type causes an error.
-        assert_eq!(
-            Err(DpeErrorCode::InvalidArgument),
-            DeriveContextCmd {
-                handle: child_handle,
-                tci_type,
-                ..Default::default()
-            }
-            .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
-        );
-
-        // Test having two contexts with the same type in separate localities
-        // also fails.
-        assert_eq!(
-            Err(DpeErrorCode::InvalidArgument),
-            DeriveContextCmd {
-                handle: child_handle,
-                tci_type,
-                target_locality: TEST_LOCALITIES[1],
-                flags: DeriveContextFlags::CHANGE_LOCALITY,
-                ..Default::default()
-            }
-            .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
-        );
     }
 }

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -152,7 +152,7 @@ mod tests {
         assert_eq!(
             Err(DpeErrorCode::InvalidLocality),
             DestroyCtxCmd {
-                handle: ContextHandle::default()
+                handle: ContextHandle::default(),
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])
         );
@@ -166,7 +166,7 @@ mod tests {
                 dpe.response_hdr(DpeErrorCode::NoError)
             )),
             DestroyCtxCmd {
-                handle: ContextHandle::default()
+                handle: ContextHandle::default(),
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -178,7 +178,7 @@ mod tests {
                 dpe.response_hdr(DpeErrorCode::NoError)
             )),
             DestroyCtxCmd {
-                handle: TEST_HANDLE
+                handle: TEST_HANDLE,
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -240,7 +240,7 @@ mod tests {
                 dpe.response_hdr(DpeErrorCode::NoError)
             )),
             DestroyCtxCmd {
-                handle: ContextHandle::default()
+                handle: ContextHandle::default(),
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -283,7 +283,7 @@ mod tests {
                 dpe.response_hdr(DpeErrorCode::NoError)
             )),
             DestroyCtxCmd {
-                handle: ContextHandle([1; ContextHandle::SIZE])
+                handle: ContextHandle([1; ContextHandle::SIZE]),
             }
             .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
         );
@@ -303,7 +303,6 @@ mod tests {
         let handle_1 = match (DeriveContextCmd {
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT | DeriveContextFlags::CHANGE_LOCALITY,
             target_locality: TEST_LOCALITIES[1],
-            tci_type: 1,
             ..Default::default()
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -317,7 +316,6 @@ mod tests {
         let handle_2 = match (DeriveContextCmd {
             handle: handle_1,
             target_locality: TEST_LOCALITIES[1],
-            tci_type: 2,
             ..Default::default()
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])
@@ -331,7 +329,6 @@ mod tests {
         let handle_3 = match (DeriveContextCmd {
             handle: handle_2,
             target_locality: TEST_LOCALITIES[1],
-            tci_type: 3,
             ..Default::default()
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])
@@ -368,7 +365,6 @@ mod tests {
         let parent_handle = match (DeriveContextCmd {
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT | DeriveContextFlags::CHANGE_LOCALITY,
             target_locality: TEST_LOCALITIES[1],
-            tci_type: 1,
             ..Default::default()
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -383,7 +379,6 @@ mod tests {
             handle: parent_handle,
             flags: DeriveContextFlags::RETAIN_PARENT_CONTEXT,
             target_locality: TEST_LOCALITIES[1],
-            tci_type: 2,
             ..Default::default()
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])
@@ -398,9 +393,9 @@ mod tests {
             handle: parent_handle,
             target_locality: TEST_LOCALITIES[1],
             // Use a distinct tci_type; the parent already has one child with
-            // tci_type=1 (from the previous DeriveContext), and INPUT_TYPE must
+            // tci_type=0 (from the previous DeriveContext), and INPUT_TYPE must
             // be unique among siblings.
-            tci_type: 3,
+            tci_type: 1,
             ..Default::default()
         })
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[1])

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -491,7 +491,7 @@ mod tests {
                 handle: ContextHandle::default(),
                 data: TciMeasurement([i; DPE_PROFILE.hash_size()]),
                 flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INPUT_ALLOW_X509,
-                tci_type: i as u32 + 1,
+                tci_type: i as u32,
                 target_locality: 0,
                 svn: 0,
             }

--- a/dpe/src/commands/update_context_measurement.rs
+++ b/dpe/src/commands/update_context_measurement.rs
@@ -141,7 +141,7 @@ mod tests {
     use crate::{
         commands::{
             rotate_context::{RotateCtxCmd, RotateCtxFlags},
-            DeriveContextCmd, DeriveContextFlags,
+            DeriveContextCmd, DeriveContextFlags, InitCtxCmd,
         },
         context::ContextHandle,
         dpe_instance::{tests::TEST_LOCALITIES, DpeInstance},

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -582,7 +582,7 @@ pub mod tests {
                 handle: ContextHandle::default(),
                 data: TciMeasurement([i; DPE_PROFILE.hash_size()]),
                 flags: DeriveContextFlags::MAKE_DEFAULT,
-                tci_type: i as u32 + 1,
+                tci_type: i as u32,
                 target_locality: 0,
                 svn: 0,
             }
@@ -648,7 +648,6 @@ pub mod tests {
             .unwrap();
         DeriveContextCmd {
             flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INTERNAL_INPUT_INFO,
-            tci_type: 1,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])
@@ -713,7 +712,6 @@ pub mod tests {
             .unwrap();
         DeriveContextCmd {
             flags: DeriveContextFlags::MAKE_DEFAULT | DeriveContextFlags::INTERNAL_INPUT_DICE,
-            tci_type: 1,
             ..Default::default()
         }
         .execute(&mut dpe, &mut env, TEST_LOCALITIES[0])

--- a/verification/testing/deriveContext.go
+++ b/verification/testing/deriveContext.go
@@ -33,7 +33,7 @@ func TestDeriveContext(d client.TestDPEInstance, c client.DPEClient, t *testing.
 	digestLen := profile.GetDigestSize()
 
 	// Child context handle returned will be the default context handle when MakeDefault flag is set
-	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.MakeDefault, 1, 0); err != nil {
+	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.MakeDefault, 0, 0); err != nil {
 		t.Errorf("[ERROR]: Error while creating child context handle: %s", err)
 	}
 	handle = &resp.NewContextHandle
@@ -43,7 +43,7 @@ func TestDeriveContext(d client.TestDPEInstance, c client.DPEClient, t *testing.
 
 	// When there is already a default handle, setting MakeDefault and RetainParentContext will cause error
 	// because there cannot be default *and* non-default handles in a locality
-	if _, err = c.DeriveContext(handle, make([]byte, digestLen), client.MakeDefault|client.RetainParentContext, 2, 0); err == nil {
+	if _, err = c.DeriveContext(handle, make([]byte, digestLen), client.MakeDefault|client.RetainParentContext, 0, 0); err == nil {
 		t.Errorf("[ERROR]: Should return %q, but returned no error", client.StatusInvalidArgument)
 	} else if !errors.Is(err, client.StatusInvalidArgument) {
 		t.Errorf("[ERROR]: Incorrect error type. Should return %q, but returned %q", client.StatusInvalidArgument, err)
@@ -52,14 +52,14 @@ func TestDeriveContext(d client.TestDPEInstance, c client.DPEClient, t *testing.
 	// Retain parent should fail because parent handle is a default handle
 	// and child handle will be a non-default handle.
 	// Default and non-default handle cannot coexist in same locality.
-	if _, err = c.DeriveContext(handle, make([]byte, digestLen), client.RetainParentContext, 3, 0); err == nil {
+	if _, err = c.DeriveContext(handle, make([]byte, digestLen), client.RetainParentContext, 0, 0); err == nil {
 		t.Errorf("[ERROR]: Should return %q, but returned no error", client.StatusInvalidArgument)
 	} else if !errors.Is(err, client.StatusInvalidArgument) {
 		t.Errorf("[ERROR]: Incorrect error type. Should return %q, but returned %q", client.StatusInvalidArgument, err)
 	}
 
 	// Child context handle should be a random handle when MakeDefault flag is NOT used
-	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), 0, 4, 0); err != nil {
+	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), 0, 0, 0); err != nil {
 		t.Errorf("[ERROR]: Error while creating child context handle: %s", err)
 	}
 	handle = &resp.NewContextHandle
@@ -68,7 +68,7 @@ func TestDeriveContext(d client.TestDPEInstance, c client.DPEClient, t *testing.
 	}
 
 	// Now, there is no default handle, setting RetainParentContext flag should succeed
-	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.RetainParentContext, 5, 0); err != nil {
+	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.RetainParentContext, 0, 0); err != nil {
 		t.Errorf("[ERROR]: Error while making child context handle as default handle: %s", err)
 	}
 	handle = &resp.NewContextHandle
@@ -86,7 +86,7 @@ func TestDeriveContextCdiExport(d client.TestDPEInstance, c client.DPEClient, t 
 		t.Fatalf("Could not get profile: %v", err)
 	}
 	digestLen := profile.GetDigestSize()
-	resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.CdiExport|client.CreateCertificate|client.RetainParentContext, 1, 0)
+	resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.CdiExport|client.CreateCertificate|client.RetainParentContext, 0, 0)
 	if err != nil {
 		t.Fatalf("[ERROR]: Error while exporting CdiExport: %s", err)
 	}
@@ -139,7 +139,7 @@ func TestDeriveContextDisallowedChildCdiExport(d client.TestDPEInstance, c clien
 		t.Fatalf("Could not get profile: %v", err)
 	}
 	digestLen := profile.GetDigestSize()
-	res, err := c.DeriveContext(handle, make([]byte, digestLen), 0, 1, 0)
+	res, err := c.DeriveContext(handle, make([]byte, digestLen), 0, 0, 0)
 	if err != nil {
 		t.Fatalf("[ERROR]: Error while making default: %s", err)
 	}
@@ -161,7 +161,7 @@ func TestDeriveContextAllowedChildCdiExport(d client.TestDPEInstance, c client.D
 		t.Fatalf("Could not get profile: %v", err)
 	}
 	digestLen := profile.GetDigestSize()
-	res, err := c.DeriveContext(handle, make([]byte, digestLen), client.AllowNewContextToExport, 1, 0)
+	res, err := c.DeriveContext(handle, make([]byte, digestLen), client.AllowNewContextToExport, 0, 0)
 	if err != nil {
 		t.Fatalf("[ERROR]: Error while making default: %s", err)
 	}
@@ -237,7 +237,7 @@ func TestChangeLocality(d client.TestDPEInstance, c client.DPEClient, t *testing
 	otherLocality := currentLocality + 1
 
 	// Create child context in other locality
-	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.ChangeLocality, 1, otherLocality); err != nil {
+	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.ChangeLocality, 0, otherLocality); err != nil {
 		t.Fatalf("[ERROR]: Error while creating child context handle in other locality: %s", err)
 	}
 	handle = &resp.NewContextHandle
@@ -246,7 +246,7 @@ func TestChangeLocality(d client.TestDPEInstance, c client.DPEClient, t *testing
 	prevLocality := currentLocality
 	d.SetLocality(otherLocality)
 
-	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.ChangeLocality, 2, prevLocality); err != nil {
+	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.ChangeLocality, 0, prevLocality); err != nil {
 		t.Fatalf("[FATAL]: Error while creating child context handle in previous locality: %s", err)
 	}
 	handle = &resp.NewContextHandle
@@ -272,7 +272,7 @@ func TestInternalInputFlags(d client.TestDPEInstance, c client.DPEClient, t *tes
 	digestLen := profile.GetDigestSize()
 	// Internal input flags
 	if d.GetSupport().InternalDice {
-		if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.DeriveContextFlags(client.InternalInputDice), 1, 0); err != nil {
+		if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.DeriveContextFlags(client.InternalInputDice), 0, 0); err != nil {
 			t.Errorf("[ERROR]: Error while making child context handle as default handle: %s", err)
 		}
 		handle = &resp.NewContextHandle
@@ -281,7 +281,7 @@ func TestInternalInputFlags(d client.TestDPEInstance, c client.DPEClient, t *tes
 	}
 
 	if d.GetSupport().InternalInfo {
-		if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.DeriveContextFlags(client.InternalInputInfo), 2, 0); err != nil {
+		if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.DeriveContextFlags(client.InternalInputInfo), 0, 0); err != nil {
 			t.Errorf("[ERROR]: Error while making child context handle as default handle: %s", err)
 		}
 		handle = &resp.NewContextHandle
@@ -309,7 +309,7 @@ func TestPrivilegesEscalation(d client.TestDPEInstance, c client.DPEClient, t *t
 	resp, err := c.DeriveContext(handle,
 		make([]byte, digestLen),
 		client.DeriveContextFlags(0),
-		1, 0)
+		0, 0)
 	if err != nil {
 		t.Fatalf("[FATAL]: Error encountered in getting child context: %v", err)
 	}
@@ -354,7 +354,7 @@ func TestMaxTCIs(d client.TestDPEInstance, c client.DPEClient, t *testing.T) {
 	maxTciCount := int(d.GetMaxTciNodes())
 	allowedTciCount := maxTciCount - 1 // since, a TCI node is already auto-initialized
 	for i := 0; i < allowedTciCount; i++ {
-		resp, err = c.DeriveContext(handle, make([]byte, digestSize), client.InputAllowX509, uint32(i+1), 0)
+		resp, err = c.DeriveContext(handle, make([]byte, digestSize), client.InputAllowX509, 0, 0)
 		if err != nil {
 			t.Fatalf("[FATAL]: Error encountered in executing derive child: %v", err)
 		}
@@ -462,7 +462,7 @@ func TestDeriveContextSimulation(d client.TestDPEInstance, c client.DPEClient, t
 	}
 
 	// Setting RetainParentContext flag should not invalidate the parent handle
-	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.RetainParentContext, 1, 0); err != nil {
+	if resp, err = c.DeriveContext(handle, make([]byte, digestLen), client.RetainParentContext, 0, 0); err != nil {
 		t.Fatalf("[FATAL]: Error while making child context and retaining parent handle %s", err)
 	}
 	handle = &resp.NewContextHandle
@@ -492,7 +492,7 @@ func TestDeriveContextRecursive(d client.TestDPEInstance, c client.DPEClient, t 
 	// The auto-init root context does not carry AllowRecursive (recursive TCI updates
 	// are opt-in). Derive a child with AllowRecursive so it can be recursively updated.
 	childResp, err := c.DeriveContext(handle, make([]byte, digestLen),
-		client.DeriveContextFlags(client.AllowRecursive|client.InputAllowX509), 1, 0)
+		client.DeriveContextFlags(client.AllowRecursive|client.InputAllowX509), 0, 0)
 	if err != nil {
 		t.Fatalf("[FATAL]: Could not create child context with AllowRecursive: %v", err)
 	}
@@ -508,7 +508,7 @@ func TestDeriveContextRecursive(d client.TestDPEInstance, c client.DPEClient, t 
 	resp, err := c.DeriveContext(childHandle,
 		tciValue,
 		client.DeriveContextFlags(client.Recursive),
-		1, 0)
+		0, 0)
 	if err != nil {
 		t.Fatalf("[FATAL]: Could not set TCI value: %v", err)
 	}
@@ -560,7 +560,7 @@ func TestDeriveContextRecursiveOnDerivedContexts(d client.TestDPEInstance, c cli
 	}()
 
 	// DeriveContext with input data, tag it and check TCI_CUMULATIVE
-	childCtx, err := c.DeriveContext(parentHandle, tciValue, client.DeriveContextFlags(client.RetainParentContext|client.InputAllowX509|client.AllowRecursive), 1, 0)
+	childCtx, err := c.DeriveContext(parentHandle, tciValue, client.DeriveContextFlags(client.RetainParentContext|client.InputAllowX509|client.AllowRecursive), 0, 0)
 	if err != nil {
 		t.Fatalf("[FATAL]: Error while creating default child handle in default context: %s", err)
 	}
@@ -596,7 +596,7 @@ func TestDeriveContextRecursiveOnDerivedContexts(d client.TestDPEInstance, c cli
 	resp, err := c.DeriveContext(childHandle,
 		extendTciValue,
 		client.DeriveContextFlags(client.Recursive),
-		1, 0)
+		0, 0)
 	if err != nil {
 		t.Fatalf("[FATAL]: Could not set TCI value: %v", err)
 	}


### PR DESCRIPTION
This reverts commit b863310e19d57d237630a74d5310c059066ec506.

Related to https://github.com/chipsalliance/caliptra-sw/issues/3660