### PR TITLE
dpe: reduce stack usage by computing TCI nodes on the fly

### DIFF
--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -629,6 +629,11 @@ mod tests {
 
     #[test]
     fn test_child_to_root_iter_backwards() {
+        // This creates a chain of nodes:
+        //
+        //     ROOT <- 0 <- 1 <- 2 <- 3 <- 4
+        //
+        // where <- points to the parent.
         let mut contexts = [CONTEXT_INITIALIZER; MAX_HANDLES];
         let mut parent_idx = Context::ROOT_INDEX;
         let leaf_idx = 4;
@@ -637,7 +642,7 @@ mod tests {
             contexts[i].parent_idx = parent_idx;
             parent_idx = i as u8;
             if i < leaf_idx {
-                contexts[i].children.add_child(i + 1);
+                contexts[i].children.add_child(i + 1).unwrap();
             }
         }
 
@@ -654,6 +659,55 @@ mod tests {
         assert_eq!(context.parent_idx, 1);
         let context = iter.next();
         assert!(context.is_none());
+    }
+
+    #[test]
+    fn test_child_to_root_iter_multiple_children() {
+        // This creats the following hierarchy of nodes:
+        //
+        //     ROOT
+        //      +-- 0
+        //      +-- 1
+        //          +-- 2
+        //              +-- 3
+        //                  +-- 6
+        //          +-- 4
+        //          +-- 5
+        let mut contexts = [CONTEXT_INITIALIZER; MAX_HANDLES];
+        let parent_map: &[(usize, usize)] = &[
+            (0, Context::ROOT_INDEX.into()),
+            (1, Context::ROOT_INDEX.into()),
+            (2, 1),
+            (3, 2),
+            (4, 1),
+            (5, 1),
+            (6, 3),
+        ];
+        for i in 0..=6 {
+            contexts[i].state = ContextState::Active;
+        }
+        for (node_idx, parent_idx) in parent_map.iter() {
+            contexts[*node_idx].parent_idx = *parent_idx as u8;
+            if *parent_idx != Context::ROOT_INDEX.into() {
+                contexts[*parent_idx].children.add_child(*node_idx).unwrap();
+            }
+        }
+
+        let ptr = contexts.as_mut_ptr();
+        let mut iter = ChildToRootIter::new(3, &contexts).unwrap();
+        assert_eq!(iter.num_nodes(), 3);
+
+        // Modify the tree such that no child of node 1 is on the path any more.
+        unsafe {
+            (*ptr.add(2)).parent_idx = Context::ROOT_INDEX;
+            let mut children = Children::empty();
+            children.add_child(2).unwrap();
+            (*ptr.add(1)).children.remove_children(children);
+        }
+        // Consume the iterator once. This should fail because now we can't find any child of node
+        // 1 on the path from node 6 to the root.
+        let context = iter.next_back();
+        assert!(matches!(context, Some(Err(DpeErrorCode::InternalError))));
     }
 
     /// This is intended for testing a list of parent to children relationships. These are indices of contexts within a DPE instance.

--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -345,21 +345,88 @@ pub struct ActiveContextArgs<'a> {
 }
 
 pub(crate) struct ChildToRootIter<'a> {
-    idx: usize,
+    front_idx: usize,
+    back_idx: usize,
+    path_len: usize,
     contexts: &'a [Context],
     done: bool,
     count: usize,
 }
 
-impl ChildToRootIter<'_> {
+impl<'a> ChildToRootIter<'a> {
     /// Create a new iterator that will start at the leaf and go to the root node.
-    pub fn new(leaf_idx: usize, contexts: &[Context]) -> ChildToRootIter {
-        ChildToRootIter {
-            idx: leaf_idx,
+    pub fn new(leaf_idx: usize, contexts: &'a [Context]) -> Result<Self, DpeErrorCode> {
+        let mut iter = Self {
+            front_idx: leaf_idx,
+            back_idx: 0,
+            path_len: 0,
             contexts,
             done: false,
             count: 0,
+        };
+
+        // Calculate the length of the path from the current front node to the root.
+        let mut curr_idx = leaf_idx;
+        loop {
+            let context = iter.get_context(curr_idx)?;
+            iter.path_len += 1;
+            if iter.path_len > MAX_HANDLES {
+                return Err(DpeErrorCode::InternalError);
+            }
+            if context.parent_idx == Context::ROOT_INDEX {
+                iter.back_idx = curr_idx;
+                break;
+            }
+            curr_idx = context.parent_idx as usize;
         }
+
+        Ok(iter)
+    }
+
+    pub fn num_nodes(&self) -> usize {
+        self.path_len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.path_len == 0
+    }
+
+    /// Attempt to get the context at index `idx` and validate it.
+    fn get_context(&mut self, idx: usize) -> Result<&'a Context, DpeErrorCode> {
+        let Some(context) = self.contexts.get(idx) else {
+            self.done = true;
+            return Err(DpeErrorCode::InternalError);
+        };
+
+        // Check if context is valid.
+        const MAX_IDX: u8 = (MAX_HANDLES - 1) as u8;
+        let valid_parent_idx = matches!(context.parent_idx, 0..=MAX_IDX | Context::ROOT_INDEX);
+        if !valid_parent_idx || context.state == ContextState::Inactive {
+            self.done = true;
+            return Err(DpeErrorCode::InvalidHandle);
+        }
+
+        Ok(context)
+    }
+
+    /// Check if node `target_idx` is on the path from node `start_idx` to the root.
+    fn is_node_on_path(
+        &mut self,
+        start_idx: usize,
+        target_idx: usize,
+    ) -> Result<bool, DpeErrorCode> {
+        let mut curr_idx = start_idx;
+        loop {
+            if curr_idx == target_idx {
+                return Ok(true);
+            }
+            let context = self.get_context(curr_idx)?;
+            if context.parent_idx == Context::ROOT_INDEX {
+                break;
+            }
+            curr_idx = context.parent_idx as usize;
+        }
+        Ok(false)
     }
 }
 
@@ -370,28 +437,70 @@ impl<'a> Iterator for ChildToRootIter<'a> {
         if self.done {
             return None;
         }
+        if self.count >= self.path_len {
+            self.done = true;
+            return None;
+        }
         if self.count >= MAX_HANDLES {
             self.done = true;
             return Some(Err(DpeErrorCode::MaxTcis));
         }
 
-        let Some(context) = self.contexts.get(self.idx) else {
-            self.done = true;
-            return Some(Err(DpeErrorCode::InternalError));
+        let context = match self.get_context(self.front_idx) {
+            Ok(context) => context,
+            Err(e) => return Some(Err(e)),
         };
-
-        // Check if context is valid.
-        const MAX_IDX: u8 = (MAX_HANDLES - 1) as u8;
-        let valid_parent_idx = matches!(context.parent_idx, 0..=MAX_IDX | Context::ROOT_INDEX);
-        if !valid_parent_idx || context.state == ContextState::Inactive {
-            self.done = true;
-            return Some(Err(DpeErrorCode::InvalidHandle));
-        }
 
         if context.parent_idx == Context::ROOT_INDEX {
             self.done = true;
         }
-        self.idx = context.parent_idx as usize;
+        self.front_idx = context.parent_idx as usize;
+        self.count += 1;
+        Some(Ok(context))
+    }
+}
+
+impl DoubleEndedIterator for ChildToRootIter<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+        if self.count >= self.path_len {
+            self.done = true;
+            return None;
+        }
+        if self.count >= MAX_HANDLES {
+            self.done = true;
+            return Some(Err(DpeErrorCode::MaxTcis));
+        }
+
+        let context = match self.get_context(self.back_idx) {
+            Ok(context) => context,
+            Err(e) => return Some(Err(e)),
+        };
+
+        // Update the back index to point to the child that is on the path from the
+        // front node to the root.
+        if self.front_idx == self.back_idx {
+            self.done = true;
+        } else {
+            let mut found_child_idx = None;
+            for child_idx in context.children.iter() {
+                match self.is_node_on_path(self.front_idx, child_idx) {
+                    Ok(true) => {
+                        found_child_idx = Some(child_idx);
+                        break;
+                    }
+                    Ok(false) => (),
+                    Err(e) => return Some(Err(e)),
+                }
+            }
+            match found_child_idx {
+                Some(child_idx) => self.back_idx = child_idx,
+                None => return Some(Err(DpeErrorCode::InternalError)),
+            }
+        }
+
         self.count += 1;
         Some(Ok(context))
     }
@@ -442,7 +551,7 @@ mod tests {
         for (answer, status) in chain_indices
             .iter()
             .rev()
-            .zip(ChildToRootIter::new(leaf_index, &contexts))
+            .zip(ChildToRootIter::new(leaf_index, &contexts).unwrap())
         {
             assert_eq!(
                 [*answer as u8; ContextHandle::SIZE],
@@ -465,12 +574,8 @@ mod tests {
         contexts[1].parent_idx = 0;
         contexts[1].state = ContextState::Active;
 
-        let mut iter = ChildToRootIter::new(0, &contexts);
-        for _ in 0..MAX_HANDLES {
-            iter.next().unwrap().unwrap();
-        }
-
-        assert_eq!(DpeErrorCode::MaxTcis, iter.next().unwrap().err().unwrap());
+        let iter = ChildToRootIter::new(0, &contexts);
+        assert!(matches!(iter, Err(DpeErrorCode::InternalError)));
     }
 
     #[test]
@@ -489,49 +594,66 @@ mod tests {
         contexts[0].parent_idx = MAX_HANDLES as u8;
 
         // Above upper bound of handles.
-        let mut iter = ChildToRootIter::new(0, &contexts);
-        assert_eq!(
-            DpeErrorCode::InvalidHandle,
-            iter.next().unwrap().err().unwrap()
-        );
+        let iter = ChildToRootIter::new(0, &contexts);
+        assert!(matches!(iter, Err(DpeErrorCode::InvalidHandle)));
 
         // Inactive.
         contexts[0].state = ContextState::Inactive;
         contexts[0].parent_idx = 0;
-        let mut iter = ChildToRootIter::new(0, &contexts);
-        assert_eq!(
-            DpeErrorCode::InvalidHandle,
-            iter.next().unwrap().err().unwrap()
-        );
+        let iter = ChildToRootIter::new(0, &contexts);
+        assert!(matches!(iter, Err(DpeErrorCode::InvalidHandle)));
 
         // Retired.
         contexts[0].state = ContextState::Retired;
-        let mut iter = ChildToRootIter::new(0, &contexts);
-        assert!(iter.next().unwrap().is_ok());
+        let iter = ChildToRootIter::new(0, &contexts);
+        assert!(matches!(iter, Err(DpeErrorCode::InternalError)));
 
         // Active and upper bound of handles.
         contexts[0].state = ContextState::Active;
         contexts[0].parent_idx = (MAX_HANDLES - 1) as u8;
-        let mut iter = ChildToRootIter::new(0, &contexts);
-        assert!(iter.next().unwrap().is_ok());
+        let iter = ChildToRootIter::new(0, &contexts);
+        assert!(matches!(iter, Err(DpeErrorCode::InvalidHandle)));
 
         // Root index.
         contexts[0].parent_idx = Context::ROOT_INDEX;
-        let mut iter = ChildToRootIter::new(0, &contexts);
+        let mut iter = ChildToRootIter::new(0, &contexts).unwrap();
         assert!(iter.next().unwrap().is_ok());
     }
 
     #[test]
     fn test_child_to_root_iter_infinite_loop() {
         let contexts = [CONTEXT_INITIALIZER; MAX_HANDLES];
-        let mut i = 0;
-        for _ in ChildToRootIter::new(30, &contexts) {
-            i += 1;
-            // fail test if we iterate over all nodes without terminating, meaning we are in infinite loop
-            if i > MAX_HANDLES {
-                panic!("child to root iterator loops without termination")
+        let iter = ChildToRootIter::new(30, &contexts);
+        assert!(matches!(iter, Err(DpeErrorCode::InvalidHandle)));
+    }
+
+    #[test]
+    fn test_child_to_root_iter_backwards() {
+        let mut contexts = [CONTEXT_INITIALIZER; MAX_HANDLES];
+        let mut parent_idx = Context::ROOT_INDEX;
+        let leaf_idx = 4;
+        for i in 0..=leaf_idx {
+            contexts[i].state = ContextState::Active;
+            contexts[i].parent_idx = parent_idx;
+            parent_idx = i as u8;
+            if i < leaf_idx {
+                contexts[i].children.add_child(i + 1);
             }
         }
+
+        let mut iter = ChildToRootIter::new(leaf_idx, &contexts).unwrap();
+        let context = iter.next_back().unwrap().unwrap();
+        assert_eq!(context.parent_idx, Context::ROOT_INDEX);
+        let context = iter.next().unwrap().unwrap();
+        assert_eq!(context.parent_idx, 3);
+        let context = iter.next_back().unwrap().unwrap();
+        assert_eq!(context.parent_idx, 0);
+        let context = iter.next().unwrap().unwrap();
+        assert_eq!(context.parent_idx, 2);
+        let context = iter.next_back().unwrap().unwrap();
+        assert_eq!(context.parent_idx, 1);
+        let context = iter.next();
+        assert!(context.is_none());
     }
 
     /// This is intended for testing a list of parent to children relationships. These are indices of contexts within a DPE instance.

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -335,7 +335,7 @@ impl DpeInstance {
         let mut uses_internal_input_dice = false;
 
         // Hash each node.
-        for status in ChildToRootIter::new(start_idx, &state.contexts) {
+        for status in ChildToRootIter::new(start_idx, &state.contexts)? {
             let context = status?;
 
             hasher.update(context.tci.as_bytes())?;
@@ -622,7 +622,7 @@ pub mod tests {
         let (crypto, _platform, state) = env.get();
         let digest = crypto
             .with_hasher(&|hasher| {
-                for result in ChildToRootIter::new(leaf_idx, &state.contexts) {
+                for result in ChildToRootIter::new(leaf_idx, &state.contexts).unwrap() {
                     let context = result.unwrap();
                     hasher.update(context.tci.as_bytes()).unwrap();
                     hasher

--- a/dpe/src/state.rs
+++ b/dpe/src/state.rs
@@ -1,18 +1,14 @@
 // Licensed under the Apache-2.0 license.
 use crate::{
-    context::{ChildToRootIter, Children, Context, ContextHandle, ContextState},
+    context::{Children, Context, ContextHandle, ContextState},
     response::DpeErrorCode,
     support::Support,
-    tci::TciNodeData,
     U8Bool, MAX_HANDLES,
 };
 use bitflags::bitflags;
 use core::mem::align_of;
 use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout};
 use zeroize::Zeroize;
-
-#[cfg(feature = "cfi")]
-use caliptra_cfi_derive::cfi_impl_fn;
 
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, FromBytes, IntoBytes, Immutable, KnownLayout, Zeroize)]
@@ -180,39 +176,6 @@ impl State {
             descendants.add_children(self.get_descendants(ctx)?);
         }
         Ok(descendants)
-    }
-
-    /// Get the TCI nodes from the context at `start_idx` to the root node following parent
-    /// links. These are the nodes that should contribute to CDI and key
-    /// derivation for the context at `start_idx`.
-    ///
-    /// # Arguments
-    ///
-    /// * `start_idx` - Index into context array
-    /// * `nodes` - Array to write TCI nodes to
-    ///
-    /// Returns the number of TCIs written to `nodes`
-    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
-    pub(crate) fn get_tcb_nodes(
-        &self,
-        start_idx: usize,
-        nodes: &mut [TciNodeData],
-    ) -> Result<usize, DpeErrorCode> {
-        let mut out_idx = 0;
-
-        for status in ChildToRootIter::new(start_idx, &self.contexts) {
-            let curr = status?;
-
-            *nodes.get_mut(out_idx).ok_or(DpeErrorCode::InternalError)? = curr.tci;
-            out_idx += 1;
-        }
-
-        nodes
-            .get_mut(..out_idx)
-            .ok_or(DpeErrorCode::InternalError)?
-            .reverse();
-
-        Ok(out_idx)
     }
 
     /// Count number of contexts satisfying some predicate

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -6,12 +6,12 @@
 //! this functionality for a no_std environment.
 
 use crate::{
-    context::ContextHandle,
+    context::{ChildToRootIter, Context, ContextHandle},
     dpe_instance::DpeEnv,
     okref,
     response::DpeErrorCode,
     tci::{TciMeasurement, TciNodeData},
-    DpeInstance, DpeProfile, State, MAX_HANDLES,
+    DpeInstance, DpeProfile, MAX_HANDLES,
 };
 use bitflags::bitflags;
 use caliptra_cfi_lib::cfi_launder;
@@ -90,9 +90,47 @@ pub struct Name<'a> {
     pub serial: DirectoryString<'a>,
 }
 
+struct TciNodes<'a> {
+    start_idx: usize,
+    contexts: &'a [Context],
+}
+
+impl<'a> TciNodes<'a> {
+    pub fn new(start_idx: usize, contexts: &'a [Context]) -> Result<Self, DpeErrorCode> {
+        let tci_nodes = Self {
+            start_idx,
+            contexts,
+        };
+        if tci_nodes.iter()?.count() > MAX_HANDLES {
+            Err(DpeErrorCode::InternalError)
+        } else {
+            Ok(tci_nodes)
+        }
+    }
+
+    fn iter(&self) -> Result<ChildToRootIter, DpeErrorCode> {
+        ChildToRootIter::new(self.start_idx, self.contexts)
+    }
+
+    pub fn is_empty(&self) -> Result<bool, DpeErrorCode> {
+        Ok(self.iter()?.is_empty())
+    }
+
+    pub fn num_nodes(&self) -> Result<usize, DpeErrorCode> {
+        Ok(self.iter()?.num_nodes())
+    }
+
+    pub fn first_node(&self) -> Result<Option<&TciNodeData>, DpeErrorCode> {
+        self.iter()?
+            .next_back()
+            .transpose()
+            .map(|opt| opt.map(|context| &context.tci))
+    }
+}
+
 pub struct MeasurementData<'a> {
+    tci_nodes: TciNodes<'a>,
     pub label: &'a [u8],
-    pub tci_nodes: &'a [TciNodeData],
     pub is_ca: bool,
     pub supports_recursive: bool,
     pub subject_key_identifier: [u8; MAX_KEY_IDENTIFIER_SIZE],
@@ -630,16 +668,16 @@ impl CertWriter<'_> {
         measurements: &MeasurementData,
         tagged: bool,
     ) -> Result<usize, DpeErrorCode> {
-        if measurements.tci_nodes.is_empty() {
+        if measurements.tci_nodes.is_empty()? {
             return Err(DpeErrorCode::InternalError);
         }
 
         // Size of concatenated tcb infos
-        let tcb_infos_size = measurements.tci_nodes.len()
+        let tcb_infos_size = measurements.tci_nodes.num_nodes()?
             * self.get_tcb_info_size(
                 measurements
                     .tci_nodes
-                    .first()
+                    .first_node()?
                     .ok_or(DpeErrorCode::InternalError)?,
                 measurements.supports_recursive,
                 /*tagged=*/ true,
@@ -1617,12 +1655,15 @@ impl CertWriter<'_> {
         &mut self,
         measurements: &MeasurementData,
     ) -> Result<usize, DpeErrorCode> {
-        let tcb_infos_size = if !measurements.tci_nodes.is_empty() {
+        let tcb_infos_size = if !measurements.tci_nodes.is_empty()? {
             self.get_tcb_info_size(
-                &measurements.tci_nodes[0],
+                measurements
+                    .tci_nodes
+                    .first_node()?
+                    .ok_or(DpeErrorCode::InternalError)?,
                 measurements.supports_recursive,
                 /*tagged=*/ true,
-            )? * measurements.tci_nodes.len()
+            )? * measurements.tci_nodes.num_nodes()?
         } else {
             0
         };
@@ -1636,8 +1677,11 @@ impl CertWriter<'_> {
         bytes_written += self.encode_size_field(tcb_infos_size);
 
         // Encode multiple tcg-dice-TcbInfos
-        for node in measurements.tci_nodes {
-            bytes_written += self.encode_tcb_info(node, measurements.supports_recursive)?;
+        for node in measurements.tci_nodes.iter()?.rev() {
+            bytes_written += self.encode_tcb_info(
+                node.map(|context| &context.tci)?,
+                measurements.supports_recursive,
+            )?;
         }
 
         Ok(bytes_written)
@@ -2617,20 +2661,6 @@ fn get_subject_name<'a>(
     Ok(subject_name)
 }
 
-fn get_tci_nodes<'a>(
-    state: &State,
-    handle: &ContextHandle,
-    locality: u32,
-    nodes: &'a mut [TciNodeData],
-) -> Result<&'a mut [TciNodeData], DpeErrorCode> {
-    let parent_idx = state.get_active_context_pos(handle, locality)?;
-    let tcb_count = state.get_tcb_nodes(parent_idx, nodes)?;
-    if tcb_count > MAX_HANDLES {
-        return Err(DpeErrorCode::InternalError);
-    }
-    Ok(&mut nodes[..tcb_count])
-}
-
 fn get_subject_key_identifier(
     crypto: &mut dyn CryptoSuite,
     pub_key: &PubKey,
@@ -2832,10 +2862,6 @@ fn create_dpe_cert_or_csr(
     let mut subj_serial = [0u8; MAX_HASH_SIZE * 2];
     let subject_name = get_subject_name(crypto, &cert_type, pub_key, &mut subj_serial)?;
 
-    const INITIALIZER: TciNodeData = TciNodeData::new();
-    let mut nodes = [INITIALIZER; MAX_HANDLES];
-    let tci_nodes = get_tci_nodes(state, args.handle, args.locality, &mut nodes)?;
-
     let mut subject_key_identifier = [0u8; MAX_KEY_IDENTIFIER_SIZE];
     get_subject_key_identifier(crypto, pub_key, &mut subject_key_identifier)?;
 
@@ -2859,8 +2885,11 @@ fn create_dpe_cert_or_csr(
     };
 
     let measurements = MeasurementData {
+        tci_nodes: TciNodes::new(
+            state.get_active_context_pos(args.handle, args.locality)?,
+            &state.contexts,
+        )?,
         label: args.ueid,
-        tci_nodes,
         is_ca,
         supports_recursive,
         subject_key_identifier,
@@ -2939,10 +2968,11 @@ fn create_dpe_cert_or_csr(
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use crate::context::{Context, ContextState};
     use crate::dpe_instance::tests::DPE_PROFILE;
     use crate::response::DpeErrorCode;
     use crate::tci::{TciMeasurement, TciNodeData};
-    use crate::x509::{CertWriter, DirectoryString, MeasurementData, Name};
+    use crate::x509::{CertWriter, DirectoryString, MeasurementData, Name, TciNodes};
     use crate::DpeProfile;
     use caliptra_dpe_crypto::ecdsa::{EcdsaAlgorithm, EcdsaSig};
     use caliptra_dpe_crypto::ecdsa::{EcdsaPub, EcdsaPubKey};
@@ -3123,7 +3153,11 @@ pub(crate) mod tests {
             .unwrap();
         let issuer = &issuer_der[..issuer_len];
 
-        let node = TciNodeData::new();
+        let context = Context {
+            state: ContextState::Active,
+            ..Context::default()
+        };
+        let contexts = [context];
         let subject_key_identifier = [0u8; MAX_KEY_IDENTIFIER_SIZE];
         let mut other_name = ArrayVec::new();
         other_name
@@ -3131,7 +3165,7 @@ pub(crate) mod tests {
             .unwrap();
         let measurements = MeasurementData {
             label: &[0; DPE_PROFILE.hash_size()],
-            tci_nodes: &[node],
+            tci_nodes: TciNodes::new(0, &contexts).unwrap(),
             is_ca: false,
             supports_recursive: true,
             subject_key_identifier,
@@ -3390,7 +3424,11 @@ pub(crate) mod tests {
 
         let test_pub = EcdsaPub::from_slice(&[0xAA; ECC_INT_SIZE], &[0xBB; ECC_INT_SIZE]);
 
-        let node = TciNodeData::new();
+        let context = Context {
+            state: ContextState::Active,
+            ..Context::default()
+        };
+        let contexts = [context];
 
         let mut hasher = match DPE_PROFILE {
             DpeProfile::P256Sha256 => Hasher::new(MessageDigest::sha256()).unwrap(),
@@ -3417,7 +3455,7 @@ pub(crate) mod tests {
         });
         let measurements = MeasurementData {
             label: &[0; DPE_PROFILE.hash_size()],
-            tci_nodes: &[node],
+            tci_nodes: TciNodes::new(0, &contexts).unwrap(),
             is_ca,
             supports_recursive: true,
             subject_key_identifier,
@@ -3510,7 +3548,11 @@ pub(crate) mod tests {
 
         let test_pub = MldsaPublicKey::from_slice(&[0xAA; ALGORITHM.public_key_size()]);
 
-        let node = TciNodeData::new();
+        let context = Context {
+            state: ContextState::Active,
+            ..Context::default()
+        };
+        let contexts = [context];
 
         let mut hasher = match DPE_PROFILE {
             DpeProfile::Mldsa87 => Hasher::new(MessageDigest::sha384()).unwrap(),
@@ -3530,7 +3572,7 @@ pub(crate) mod tests {
         });
         let measurements = MeasurementData {
             label: &[0; DPE_PROFILE.hash_size()],
-            tci_nodes: &[node],
+            tci_nodes: TciNodes::new(0, &contexts).unwrap(),
             is_ca,
             supports_recursive: true,
             subject_key_identifier,
@@ -3766,21 +3808,25 @@ pub(crate) mod tests {
         }
     }
 
-    fn build_test_node() -> TciNodeData {
+    fn build_test_context() -> Context {
         use crate::tci::TciMeasurement;
 
+        let mut context = Context::new();
         let mut node = TciNodeData::new();
         node.tci_type = 0x01020304;
         node.tci_current = TciMeasurement([0xAA; DPE_PROFILE.tci_size()]);
         node.tci_cumulative = TciMeasurement([0xBB; DPE_PROFILE.tci_size()]);
         node.locality = 0x05060708;
-        node
+
+        context.tci = node;
+        context.state = ContextState::Active;
+        context
     }
 
-    fn build_test_measurements<'a>(nodes: &'a [TciNodeData], is_ca: bool) -> MeasurementData<'a> {
+    fn build_test_measurements<'a>(contexts: &'a [Context], is_ca: bool) -> MeasurementData<'a> {
         MeasurementData {
             label: &[0xAA; 4],
-            tci_nodes: nodes,
+            tci_nodes: TciNodes::new(0, contexts).unwrap(),
             is_ca,
             supports_recursive: true,
             subject_key_identifier: [0xBB; MAX_KEY_IDENTIFIER_SIZE],
@@ -3791,9 +3837,9 @@ pub(crate) mod tests {
 
     #[test]
     fn test_encode_multi_tcb_info_bytes() {
-        let node = build_test_node();
-        let nodes = [node];
-        let measurements = build_test_measurements(&nodes, true);
+        let context = build_test_context();
+        let contexts = [context];
+        let measurements = build_test_measurements(&contexts, true);
 
         let mut buf = [0u8; 1024];
         let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
@@ -3874,9 +3920,9 @@ pub(crate) mod tests {
 
     #[test]
     fn test_encode_ueid_bytes() {
-        let node = build_test_node();
-        let nodes = [node];
-        let measurements = build_test_measurements(&nodes, true);
+        let context = build_test_context();
+        let contexts = [context];
+        let measurements = build_test_measurements(&contexts, true);
 
         let mut buf = [0u8; 1024];
         let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
@@ -3895,9 +3941,9 @@ pub(crate) mod tests {
 
     #[test]
     fn test_encode_basic_constraints_bytes() {
-        let node = build_test_node();
-        let nodes = [node];
-        let measurements = build_test_measurements(&nodes, true);
+        let context = build_test_context();
+        let contexts = [context];
+        let measurements = build_test_measurements(&contexts, true);
 
         let mut buf = [0u8; 1024];
         let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
@@ -3932,9 +3978,9 @@ pub(crate) mod tests {
 
     #[test]
     fn test_encode_extended_key_usage_bytes() {
-        let node = build_test_node();
-        let nodes = [node];
-        let measurements = build_test_measurements(&nodes, true);
+        let context = build_test_context();
+        let contexts = [context];
+        let measurements = build_test_measurements(&contexts, true);
 
         let mut buf = [0u8; 1024];
         let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
@@ -3953,9 +3999,9 @@ pub(crate) mod tests {
 
     #[test]
     fn test_encode_subject_alt_name_extension_bytes() {
-        let node = build_test_node();
-        let nodes = [node];
-        let mut measurements = build_test_measurements(&nodes, true);
+        let context = build_test_context();
+        let contexts = [context];
+        let mut measurements = build_test_measurements(&contexts, true);
 
         let mut other_name_val = ArrayVec::new();
         other_name_val.try_extend_from_slice(b"test").unwrap();
@@ -3983,9 +4029,9 @@ pub(crate) mod tests {
 
     #[test]
     fn test_encode_authority_key_identifier_extension_bytes() {
-        let node = build_test_node();
-        let nodes = [node];
-        let measurements = build_test_measurements(&nodes, true);
+        let context = build_test_context();
+        let contexts = [context];
+        let measurements = build_test_measurements(&contexts, true);
 
         let mut buf = [0u8; 1024];
         let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
@@ -4006,9 +4052,9 @@ pub(crate) mod tests {
 
     #[test]
     fn test_encode_subject_key_identifier_extension_bytes() {
-        let node = build_test_node();
-        let nodes = [node];
-        let measurements = build_test_measurements(&nodes, true);
+        let context = build_test_context();
+        let contexts = [context];
+        let measurements = build_test_measurements(&contexts, true);
 
         let mut buf = [0u8; 1024];
         let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
@@ -4063,11 +4109,15 @@ pub(crate) mod tests {
         };
         let mut sign_cb = |_data: &[u8], _use_derived: bool| Ok(test_sig.clone());
 
-        let node = TciNodeData::new();
+        let context = Context {
+            state: ContextState::Active,
+            ..Context::default()
+        };
+        let contexts = [context];
         let subject_key_identifier = [0xBB; MAX_KEY_IDENTIFIER_SIZE];
         let measurements = MeasurementData {
             label: &[0; DPE_PROFILE.hash_size()],
-            tci_nodes: &[node],
+            tci_nodes: TciNodes::new(0, &contexts).unwrap(),
             is_ca: false,
             supports_recursive: false,
             subject_key_identifier,


### PR DESCRIPTION
Enhance the `ChildToRootIter` type such that it supports traversing the TCI nodes in both directions. Avoid storing TCI data for `MAX_HANDLES` nodes on the stack but instead computing the TCI nodes information by using the iterator on the fly.

This will save `size_of::<TciNodeData>() * MAX_HANDLES`, which is `(48*2 + 4*3) * 64 == 6912` bytes from the stack when ML-DSA is enabled. The cost is the time spent on maintaining the iterator's internal state. But given the maximum node is 64 it should be acceptable compared to the reduction of stack usage.