### PR TITLE
Optimize MLDSA CSR stack usage

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -462,11 +462,91 @@ pub trait CryptoSuite: Crypto + SignatureType + DigestType {
 }
 
 pub trait Signer {
-    /// Sign `data` with the derived private key
-    fn sign(&mut self, data: &SignData) -> Result<Signature, CryptoError>;
+    /// Sign `data` with the derived private key into a caller-provided byte slice.
+    /// For ECDSA, writes raw r||s bytes (64 bytes for P-256, 96 bytes for P-384).
+    /// For ML-DSA, writes raw signature bytes (4627 bytes for ML-DSA-87).
+    /// The `pub_key` parameter is used by implementations that need the public key
+    /// for post-sign verification (e.g., ML-DSA hardware).
+    fn sign_into_slice(
+        &mut self,
+        data: &SignData,
+        pub_key: Option<&[u8]>,
+        signature: &mut [u8],
+    ) -> Result<(), CryptoError>;
 
-    /// Get the public key associated with the derived key-pair
-    fn public_key(&mut self) -> Result<PubKey, CryptoError>;
+    /// Sign `data` with the derived private key, returning the signature by value.
+    /// Default implementation calls `sign_into_slice`.
+    fn sign(&mut self, data: &SignData) -> Result<Signature, CryptoError> {
+        match self.signature_alg() {
+            SignatureAlgorithm::Ecdsa(alg) => {
+                let curve_size = alg.curve_size();
+                let mut buf = [0u8; ecdsa::curve_384::CURVE_SIZE * 2];
+                self.sign_into_slice(data, None, &mut buf[..curve_size * 2])?;
+                let (r, s) = buf[..curve_size * 2].split_at(curve_size);
+                Ok(Signature::Ecdsa(match alg {
+                    ecdsa::EcdsaAlgorithm::Bit256 => {
+                        ecdsa::EcdsaSignature::Ecdsa256(ecdsa::EcdsaSig::from_slice(
+                            r.try_into().map_err(|_| CryptoError::Size)?,
+                            s.try_into().map_err(|_| CryptoError::Size)?,
+                        ))
+                    }
+                    ecdsa::EcdsaAlgorithm::Bit384 => {
+                        ecdsa::EcdsaSignature::Ecdsa384(ecdsa::EcdsaSig::from_slice(
+                            r.try_into().map_err(|_| CryptoError::Size)?,
+                            s.try_into().map_err(|_| CryptoError::Size)?,
+                        ))
+                    }
+                }))
+            }
+            #[cfg(feature = "ml-dsa")]
+            SignatureAlgorithm::Mldsa(_) => {
+                let mut buf = [0u8; ml_dsa::MldsaAlgorithm::Mldsa87.signature_size()];
+                self.sign_into_slice(data, None, &mut buf)?;
+                Ok(Signature::Mldsa(ml_dsa::MldsaSignature(buf)))
+            }
+        }
+    }
+
+    /// Get the public key associated with the derived key-pair into a caller-provided byte slice.
+    /// For ECDSA, writes raw x||y bytes (64 bytes for P-256, 96 bytes for P-384).
+    /// For ML-DSA, writes raw public key bytes (2592 bytes for ML-DSA-87).
+    fn public_key_into(&mut self, pub_key: &mut [u8]) -> Result<(), CryptoError>;
+
+    /// Get the public key associated with the derived key-pair, returning by value.
+    /// Default implementation calls `public_key_into`.
+    fn public_key(&mut self) -> Result<PubKey, CryptoError> {
+        match self.signature_alg() {
+            SignatureAlgorithm::Ecdsa(alg) => {
+                let curve_size = alg.curve_size();
+                let mut buf = [0u8; ecdsa::curve_384::CURVE_SIZE * 2];
+                self.public_key_into(&mut buf[..curve_size * 2])?;
+                let (x, y) = buf[..curve_size * 2].split_at(curve_size);
+                Ok(PubKey::Ecdsa(match alg {
+                    ecdsa::EcdsaAlgorithm::Bit256 => {
+                        ecdsa::EcdsaPubKey::Ecdsa256(ecdsa::EcdsaPub::from_slice(
+                            x.try_into().map_err(|_| CryptoError::Size)?,
+                            y.try_into().map_err(|_| CryptoError::Size)?,
+                        ))
+                    }
+                    ecdsa::EcdsaAlgorithm::Bit384 => {
+                        ecdsa::EcdsaPubKey::Ecdsa384(ecdsa::EcdsaPub::from_slice(
+                            x.try_into().map_err(|_| CryptoError::Size)?,
+                            y.try_into().map_err(|_| CryptoError::Size)?,
+                        ))
+                    }
+                }))
+            }
+            #[cfg(feature = "ml-dsa")]
+            SignatureAlgorithm::Mldsa(_) => {
+                let mut buf = [0u8; ml_dsa::MldsaAlgorithm::Mldsa87.public_key_size()];
+                self.public_key_into(&mut buf)?;
+                Ok(PubKey::Mldsa(ml_dsa::MldsaPublicKey(buf)))
+            }
+        }
+    }
+
+    /// Returns the signature algorithm used by this signer.
+    fn signature_alg(&self) -> SignatureAlgorithm;
 }
 
 pub trait CdiManager {
@@ -509,6 +589,19 @@ pub trait CdiManager {
         self.derive_key_pair(label, info)?.sign(data)
     }
 
+    /// Sign `data` with a derived key-pair from the CDI into a caller-provided byte slice.
+    fn sign_with_derived_into_slice(
+        &mut self,
+        label: &[u8],
+        info: &[u8],
+        data: &SignData,
+        pub_key: Option<&[u8]>,
+        signature: &mut [u8],
+    ) -> Result<(), CryptoError> {
+        self.derive_key_pair(label, info)?
+            .sign_into_slice(data, pub_key, signature)
+    }
+
     /// Get the public key of a derived key-pair from the CDI
     ///
     /// # Arguments
@@ -517,6 +610,16 @@ pub trait CdiManager {
     /// * `info` - Caller-supplied info string to use in asymmetric key derivation
     fn derive_pub_key(&mut self, label: &[u8], info: &[u8]) -> Result<PubKey, CryptoError> {
         self.derive_key_pair(label, info)?.public_key()
+    }
+
+    /// Get the public key of a derived key-pair from the CDI into a caller-provided byte slice.
+    fn derive_pub_key_into(
+        &mut self,
+        label: &[u8],
+        info: &[u8],
+        pub_key: &mut [u8],
+    ) -> Result<(), CryptoError> {
+        self.derive_key_pair(label, info)?.public_key_into(pub_key)
     }
 
     /// This should only be used in testing
@@ -649,11 +752,14 @@ pub trait Crypto {
         info: &[u8],
     ) -> Result<&mut dyn Signer, CryptoError>;
 
-    /// Sign `digest` with the platform Alias Key
-    ///
-    /// # Arguments
-    ///
-    /// * `data` - Data to be signed.
+    /// Sign `data` with the platform Alias Key into a caller-provided byte slice.
+    fn sign_with_alias_into_slice(
+        &mut self,
+        data: &SignData,
+        signature: &mut [u8],
+    ) -> Result<(), CryptoError>;
+
+    /// Sign `digest` with the platform Alias Key, returning the signature by value.
     fn sign_with_alias(&mut self, data: &SignData) -> Result<Signature, CryptoError>;
 
     /// Sign `data` with a key derived from the current CDI and measurements.
@@ -677,6 +783,22 @@ pub trait Crypto {
             .sign_with_derived(label, derived_info, data)
     }
 
+    /// Sign `data` with a key derived from the current CDI and measurements into a caller-provided byte slice.
+    #[allow(clippy::too_many_arguments)]
+    fn sign_with_derived_into_slice(
+        &mut self,
+        measurement: &Digest,
+        info: &[u8],
+        label: &[u8],
+        derived_info: &[u8],
+        data: &SignData,
+        pub_key: Option<&[u8]>,
+        signature: &mut [u8],
+    ) -> Result<(), CryptoError> {
+        self.derive_cdi(measurement, info)?
+            .sign_with_derived_into_slice(label, derived_info, data, pub_key, signature)
+    }
+
     /// Derive the public key for a key derived from the current CDI and measurements.
     ///
     /// # Arguments
@@ -694,5 +816,18 @@ pub trait Crypto {
     ) -> Result<PubKey, CryptoError> {
         self.derive_cdi(measurement, info)?
             .derive_pub_key(label, derived_info)
+    }
+
+    /// Derive the public key for a key derived from the current CDI and measurements into a caller-provided byte slice.
+    fn derive_pub_key_into(
+        &mut self,
+        measurement: &Digest,
+        info: &[u8],
+        label: &[u8],
+        derived_info: &[u8],
+        pub_key: &mut [u8],
+    ) -> Result<(), CryptoError> {
+        self.derive_cdi(measurement, info)?
+            .derive_pub_key_into(label, derived_info, pub_key)
     }
 }

--- a/crypto/src/rustcrypto.rs
+++ b/crypto/src/rustcrypto.rs
@@ -220,6 +220,59 @@ impl crate::Signer for RustCryptoSigner {
             }
         }
     }
+
+    fn sign_into_slice(
+        &mut self,
+        data: &SignData,
+        _pub_key: Option<&[u8]>,
+        signature: &mut [u8],
+    ) -> Result<(), CryptoError> {
+        let sig = self.sign(data)?;
+        match &sig {
+            super::Signature::Ecdsa(ecdsa_sig) => {
+                let (r, s) = ecdsa_sig.as_slice();
+                if signature.len() != r.len() + s.len() {
+                    return Err(CryptoError::Size);
+                }
+                signature[..r.len()].copy_from_slice(r);
+                signature[r.len()..].copy_from_slice(s);
+            }
+            #[cfg(feature = "ml-dsa")]
+            super::Signature::Mldsa(mldsa_sig) => {
+                if signature.len() != mldsa_sig.0.len() {
+                    return Err(CryptoError::Size);
+                }
+                signature.copy_from_slice(&mldsa_sig.0);
+            }
+        }
+        Ok(())
+    }
+
+    fn public_key_into(&mut self, pub_key: &mut [u8]) -> Result<(), CryptoError> {
+        let key = self.public_key()?;
+        match &key {
+            PubKey::Ecdsa(ecdsa_key) => {
+                let (x, y) = ecdsa_key.as_slice();
+                if pub_key.len() != x.len() + y.len() {
+                    return Err(CryptoError::Size);
+                }
+                pub_key[..x.len()].copy_from_slice(x);
+                pub_key[x.len()..].copy_from_slice(y);
+            }
+            #[cfg(feature = "ml-dsa")]
+            PubKey::Mldsa(mldsa_key) => {
+                if pub_key.len() != mldsa_key.0.len() {
+                    return Err(CryptoError::Size);
+                }
+                pub_key.copy_from_slice(&mldsa_key.0);
+            }
+        }
+        Ok(())
+    }
+
+    fn signature_alg(&self) -> SignatureAlgorithm {
+        self.signature_alg
+    }
 }
 
 pub struct RustCryptoCdi {
@@ -479,5 +532,31 @@ impl Crypto for RustCryptoImpl {
                 Self::mldsa_sign_data_inner(&ml_dsa_secret, data)
             }
         }
+    }
+
+    fn sign_with_alias_into_slice(
+        &mut self,
+        data: &SignData,
+        signature: &mut [u8],
+    ) -> Result<(), CryptoError> {
+        let sig = self.sign_with_alias(data)?;
+        match &sig {
+            super::Signature::Ecdsa(ecdsa_sig) => {
+                let (r, s) = ecdsa_sig.as_slice();
+                if signature.len() != r.len() + s.len() {
+                    return Err(CryptoError::Size);
+                }
+                signature[..r.len()].copy_from_slice(r);
+                signature[r.len()..].copy_from_slice(s);
+            }
+            #[cfg(feature = "ml-dsa")]
+            super::Signature::Mldsa(mldsa_sig) => {
+                if signature.len() != mldsa_sig.0.len() {
+                    return Err(CryptoError::Size);
+                }
+                signature.copy_from_slice(&mldsa_sig.0);
+            }
+        }
+        Ok(())
     }
 }

--- a/verification/panic-check/firmware/src/crypto_dummy.rs
+++ b/verification/panic-check/firmware/src/crypto_dummy.rs
@@ -78,6 +78,14 @@ impl Crypto for DummyCrypto {
         let _ = data;
         Err(CryptoError::NotImplemented)
     }
+
+    fn sign_with_alias_into_slice(
+        &mut self,
+        _data: &SignData,
+        _signature: &mut [u8],
+    ) -> Result<(), CryptoError> {
+        Err(CryptoError::NotImplemented)
+    }
 }
 
 impl CryptoSuite for DummyCrypto {}
@@ -135,12 +143,20 @@ impl CdiManager for DummyCdiManager {
 pub struct DummySigner;
 
 impl Signer for DummySigner {
-    fn sign(&mut self, data: &SignData) -> Result<crypto::Signature, CryptoError> {
-        let _ = data;
+    fn sign_into_slice(
+        &mut self,
+        _data: &SignData,
+        _pub_key: Option<&[u8]>,
+        _signature: &mut [u8],
+    ) -> Result<(), CryptoError> {
         Err(CryptoError::NotImplemented)
     }
 
-    fn public_key(&mut self) -> Result<PubKey, CryptoError> {
+    fn public_key_into(&mut self, _pub_key: &mut [u8]) -> Result<(), CryptoError> {
         Err(CryptoError::NotImplemented)
+    }
+
+    fn signature_alg(&self) -> SignatureAlgorithm {
+        SignatureAlgorithm::Ecdsa(crypto::ecdsa::EcdsaAlgorithm::Bit384)
     }
 }


### PR DESCRIPTION
Add a ML-DSA-specific CertifyKey CSR path that writes the derived public key and signatures into caller-provided output buffers instead of returning large PubKey and Signature enum values by value.

This avoids stack-resident ML-DSA public key/signature temporaries in the CSR path while preserving the existing generic path for other profiles and certificate formats.