### PR TITLE
dpe: fix tests and compiler complaints

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -439,12 +439,11 @@ mod tests {
     };
     use caliptra_cfi_lib::CfiCounter;
     use caliptra_dpe_crypto::artifacts;
+    #[cfg(not(feature = "ml-dsa"))]
+    use caliptra_dpe_crypto::ecdsa::EcdsaPub;
     #[cfg(feature = "ml-dsa")]
     use caliptra_dpe_crypto::ml_dsa::{MldsaAlgorithm, MldsaPublicKey};
-    use caliptra_dpe_crypto::{
-        ecdsa::{EcdsaAlgorithm, EcdsaPub},
-        PubKey, SignatureAlgorithm,
-    };
+    use caliptra_dpe_crypto::{ecdsa::EcdsaAlgorithm, PubKey, SignatureAlgorithm};
     use cms::{
         content_info::{CmsVersion, ContentInfo},
         signed_data::{SignedData, SignerIdentifier},

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -498,8 +498,6 @@ impl Default for DeriveContextCmd {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "ml-dsa")]
-    use crate::commands::{sign::SignMldsa87Cmd as SignCmd, CertifyKeyMldsa87Cmd as CertifyKeyCmd};
     #[cfg(feature = "p256")]
     use crate::commands::{sign::SignP256Cmd as SignCmd, CertifyKeyP256Cmd as CertifyKeyCmd};
     #[cfg(feature = "p384")]
@@ -507,26 +505,28 @@ mod tests {
     use crate::{
         commands::{
             rotate_context::{RotateCtxCmd, RotateCtxFlags},
-            tests::{PROFILES, TEST_DIGEST, TEST_LABEL},
-            CertifyKeyCommand, CertifyKeyFlags, Command, CommandHdr, InitCtxCmd, SignFlags,
+            tests::{PROFILES, TEST_DIGEST},
+            Command, CommandHdr, InitCtxCmd,
         },
         context::ContextType,
         dpe_instance::tests::{DPE_PROFILE, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_LOCALITIES},
-        response::{NewHandleResp, Response, SignResp},
+        response::{NewHandleResp, Response},
         support::Support,
         test_env,
         validation::DpeValidator,
         AlignedBuf, DpeProfile, MAX_CERT_SIZE, MAX_EXPORTED_CDI_SIZE, MAX_HANDLES, TCI_SIZE,
     };
+    #[cfg(not(feature = "ml-dsa"))]
+    use crate::{
+        commands::{tests::TEST_LABEL, CertifyKeyCommand, CertifyKeyFlags, SignFlags},
+        response::SignResp,
+    };
     use caliptra_cfi_lib::CfiCounter;
     use caliptra_dpe_platform::MAX_KEY_IDENTIFIER_SIZE;
     use core::mem::size_of;
-    use openssl::{
-        bn::BigNum,
-        ecdsa::EcdsaSig,
-        hash::{Hasher as OpenSSLHasher, MessageDigest},
-        x509::X509,
-    };
+    use openssl::hash::{Hasher as OpenSSLHasher, MessageDigest};
+    #[cfg(not(feature = "ml-dsa"))]
+    use openssl::{bn::BigNum, ecdsa::EcdsaSig, x509::X509};
     use x509_parser::{nom::Parser, oid_registry::asn1_rs::oid, prelude::*};
     use zerocopy::IntoBytes;
 

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -366,6 +366,8 @@ impl CommandExecution for SignMldsa87RawCmd {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(any(feature = "p256", feature = "p384"))]
+    use crate::commands::tests::TEST_DIGEST;
     #[cfg(feature = "ml-dsa")]
     use crate::commands::{sign::SignMldsa87Cmd as SignCmd, CertifyKeyMldsa87Cmd as CertifyKeyCmd};
     #[cfg(feature = "p256")]
@@ -376,7 +378,7 @@ mod tests {
         commands::{
             certify_key::{CertifyKeyCommand, CertifyKeyFlags},
             derive_context::DeriveContextFlags,
-            tests::{TEST_DIGEST, TEST_LABEL},
+            tests::TEST_LABEL,
             Command, CommandHdr, DeriveContextCmd, InitCtxCmd,
         },
         dpe_instance::tests::{
@@ -388,8 +390,11 @@ mod tests {
     };
     use caliptra_cfi_lib::CfiCounter;
     use core::mem::size_of;
-    use openssl::x509::X509;
-    use openssl::{bn::BigNum, ecdsa::EcdsaSig};
+    #[cfg(any(feature = "p256", feature = "p384"))]
+    use openssl::{
+        x509::X509,
+        {bn::BigNum, ecdsa::EcdsaSig},
+    };
     use zerocopy::IntoBytes;
 
     #[cfg(feature = "ml-dsa")]
@@ -483,6 +488,7 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore)]
+    #[allow(unreachable_patterns)]
     fn test_asymmetric() {
         CfiCounter::reset_for_test();
         let mut state = test_state();
@@ -555,7 +561,6 @@ mod tests {
             #[cfg(feature = "ml-dsa")]
             DpeProfile::Mldsa87 => {
                 use crate::response::CertifyKeyResp;
-                use ml_dsa::signature::Verifier;
                 use ml_dsa::{EncodedSignature, EncodedVerifyingKey, VerifyingKey};
 
                 let sig_bytes = match sign_resp {
@@ -657,6 +662,7 @@ mod tests {
 
     #[cfg(feature = "ml-dsa")]
     #[test]
+    #[allow(unreachable_patterns)]
     fn test_sign_raw_mode_signature_is_valid() {
         CfiCounter::reset_for_test();
         let mut state = test_state();

--- a/dpe/src/commands/update_context_measurement.rs
+++ b/dpe/src/commands/update_context_measurement.rs
@@ -141,7 +141,7 @@ mod tests {
     use crate::{
         commands::{
             rotate_context::{RotateCtxCmd, RotateCtxFlags},
-            DeriveContextCmd, DeriveContextFlags, InitCtxCmd,
+            DeriveContextCmd, DeriveContextFlags,
         },
         context::ContextHandle,
         dpe_instance::{tests::TEST_LOCALITIES, DpeInstance},

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -2975,8 +2975,8 @@ pub(crate) mod tests {
     use crate::x509::{CertWriter, DirectoryString, MeasurementData, Name, TciNodes};
     use crate::DpeProfile;
     use crate::MAX_HANDLES;
-    use caliptra_dpe_crypto::ecdsa::{EcdsaAlgorithm, EcdsaSig};
-    use caliptra_dpe_crypto::ecdsa::{EcdsaPub, EcdsaPubKey};
+    #[cfg(not(feature = "ml-dsa"))]
+    use caliptra_dpe_crypto::ecdsa::{EcdsaAlgorithm, EcdsaPub, EcdsaPubKey, EcdsaSig};
     #[cfg(feature = "ml-dsa")]
     use caliptra_dpe_crypto::ml_dsa::MldsaPublicKey;
     #[cfg(feature = "ml-dsa")]
@@ -2991,7 +2991,9 @@ pub(crate) mod tests {
     #[cfg(not(feature = "disable_csr"))]
     use cms::signed_data::{SignerIdentifier as CmsSignerIdentifier, SignerInfo as CmsSignerInfo};
     #[cfg(not(feature = "disable_csr"))]
-    use der::{Decode, Encode};
+    use der::Decode;
+    #[cfg(not(feature = "ml-dsa"))]
+    use der::Encode;
     use openssl::hash::{Hasher, MessageDigest};
     #[cfg(not(feature = "disable_csr"))]
     use spki::ObjectIdentifier;
@@ -3421,11 +3423,13 @@ pub(crate) mod tests {
         serial: DirectoryString::PrintableString(&[0x00; DPE_PROFILE.hash_size() * 2]),
     };
 
+    #[cfg(not(feature = "ml-dsa"))]
     const ECC_INT_SIZE: usize = DPE_PROFILE.ecc_int_size();
 
     const DEFAULT_OTHER_NAME_OID: &[u8] = &[0, 0, 0];
     const DEFAULT_OTHER_NAME_VALUE: &str = "default-other-name";
 
+    #[cfg(not(feature = "ml-dsa"))]
     fn build_test_cert_ecdsa(is_ca: bool, cert_buf: &mut [u8]) -> (usize, X509Certificate<'_>) {
         let mut issuer_der = [0u8; 1024];
         let mut issuer_writer = CertWriter::new(&mut issuer_der, DPE_PROFILE, true);
@@ -4189,8 +4193,13 @@ pub(crate) mod tests {
         buf
     }
 
-    fn make_tci_nodes(n: usize) -> Vec<TciNodeData> {
-        (0..n).map(|_| TciNodeData::new()).collect()
+    fn make_test_contexts(n: usize) -> Vec<Context> {
+        (0..n)
+            .map(|_| Context {
+                state: ContextState::Active,
+                ..Context::default()
+            })
+            .collect()
     }
 
     // Expected DER bytes of SEQUENCE { INTEGER(r), INTEGER(s) } for our ECDSA test sig.
@@ -4251,7 +4260,7 @@ pub(crate) mod tests {
             (issuer, label, other_name)
         };
 
-        let tci_nodes = make_tci_nodes(n_nodes);
+        let contexts = make_test_contexts(n_nodes);
         let ski = [0xBBu8; MAX_KEY_IDENTIFIER_SIZE];
         let mut other_name_av = ArrayVec::new();
         other_name_av
@@ -4259,7 +4268,7 @@ pub(crate) mod tests {
             .unwrap();
         let measurements = MeasurementData {
             label: &label_bytes,
-            tci_nodes: &tci_nodes,
+            tci_nodes: TciNodes::new(0, contexts.as_slice()).unwrap(),
             is_ca: false,
             supports_recursive: true,
             subject_key_identifier: ski,
@@ -4362,7 +4371,7 @@ pub(crate) mod tests {
             (issuer, label, other_name)
         };
 
-        let tci_nodes = make_tci_nodes(n_nodes);
+        let contexts = make_test_contexts(n_nodes);
         let ski = [0xBBu8; MAX_KEY_IDENTIFIER_SIZE];
         let mut other_name_av = ArrayVec::new();
         other_name_av
@@ -4370,7 +4379,7 @@ pub(crate) mod tests {
             .unwrap();
         let measurements = MeasurementData {
             label: &label_bytes,
-            tci_nodes: &tci_nodes,
+            tci_nodes: TciNodes::new(0, contexts.as_slice()).unwrap(),
             is_ca: false,
             supports_recursive: true,
             subject_key_identifier: ski,
@@ -4474,7 +4483,7 @@ pub(crate) mod tests {
             DEFAULT_OTHER_NAME_VALUE.as_bytes().to_vec()
         };
 
-        let tci_nodes = make_tci_nodes(n_nodes);
+        let contexts = make_test_contexts(n_nodes);
         let ski = [0xBBu8; MAX_KEY_IDENTIFIER_SIZE];
         let mut other_name_av = ArrayVec::new();
         other_name_av
@@ -4482,7 +4491,7 @@ pub(crate) mod tests {
             .unwrap();
         let measurements = MeasurementData {
             label: &label_bytes,
-            tci_nodes: &tci_nodes,
+            tci_nodes: TciNodes::new(0, contexts.as_slice()).unwrap(),
             is_ca: false,
             supports_recursive: true,
             subject_key_identifier: ski,
@@ -4568,7 +4577,7 @@ pub(crate) mod tests {
             DEFAULT_OTHER_NAME_VALUE.as_bytes().to_vec()
         };
 
-        let tci_nodes = make_tci_nodes(n_nodes);
+        let contexts = make_test_contexts(n_nodes);
         let ski = [0xBBu8; MAX_KEY_IDENTIFIER_SIZE];
         let mut other_name_av = ArrayVec::new();
         other_name_av
@@ -4576,7 +4585,7 @@ pub(crate) mod tests {
             .unwrap();
         let measurements = MeasurementData {
             label: &label_bytes,
-            tci_nodes: &tci_nodes,
+            tci_nodes: TciNodes::new(0, contexts.as_slice()).unwrap(),
             is_ca: false,
             supports_recursive: true,
             subject_key_identifier: ski,
@@ -4659,7 +4668,7 @@ pub(crate) mod tests {
             DEFAULT_OTHER_NAME_VALUE.as_bytes().to_vec()
         };
 
-        let tci_nodes = make_tci_nodes(n_nodes);
+        let contexts = make_test_contexts(n_nodes);
         let ski = [0xBBu8; MAX_KEY_IDENTIFIER_SIZE];
         let mut other_name_av = ArrayVec::new();
         other_name_av
@@ -4667,7 +4676,7 @@ pub(crate) mod tests {
             .unwrap();
         let measurements = MeasurementData {
             label: &label_bytes,
-            tci_nodes: &tci_nodes,
+            tci_nodes: TciNodes::new(0, contexts.as_slice()).unwrap(),
             is_ca: false,
             supports_recursive: true,
             subject_key_identifier: ski,
@@ -4758,7 +4767,7 @@ pub(crate) mod tests {
             DEFAULT_OTHER_NAME_VALUE.as_bytes().to_vec()
         };
 
-        let tci_nodes = make_tci_nodes(n_nodes);
+        let contexts = make_test_contexts(n_nodes);
         let ski = [0xBBu8; MAX_KEY_IDENTIFIER_SIZE];
         let mut other_name_av = ArrayVec::new();
         other_name_av
@@ -4766,7 +4775,7 @@ pub(crate) mod tests {
             .unwrap();
         let measurements = MeasurementData {
             label: &label_bytes,
-            tci_nodes: &tci_nodes,
+            tci_nodes: TciNodes::new(0, contexts.as_slice()).unwrap(),
             is_ca: false,
             supports_recursive: true,
             subject_key_identifier: ski,


### PR DESCRIPTION
This PR fixes the compiler warnings and failing tests introduced by the recently merged 2 PRs since they both touched X509 tests.