### PR TITLE
Minimize MAX_CERT_SIZE using linear approximation 

### DIFF
--- a/dpe/build.rs
+++ b/dpe/build.rs
@@ -34,7 +34,7 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     let max_handles_str = format!("pub const MAX_HANDLES: usize = {};", max_handles);
-    let handles_path = PathBuf::from(format!("{}/arbitrary_max_handles.rs", out_dir));
+    let handles_path = PathBuf::from(format!("{}/max_handles.rs", out_dir));
 
     write_if_changed(&handles_path, &max_handles_str);
     println!("cargo:rerun-if-changed={}", handles_path.display());
@@ -51,12 +51,9 @@ fn main() {
         (P384_BASE, P384_HANDLE)
     };
 
-    let max_cert_size = base + per_handle * max_handles;
-
-    // Round up to next multiple of 4 for alignment. The response structs (e.g.
-    // CertifyKeyP384Resp) contain [u8; MAX_CERT_SIZE] followed by u32 fields,
-    // and `zerocopy::IntoBytes` requires no padding.
-    let max_cert_size = (max_cert_size + 3) & !3;
+    // The response structs (for example CertifyKeyP384Resp) contain [u8; MAX_CERT_SIZE]
+    // followed by u32 fields, and `zerocopy::IntoBytes` requires no padding.
+    let max_cert_size: usize = (base + per_handle * max_handles).next_multiple_of(4);
 
     let max_cert_size_str = format!("const MAX_CERT_SIZE: usize = {};", max_cert_size);
     let cert_size_path = PathBuf::from(format!("{}/max_cert_size.rs", out_dir));

--- a/dpe/build.rs
+++ b/dpe/build.rs
@@ -3,27 +3,70 @@
 use std::env;
 use std::path::PathBuf;
 
-fn main() {
-    let default_value: usize = 24;
+/// Default MAX_HANDLES when the `arbitrary_max_handles` feature is NOT enabled.
+/// Must match the hardcoded constant in `dpe/src/lib.rs`.
+const DEFAULT_MAX_HANDLES: usize = 64;
+const DEFAULT_ARBITRARY_MAX_HANDLES: usize = 24;
 
-    let arbitrary_max_handles = env::var("ARBITRARY_MAX_HANDLES")
-        .ok()
-        .and_then(|value| value.parse().ok())
-        .unwrap_or(default_value);
+const MLDSA_BASE: usize = 12307;
+const MLDSA_HANDLE: usize = 158;
+
+const P256_BASE: usize = 643;
+const P256_HANDLE: usize = 126;
+
+const P384_BASE: usize = 756;
+const P384_HANDLE: usize = 159;
+
+fn main() {
+    let is_arbitrary = env::var("CARGO_FEATURE_ARBITRARY_MAX_HANDLES").is_ok();
+
+    let max_handles = if is_arbitrary {
+        env::var("ARBITRARY_MAX_HANDLES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_ARBITRARY_MAX_HANDLES)
+    } else {
+        DEFAULT_MAX_HANDLES
+    };
 
     let out_dir = env::var("OUT_DIR").unwrap();
-    let dest_path = format!("{}/arbitrary_max_handles.rs", out_dir);
-
     println!("cargo:rerun-if-env-changed=ARBITRARY_MAX_HANDLES");
     println!("cargo:rerun-if-changed=build.rs");
 
-    let max_handles_str = format!("pub const MAX_HANDLES: usize = {};", arbitrary_max_handles);
+    let max_handles_str = format!("pub const MAX_HANDLES: usize = {};", max_handles);
+    let handles_path = PathBuf::from(format!("{}/arbitrary_max_handles.rs", out_dir));
 
-    let dest_path = PathBuf::from(&dest_path);
-    match std::fs::read_to_string(&dest_path) {
-        // arbitrary_max_handles.rs already exists with the data we want.
-        Ok(handles) if handles.contains(&max_handles_str) => (),
-        _ => std::fs::write(&dest_path, max_handles_str).unwrap(),
+    write_if_changed(&handles_path, &max_handles_str);
+    println!("cargo:rerun-if-changed={}", handles_path.display());
+
+    let is_ml_dsa = env::var("CARGO_FEATURE_ML_DSA").is_ok();
+    let is_p256 = env::var("CARGO_FEATURE_P256").is_ok();
+
+    let (base, per_handle): (usize, usize) = if is_ml_dsa {
+        (MLDSA_BASE, MLDSA_HANDLE)
+    } else if is_p256 {
+        (P256_BASE, P256_HANDLE)
+    } else {
+        // P384
+        (P384_BASE, P384_HANDLE)
+    };
+
+    let max_cert_size = base + per_handle * max_handles;
+
+    // Round up to next multiple of 4 for alignment. The response structs (e.g.
+    // CertifyKeyP384Resp) contain [u8; MAX_CERT_SIZE] followed by u32 fields,
+    // and `zerocopy::IntoBytes` requires no padding.
+    let max_cert_size = (max_cert_size + 3) & !3;
+
+    let max_cert_size_str = format!("const MAX_CERT_SIZE: usize = {};", max_cert_size);
+    let cert_size_path = PathBuf::from(format!("{}/max_cert_size.rs", out_dir));
+    write_if_changed(&cert_size_path, &max_cert_size_str);
+    println!("cargo:rerun-if-changed={}", cert_size_path.display());
+}
+
+fn write_if_changed(path: &PathBuf, content: &str) {
+    match std::fs::read_to_string(path) {
+        Ok(existing) if existing.contains(content) => (),
+        _ => std::fs::write(path, content).unwrap(),
     }
-    println!("cargo:rerun-if-changed={}", dest_path.display());
 }

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -45,11 +45,10 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, TryFromBytes};
 
 pub use caliptra_dpe_crypto::{ecdsa::EcdsaAlgorithm, ExportedCdiHandle, MAX_EXPORTED_CDI_SIZE};
 
-// Max cert size returned by CertifyKey
-#[cfg(feature = "ml-dsa")]
-const MAX_CERT_SIZE: usize = 22 * 1024;
-#[cfg(not(feature = "ml-dsa"))]
-const MAX_CERT_SIZE: usize = 11 * 1024;
+// Max cert/CSR size returned by CertifyKey. Computed in build.rs as a
+// linear function of MAX_HANDLES and the algorithm (see build.rs for details).
+include!(concat!(env!("OUT_DIR"), "/max_cert_size.rs"));
+
 #[cfg(not(feature = "arbitrary_max_handles"))]
 pub const MAX_HANDLES: usize = 64;
 #[cfg(feature = "arbitrary_max_handles")]

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -45,14 +45,9 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, TryFromBytes};
 
 pub use caliptra_dpe_crypto::{ecdsa::EcdsaAlgorithm, ExportedCdiHandle, MAX_EXPORTED_CDI_SIZE};
 
-// Max cert/CSR size returned by CertifyKey. Computed in build.rs as a
-// linear function of MAX_HANDLES and the algorithm (see build.rs for details).
+// Max cert/CSR size returned by CertifyKey.
 include!(concat!(env!("OUT_DIR"), "/max_cert_size.rs"));
-
-#[cfg(not(feature = "arbitrary_max_handles"))]
-pub const MAX_HANDLES: usize = 64;
-#[cfg(feature = "arbitrary_max_handles")]
-include!(concat!(env!("OUT_DIR"), "/arbitrary_max_handles.rs"));
+include!(concat!(env!("OUT_DIR"), "/max_handles.rs"));
 
 const CURRENT_PROFILE_MAJOR_VERSION: u16 = 0;
 const CURRENT_PROFILE_MINOR_VERSION: u16 = 13;

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -40,4 +40,4 @@ path = "src/sample_dpe_cert.rs"
 
 [[bin]]
 name = "cert-size"
-path = "src/cert_size.rs"
+path = "src/cert_size/main.rs"

--- a/tools/src/cert_size.rs
+++ b/tools/src/cert_size.rs
@@ -1,5 +1,7 @@
 // Licensed under the Apache-2.0 license
 
+use std::fmt::Display;
+
 use anyhow::{anyhow, Result};
 use caliptra_dpe::dpe_instance::DpeEnvImpl;
 use caliptra_dpe::{
@@ -117,7 +119,26 @@ fn send_certify_key(dpe: &mut DpeInstance, env: &mut dyn DpeEnv, args: &Args) ->
     }
 }
 
-fn run(env: &mut dyn DpeEnv, args: &Args) -> Result<()> {
+#[derive(Debug)]
+pub(crate) enum CertOrCsrSize {
+    Cert(usize),
+    Csr(usize),
+}
+
+impl Display for CertOrCsrSize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CertOrCsrSize::Cert(size) => {
+                write!(f, "certificate size = {}", size)
+            }
+            CertOrCsrSize::Csr(size) => {
+                write!(f, "csr size = {}", size)
+            }
+        }
+    }
+}
+
+pub(crate) fn calculate_cert_csr_size(env: &mut dyn DpeEnv, args: &Args) -> Result<CertOrCsrSize> {
     let mut dpe = DpeInstance::new(env, args.algorithm.into())
         .map_err(|e| anyhow!("DPE error creating instance: {e:?}"))?;
 
@@ -148,13 +169,14 @@ fn run(env: &mut dyn DpeEnv, args: &Args) -> Result<()> {
     };
     let len = certify_resp
         .cert()
-        .expect("Failed to parse cert from response")
+        .map_err(|_| anyhow!("Error retrieving certificate"))?
         .len();
-    println!(
-        "Total {} size: {len}",
-        if args.cert { "certificate" } else { "CSR" }
-    );
-    Ok(())
+
+    if args.cert {
+        Ok(CertOrCsrSize::Cert(len))
+    } else {
+        Ok(CertOrCsrSize::Csr(len))
+    }
 }
 
 fn main() -> Result<()> {
@@ -175,9 +197,9 @@ fn main() -> Result<()> {
     let flags = DpeFlags::empty();
     let mut state = caliptra_dpe::State::new(support, flags);
 
-    match args.algorithm {
+    let size: Result<CertOrCsrSize> = match args.algorithm {
         #[cfg(any(feature = "p256", feature = "p384"))]
-        Algorithm::Ec => run(
+        Algorithm::Ec => calculate_cert_csr_size(
             &mut DpeEnvImpl {
                 crypto: &mut ec::new_crypto(),
                 platform: &mut DefaultPlatform(args.algorithm.into()),
@@ -186,7 +208,7 @@ fn main() -> Result<()> {
             &args,
         ),
         #[cfg(feature = "ml-dsa")]
-        Algorithm::Mldsa => run(
+        Algorithm::Mldsa => calculate_cert_csr_size(
             &mut DpeEnvImpl {
                 crypto: &mut caliptra_dpe_crypto::RustCryptoImpl::new_mldsa87(),
                 platform: &mut DefaultPlatform(DefaultPlatformProfile::Mldsa87),
@@ -196,5 +218,16 @@ fn main() -> Result<()> {
         ),
         #[allow(unreachable_patterns)]
         _ => Err(anyhow!("Unsupported algorithm")),
+    };
+
+    match size {
+        Ok(ccs) => {
+            println!("{}", ccs);
+        }
+        Err(e) => {
+            eprintln!("{:?}", e);
+        }
     }
+
+    Ok(())
 }

--- a/tools/src/cert_size/benchmark.rs
+++ b/tools/src/cert_size/benchmark.rs
@@ -1,0 +1,213 @@
+// Licensed under the Apache-2.0 license
+
+use std::fmt::{self, Display};
+
+use anyhow::{anyhow, Result};
+use caliptra_dpe::MAX_HANDLES;
+
+use super::{measure_cert_csr, Algorithm};
+
+/// Linear Approximation/Linearization derived from a single measurement series (cert or CSR).
+///
+/// Models certificate size as `base + per_handle * n` where `n` is the
+/// number of TCI nodes (handles). `per_handle` is the delta between the
+/// first two sample points (the maximum observed rate, since DER length
+/// encoding causes slightly higher growth at small `n`).
+struct LinearApprox {
+    per_handle: usize,
+    base: usize,
+    /// Whether `base + per_handle * n >= actual` for every sample point.
+    covers_all: bool,
+    /// Worst-case under-estimation in bytes (0 when `covers_all` is true).
+    worst_deficit: usize,
+    /// `(n, predicted, actual)` at the last sample point.
+    last_check: (usize, usize, usize),
+}
+
+impl LinearApprox {
+    /// Derive a linear upper-bound approximation from measured `(n, size)` pairs.
+    fn from_sizes(sizes: &[(usize, usize)]) -> Option<Self> {
+        if sizes.len() < 2 {
+            return None;
+        }
+        let (x1, y1) = sizes[0];
+        let (x2, y2) = sizes[1];
+
+        // violates monotonic, linear growth which we assume is the case for
+        // increasing ASN.1 certificates.
+        if x2 <= x1 || y2 <= y1 {
+            return None;
+        }
+
+        let per_handle = (y2 - y1) / (x2 - x1);
+        let base = y1.saturating_sub(per_handle * x1);
+
+        let worst_deficit = sizes
+            .iter()
+            .filter_map(|&(n, s)| {
+                let predicted = base + per_handle * n;
+                (predicted < s).then(|| s - predicted)
+            })
+            .max()
+            .unwrap_or(0);
+
+        let &(x_n, y_n) = sizes.last().unwrap();
+        let predicted_last = base + per_handle * x_n;
+
+        Some(Self {
+            per_handle,
+            base,
+            covers_all: worst_deficit == 0,
+            worst_deficit,
+            last_check: (x_n, predicted_last, y_n),
+        })
+    }
+}
+
+impl Display for LinearApprox {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "per_handle={:<5} base={:<7}", self.per_handle, self.base)?;
+        let (n, predicted, actual) = self.last_check;
+        if self.covers_all {
+            let overshoot = if actual > 0 {
+                ((predicted as f64 - actual as f64) / actual as f64) * 100.0
+            } else {
+                0.0
+            };
+            write!(
+                f,
+                "  n={n}: predicted={predicted} actual={actual} (+{overshoot:.1}%)"
+            )
+        } else {
+            write!(
+                f,
+                "  WARNING: under-estimates by up to {} bytes!",
+                self.worst_deficit
+            )
+        }
+    }
+}
+
+struct BenchmarkResults {
+    algo_name: &'static str,
+    max_handles: usize,
+    handle_counts: Vec<usize>,
+    cert_sizes: Vec<(usize, usize)>,
+    csr_sizes: Vec<(usize, usize)>,
+}
+
+impl BenchmarkResults {
+    fn approx(&self) -> Option<(usize, usize)> {
+        let cert_approx = LinearApprox::from_sizes(&self.cert_sizes)?;
+        let csr_approx = LinearApprox::from_sizes(&self.csr_sizes)?;
+
+        let per_handle = cert_approx.per_handle.max(csr_approx.per_handle);
+        let (x1, y1) = self.csr_sizes[0];
+        let base = y1.saturating_sub(per_handle * x1);
+        Some((base, per_handle))
+    }
+
+    /// Check that `(base, per_handle)` covers every sample in both series to ensure
+    /// there will be enough space for the Cert/CSR.
+    fn verify(&self, base: usize, per_handle: usize) -> bool {
+        self.cert_sizes
+            .iter()
+            .chain(self.csr_sizes.iter())
+            .all(|&(n, s)| base + per_handle * n >= s)
+    }
+}
+
+impl Display for BenchmarkResults {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "Benchmark: {} (MAX_HANDLES={})\n",
+            self.algo_name, self.max_handles
+        )?;
+
+        write!(f, "{:>6}", "n")?;
+        for n in &self.handle_counts {
+            write!(f, "{n:>8}")?;
+        }
+        writeln!(f)?;
+        write!(f, "{:->6}", "")?;
+        for _ in &self.handle_counts {
+            write!(f, "{:->8}", "")?;
+        }
+        writeln!(f)?;
+
+        for (label, sizes) in [("cert", &self.cert_sizes), ("csr", &self.csr_sizes)] {
+            write!(f, "{label:>6}")?;
+            for (_, size) in sizes {
+                write!(f, "{size:>8}")?;
+            }
+            writeln!(f)?;
+        }
+
+        for (label, sizes) in [("cert", &self.cert_sizes), ("csr", &self.csr_sizes)] {
+            if let Some(approx) = LinearApprox::from_sizes(sizes) {
+                writeln!(f, "  {label:>4}:  {approx}")?;
+            }
+        }
+
+        if let Some((base, per_handle)) = self.approx() {
+            let verified = self.verify(base, per_handle);
+            writeln!(
+                f,
+                "\nUse base={base}, per_handle={per_handle} for dpe/build.rs constants"
+            )?;
+            if verified {
+                write!(f, "Verified as upper bound at all sample points.")?;
+            } else {
+                write!(f, "ERR: Approximation failed for some sample points")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub(crate) fn run(algorithm: Algorithm) -> Result<()> {
+    let handle_counts: Vec<usize> = [1, 2, 4, 8, 16, 24, 32, 48, 64]
+        .into_iter()
+        .filter(|&n| n <= MAX_HANDLES)
+        .collect();
+
+    if handle_counts.len() < 2 {
+        return Err(anyhow!(
+            "MAX_HANDLES={MAX_HANDLES} is too small for benchmark (need at least 2)"
+        ));
+    }
+
+    let algo_name: &'static str = match algorithm {
+        #[cfg(feature = "p256")]
+        Algorithm::Ec => "P256",
+        #[cfg(feature = "p384")]
+        Algorithm::Ec => "P384",
+        #[cfg(feature = "ml-dsa")]
+        Algorithm::Mldsa => "ML-DSA-87",
+        #[allow(unreachable_patterns)]
+        _ => "unknown",
+    };
+
+    let mut cert_sizes = Vec::new();
+    let mut csr_sizes = Vec::new();
+
+    for &n in &handle_counts {
+        for (is_cert, sizes) in [(true, &mut cert_sizes), (false, &mut csr_sizes)] {
+            let sz = measure_cert_csr(algorithm, n, is_cert)?;
+            sizes.push((n, sz.size()));
+        }
+    }
+
+    let results = BenchmarkResults {
+        algo_name,
+        max_handles: MAX_HANDLES,
+        handle_counts,
+        cert_sizes,
+        csr_sizes,
+    };
+
+    println!("{results}");
+    Ok(())
+}

--- a/tools/src/cert_size/main.rs
+++ b/tools/src/cert_size/main.rs
@@ -1,5 +1,7 @@
 // Licensed under the Apache-2.0 license
 
+mod benchmark;
+
 use std::fmt::Display;
 
 use anyhow::{anyhow, Result};
@@ -78,7 +80,7 @@ impl From<Algorithm> for DpeProfile {
     }
 }
 
-/// Starts a DPE simulator that will receive commands and send responses over unix streams.
+/// Measure DPE certificate and CSR sizes.
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
@@ -91,15 +93,23 @@ struct Args {
     /// Whether to generate a cert or CSR
     #[arg(long)]
     cert: bool,
+    /// Run a sweep over handle counts and derive build.rs constants.
+    #[arg(long)]
+    benchmark: bool,
 }
 
-fn send_certify_key(dpe: &mut DpeInstance, env: &mut dyn DpeEnv, args: &Args) -> Result<Response> {
-    let format = if args.cert {
+fn send_certify_key(
+    dpe: &mut DpeInstance,
+    env: &mut dyn DpeEnv,
+    algorithm: Algorithm,
+    cert: bool,
+) -> Result<Response> {
+    let format = if cert {
         CertifyKeyCommand::FORMAT_X509
     } else {
         CertifyKeyCommand::FORMAT_CSR
     };
-    match args.algorithm {
+    match algorithm {
         #[cfg(any(feature = "p256", feature = "p384"))]
         Algorithm::Ec => CertifyKeyCmd {
             format,
@@ -125,6 +135,14 @@ pub(crate) enum CertOrCsrSize {
     Csr(usize),
 }
 
+impl CertOrCsrSize {
+    pub(crate) fn size(&self) -> usize {
+        match self {
+            CertOrCsrSize::Cert(s) | CertOrCsrSize::Csr(s) => *s,
+        }
+    }
+}
+
 impl Display for CertOrCsrSize {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -138,55 +156,23 @@ impl Display for CertOrCsrSize {
     }
 }
 
-pub(crate) fn calculate_cert_csr_size(env: &mut dyn DpeEnv, args: &Args) -> Result<CertOrCsrSize> {
-    let mut dpe = DpeInstance::new(env, args.algorithm.into())
-        .map_err(|e| anyhow!("DPE error creating instance: {e:?}"))?;
-
-    if args.num_contexts > MAX_HANDLES {
-        return Err(anyhow!("Too many contexts. Max is {MAX_HANDLES}."));
+/// Measure the cert or CSR size for a given number of contexts.
+pub(crate) fn measure_cert_csr(
+    algorithm: Algorithm,
+    num_contexts: usize,
+    cert: bool,
+) -> Result<CertOrCsrSize> {
+    if num_contexts == 0 || num_contexts > MAX_HANDLES {
+        return Err(anyhow!(
+            "num_contexts must be in 1..={MAX_HANDLES}, got {num_contexts}"
+        ));
     }
-    let mut flags = DeriveContextFlags::MAKE_DEFAULT
-        | DeriveContextFlags::INTERNAL_INPUT_INFO
-        | DeriveContextFlags::INTERNAL_INPUT_DICE;
-    if args.cert {
-        flags |= DeriveContextFlags::INPUT_ALLOW_X509;
-    }
-
-    // Minus 1 to account for the default context
-    for i in 0..args.num_contexts - 1 {
-        let _resp = DeriveContextCmd {
-            flags,
-            tci_type: i as u32 + 1,
-            ..Default::default()
-        }
-        .execute(&mut dpe, env, 0)
-        .map_err(|e| anyhow!("DPE error creating {i}th context: {e:?}"))?;
-    }
-
-    let certify_resp = send_certify_key(&mut dpe, env, args)?;
-    let Response::CertifyKey(certify_resp) = certify_resp else {
-        return Err(anyhow!("Unexpected response type"));
-    };
-    let len = certify_resp
-        .cert()
-        .map_err(|_| anyhow!("Error retrieving certificate"))?
-        .len();
-
-    if args.cert {
-        Ok(CertOrCsrSize::Cert(len))
-    } else {
-        Ok(CertOrCsrSize::Csr(len))
-    }
-}
-
-fn main() -> Result<()> {
-    let args = Args::parse();
 
     let mut support = Support::default();
     support.set(Support::SIMULATION, true);
     support.set(Support::AUTO_INIT, true);
-    support.set(Support::X509, args.cert);
-    support.set(Support::CSR, !args.cert);
+    support.set(Support::X509, cert);
+    support.set(Support::CSR, !cert);
     support.set(Support::RECURSIVE, true);
     support.set(Support::ROTATE_CONTEXT, true);
     support.set(Support::INTERNAL_DICE, true);
@@ -197,36 +183,89 @@ fn main() -> Result<()> {
     let flags = DpeFlags::empty();
     let mut state = caliptra_dpe::State::new(support, flags);
 
-    let size: Result<CertOrCsrSize> = match args.algorithm {
+    let result: Result<CertOrCsrSize> = match algorithm {
         #[cfg(any(feature = "p256", feature = "p384"))]
-        Algorithm::Ec => calculate_cert_csr_size(
+        Algorithm::Ec => execute_and_measure(
             &mut DpeEnvImpl {
                 crypto: &mut ec::new_crypto(),
-                platform: &mut DefaultPlatform(args.algorithm.into()),
+                platform: &mut DefaultPlatform(algorithm.into()),
                 state: &mut state,
             },
-            &args,
+            algorithm,
+            num_contexts,
+            cert,
         ),
         #[cfg(feature = "ml-dsa")]
-        Algorithm::Mldsa => calculate_cert_csr_size(
+        Algorithm::Mldsa => execute_and_measure(
             &mut DpeEnvImpl {
                 crypto: &mut caliptra_dpe_crypto::RustCryptoImpl::new_mldsa87(),
                 platform: &mut DefaultPlatform(DefaultPlatformProfile::Mldsa87),
                 state: &mut state,
             },
-            &args,
+            algorithm,
+            num_contexts,
+            cert,
         ),
         #[allow(unreachable_patterns)]
         _ => Err(anyhow!("Unsupported algorithm")),
     };
+    result
+}
 
-    match size {
-        Ok(ccs) => {
-            println!("{}", ccs);
+/// Generate a `DeriveContextCmd`, execute it for a newly created `DpeInstance`,
+/// and measure the certificate size.
+fn execute_and_measure(
+    env: &mut dyn DpeEnv,
+    algorithm: Algorithm,
+    num_contexts: usize,
+    cert: bool,
+) -> Result<CertOrCsrSize> {
+    let mut dpe = DpeInstance::new(env, algorithm.into())
+        .map_err(|e| anyhow!("DPE error creating instance: {e:?}"))?;
+
+    let mut flags = DeriveContextFlags::MAKE_DEFAULT
+        | DeriveContextFlags::INTERNAL_INPUT_INFO
+        | DeriveContextFlags::INTERNAL_INPUT_DICE;
+    if cert {
+        flags |= DeriveContextFlags::INPUT_ALLOW_X509;
+    }
+
+    for i in 0..num_contexts - 1 {
+        DeriveContextCmd {
+            flags,
+            tci_type: i as u32 + 1,
+            ..Default::default()
         }
-        Err(e) => {
-            eprintln!("{:?}", e);
-        }
+        .execute(&mut dpe, env, 0)
+        .map_err(|e| anyhow!("DPE error creating {i}th context: {e:?}"))?;
+    }
+
+    let certify_resp = send_certify_key(&mut dpe, env, algorithm, cert)?;
+    let Response::CertifyKey(certify_resp) = certify_resp else {
+        return Err(anyhow!("Unexpected response type"));
+    };
+    let len = certify_resp
+        .cert()
+        .map_err(|_| anyhow!("Error retrieving certificate"))?
+        .len();
+
+    if cert {
+        Ok(CertOrCsrSize::Cert(len))
+    } else {
+        Ok(CertOrCsrSize::Csr(len))
+    }
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    if args.benchmark {
+        return benchmark::run(args.algorithm);
+    }
+
+    match measure_cert_csr(args.algorithm, args.num_contexts, args.cert) {
+        Ok(ccs) => println!("{ccs}"),
+        Err(e) => eprintln!("{e:?}"),
     }
 
     Ok(())


### PR DESCRIPTION
- Add `benchmark` mode to `tools/cert-size` to empirically determine linear approximation  for `p256`, `mldsa`, and `p384`.
- Update `dpe/build.rs` to provide approximated sizes for `MAX_CERT_SIZE`  to reduce memory footprint.