### PR TITLE
dpe: Utilize ResponseBuffer abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,7 @@ dependencies = [
  "caliptra-cfi-lib",
  "caliptra-dpe-crypto",
  "caliptra-dpe-platform",
+ "caliptra-dpe-response-buffer",
  "cfg-if",
  "cms",
  "const-oid 0.10.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ dependencies = [
  "base64ct",
  "caliptra-cfi-derive",
  "caliptra-cfi-lib",
+ "caliptra-dpe-response-buffer",
  "caliptra-dpe-test-artifacts",
  "constant_time_eq",
  "ecdsa",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -32,6 +32,7 @@ test-artifacts = ["dep:caliptra-dpe-test-artifacts"]
 arrayvec.workspace = true
 caliptra-cfi-derive.workspace = true
 caliptra-cfi-lib = { workspace = true, default-features = false }
+caliptra-dpe-response-buffer.workspace = true
 caliptra-dpe-test-artifacts = { workspace = true, optional = true }
 constant_time_eq.workspace = true
 ecdsa = { version = "0.16.9", optional = true, features = ["pem"] }

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -5,8 +5,12 @@ Abstract:
 --*/
 #![cfg_attr(not(any(feature = "rustcrypto", test)), no_std)]
 
+use core::ops::Range;
+
 use ecdsa::EcdsaSignature;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+use caliptra_dpe_response_buffer::ResponseBuffer;
 
 #[cfg(feature = "rustcrypto")]
 pub use crate::rustcrypto::*;
@@ -313,10 +317,10 @@ impl From<Mu> for PrecomputedSignData {
     }
 }
 
-#[derive(Debug)]
 pub enum SignData<'a> {
     Digest(Digest),
     Mu(Mu),
+    ResponseBuffer(&'a dyn ResponseBuffer, Range<usize>),
     Raw(&'a [u8]),
 }
 
@@ -325,14 +329,8 @@ impl SignData<'_> {
         match self {
             Self::Digest(dig) => dig.size(),
             Self::Mu(mu) => mu.0.len(),
+            Self::ResponseBuffer(_, range) => range.len(),
             Self::Raw(raw) => raw.len(),
-        }
-    }
-    pub fn as_slice(&self) -> &[u8] {
-        match self {
-            Self::Digest(dig) => dig.as_slice(),
-            Self::Mu(mu) => mu.0.as_slice(),
-            Self::Raw(raw) => raw,
         }
     }
 }

--- a/crypto/src/rustcrypto.rs
+++ b/crypto/src/rustcrypto.rs
@@ -356,21 +356,33 @@ impl RustCryptoImpl {
         data: &SignData,
         alg: SignatureAlgorithm,
     ) -> Result<Signature<C>, CryptoError> {
+        let digest = |raw| match alg {
+            SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit256) => {
+                use sha2::{Digest, Sha256};
+                Ok(Sha256::digest(raw).to_vec())
+            }
+            SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit384) => {
+                use sha2::{Digest, Sha384};
+                Ok(Sha384::digest(raw).to_vec())
+            }
+            #[allow(unreachable_patterns)]
+            _ => Err(CryptoError::MismatchedAlgorithm),
+        };
+
         match data {
             SignData::Digest(dig) => Ok(key.sign_prehash(dig.as_slice())?),
+            SignData::ResponseBuffer(buf, range) => {
+                let mut raw = Vec::new();
+                buf.read_range(range.clone(), &mut |data| {
+                    raw.extend_from_slice(data);
+                    Ok(())
+                })
+                .map_err(|_| CryptoError::Size)?;
+                let digest_bytes = digest(raw.as_slice())?;
+                Ok(key.sign_prehash(&digest_bytes)?)
+            }
             SignData::Raw(raw) => {
-                let digest_bytes = match alg {
-                    SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit256) => {
-                        use sha2::{Digest, Sha256};
-                        Sha256::digest(raw).to_vec()
-                    }
-                    SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit384) => {
-                        use sha2::{Digest, Sha384};
-                        Sha384::digest(raw).to_vec()
-                    }
-                    #[allow(unreachable_patterns)]
-                    _ => return Err(CryptoError::MismatchedAlgorithm),
-                };
+                let digest_bytes = digest(raw)?;
                 Ok(key.sign_prehash(&digest_bytes)?)
             }
             _ => Err(CryptoError::MismatchedAlgorithm),
@@ -384,6 +396,15 @@ impl RustCryptoImpl {
     ) -> Result<super::Signature, CryptoError> {
         let sig = match data {
             SignData::Mu(mu) => key.signing_key().sign_mu_deterministic((&mu.0).into()),
+            SignData::ResponseBuffer(buf, range) => {
+                let mut raw = Vec::new();
+                buf.read_range(range.clone(), &mut |data| {
+                    raw.extend_from_slice(data);
+                    Ok(())
+                })
+                .map_err(|_| CryptoError::Size)?;
+                key.sign(raw.as_slice())
+            }
             SignData::Raw(raw) => key.sign(raw),
             SignData::Digest(_) => return Err(CryptoError::MismatchedAlgorithm),
         };

--- a/dpe/Cargo.toml
+++ b/dpe/Cargo.toml
@@ -39,6 +39,7 @@ caliptra-cfi-derive.workspace = true
 caliptra-cfi-lib = { workspace = true, default-features = false }
 caliptra-dpe-crypto = { workspace = true, default-features = false }
 caliptra-dpe-platform = { workspace = true, default-features = false }
+caliptra-dpe-response-buffer.workspace = true
 cfg-if.workspace = true
 constant_time_eq.workspace = true
 log = { version = "0.4.28", optional = true }

--- a/dpe/fuzz/src/fuzz_target_1.rs
+++ b/dpe/fuzz/src/fuzz_target_1.rs
@@ -71,7 +71,7 @@ fn harness(data: &[u8]) {
         Response::GetProfile(ref res) => res.resp_hdr.status,
         Response::InitCtx(ref res) => res.resp_hdr.status,
         Response::DeriveContext(ref res) => res.resp_hdr.status,
-        Response::DeriveContextExportedCdi(ref res) => res.resp_hdr.status,
+        Response::DeriveContextExportedCdi(ref res) => res.header.resp_hdr.status,
         Response::RotateCtx(ref res) => res.resp_hdr.status,
         Response::CertifyKey(ref res) => res.resp_hdr().status,
         Response::Sign(ref res) => res.resp_hdr().status,

--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -4,7 +4,6 @@ use crate::{
     context::ContextHandle,
     dpe_instance::{DpeEnv, DpeInstance},
     error::{DpeErrorCode, InternalErrorCode},
-    mutresp, okref,
     x509::{create_dpe_cert, CreateDpeCertArgs, CreateDpeCertResult},
     DpeFlags, DpeProfile,
 };
@@ -16,6 +15,7 @@ use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_assert_eq};
 #[cfg(any(feature = "p256", feature = "p384"))]
 use caliptra_dpe_crypto::ecdsa::EcdsaPubKey;
 use caliptra_dpe_crypto::PubKey;
+use caliptra_dpe_response_buffer::{OffsetResponseBuffer, ResponseBuffer};
 use cfg_if::cfg_if;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
@@ -94,20 +94,15 @@ impl CertifyKeyCommand<'_> {
         }
     }
 
-    fn response_bytes<'a>(
-        &self,
-        p: DpeProfile,
-        out: &'a mut [u8],
-    ) -> Result<CertifyKeyResponseBytes<'a>, DpeErrorCode> {
-        let r = match self {
+    fn response_bytes(&self) -> CertifyKeyResponseBytes {
+        match self {
             #[cfg(feature = "p256")]
-            CertifyKeyCommand::P256(_) => CertifyKeyResponseBytes::P256(mutresp(p, out)?),
+            CertifyKeyCommand::P256(_) => CertifyKeyResponseBytes::P256,
             #[cfg(feature = "p384")]
-            CertifyKeyCommand::P384(_) => CertifyKeyResponseBytes::P384(mutresp(p, out)?),
+            CertifyKeyCommand::P384(_) => CertifyKeyResponseBytes::P384,
             #[cfg(feature = "ml-dsa")]
-            CertifyKeyCommand::Mldsa87(_) => CertifyKeyResponseBytes::Mldsa87(mutresp(p, out)?),
-        };
-        Ok(r)
+            CertifyKeyCommand::Mldsa87(_) => CertifyKeyResponseBytes::Mldsa87,
+        }
     }
 }
 
@@ -140,7 +135,7 @@ impl CommandExecution for CertifyKeyCommand<'_> {
         dpe: &mut DpeInstance,
         env: &mut dyn DpeEnv,
         locality: u32,
-        out: &mut [u8],
+        out: &mut dyn ResponseBuffer,
     ) -> Result<usize, DpeErrorCode> {
         let (handle, format, label) = match *self {
             #[cfg(feature = "p256")]
@@ -196,16 +191,38 @@ impl CommandExecution for CertifyKeyCommand<'_> {
                 .contains(DpeFlags::MARK_DICE_EXTENSIONS_CRITICAL),
         };
 
-        let mut response = self.response_bytes(dpe.profile, out)?;
-        let cert = response.cert_mut();
+        let response = self.response_bytes();
+        let hdr_size = response.hdr_size();
+        let mut cert_view = OffsetResponseBuffer::new(out, hdr_size);
+        let result = Self::run_cert_format(format, &args, dpe, env, &mut cert_view)?;
 
-        let result = match format {
+        #[allow(clippy::indexing_slicing)]
+        let new_handle = {
+            let mut ctx = env.state().contexts[idx];
+            dpe.roll_onetime_use_handle(env, &mut ctx)?;
+            env.state().contexts[idx] = ctx;
+            ctx.handle
+        };
+
+        response.write_header(out, dpe, &result, new_handle)
+    }
+}
+
+impl CertifyKeyCommand<'_> {
+    fn run_cert_format(
+        format: u32,
+        args: &CreateDpeCertArgs,
+        dpe: &mut DpeInstance,
+        env: &mut dyn DpeEnv,
+        out: &mut dyn ResponseBuffer,
+    ) -> Result<CreateDpeCertResult, DpeErrorCode> {
+        match format {
             Self::FORMAT_X509 => {
                 cfg_if! {
                     if #[cfg(not(feature = "disable_x509"))] {
                         #[cfg(feature = "cfi")]
                         cfi_assert_eq(format, Self::FORMAT_X509);
-                        create_dpe_cert(&args, dpe, env, cert)
+                        create_dpe_cert(args, dpe, env, out)
                     } else {
                         Err(DpeErrorCode::ArgumentNotSupported)
                     }
@@ -216,69 +233,14 @@ impl CommandExecution for CertifyKeyCommand<'_> {
                     if #[cfg(not(feature = "disable_csr"))] {
                         #[cfg(feature = "cfi")]
                         cfi_assert_eq(format, Self::FORMAT_CSR);
-                        crate::x509::create_dpe_csr(&args, dpe, env, cert)
+                        crate::x509::create_dpe_csr(args, dpe, env, out)
                     } else {
                         Err(DpeErrorCode::ArgumentNotSupported)
                     }
                 }
             }
-            _ => return Err(DpeErrorCode::InvalidArgument),
-        };
-
-        let CreateDpeCertResult {
-            cert_size,
-            ref pub_key,
-            ..
-        } = *okref(&result)?;
-
-        match (&mut response, pub_key) {
-            #[cfg(feature = "p256")]
-            (
-                CertifyKeyResponseBytes::P256(resp),
-                PubKey::Ecdsa(EcdsaPubKey::Ecdsa256(pub_key)),
-            ) => {
-                let (x, y) = pub_key.as_slice();
-                resp.new_context_handle = ContextHandle::new_invalid();
-                resp.derived_pubkey_x = *x;
-                resp.derived_pubkey_y = *y;
-                resp.cert_size = cert_size;
-                resp.resp_hdr = dpe.response_hdr(DpeErrorCode::NoError);
-            }
-            #[cfg(feature = "p384")]
-            (
-                CertifyKeyResponseBytes::P384(resp),
-                PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(pub_key)),
-            ) => {
-                let (x, y) = pub_key.as_slice();
-                resp.new_context_handle = ContextHandle::new_invalid();
-                resp.derived_pubkey_x = *x;
-                resp.derived_pubkey_y = *y;
-                resp.cert_size = cert_size;
-                resp.resp_hdr = dpe.response_hdr(DpeErrorCode::NoError);
-            }
-            #[cfg(feature = "ml-dsa")]
-            (
-                CertifyKeyResponseBytes::Mldsa87(resp),
-                PubKey::Mldsa(caliptra_dpe_crypto::ml_dsa::MldsaPublicKey(pubkey)),
-            ) => {
-                resp.new_context_handle = ContextHandle::new_invalid();
-                resp.pubkey = *pubkey;
-                resp.cert_size = cert_size;
-                resp.resp_hdr = dpe.response_hdr(DpeErrorCode::NoError);
-            }
-            _ => Err(DpeErrorCode::InvalidArgument)?,
-        };
-
-        let len = response.size()?;
-        // Rotate handle if it isn't the default
-        #[allow(clippy::indexing_slicing)]
-        {
-            let mut ctx = env.state().contexts[idx];
-            dpe.roll_onetime_use_handle(env, &mut ctx)?;
-            env.state().contexts[idx] = ctx;
-            response.set_handle(ctx.handle);
+            _ => Err(DpeErrorCode::InvalidArgument),
         }
-        Ok(len)
     }
 }
 
@@ -299,7 +261,7 @@ impl CommandExecution for CertifyKeyP256Cmd {
         dpe: &mut DpeInstance,
         env: &mut dyn DpeEnv,
         locality: u32,
-        out: &mut [u8],
+        out: &mut dyn ResponseBuffer,
     ) -> Result<usize, DpeErrorCode> {
         CertifyKeyCommand::from(self).execute_serialized(dpe, env, locality, out)
     }
@@ -333,7 +295,7 @@ impl CommandExecution for CertifyKeyP384Cmd {
         dpe: &mut DpeInstance,
         env: &mut dyn DpeEnv,
         locality: u32,
-        out: &mut [u8],
+        out: &mut dyn ResponseBuffer,
     ) -> Result<usize, DpeErrorCode> {
         CertifyKeyCommand::from(self).execute_serialized(dpe, env, locality, out)
     }
@@ -368,52 +330,86 @@ impl CommandExecution for CertifyKeyMldsa87Cmd {
         dpe: &mut DpeInstance,
         env: &mut dyn DpeEnv,
         locality: u32,
-        out: &mut [u8],
+        out: &mut dyn ResponseBuffer,
     ) -> Result<usize, DpeErrorCode> {
         CertifyKeyCommand::from(self).execute_serialized(dpe, env, locality, out)
     }
 }
 
-enum CertifyKeyResponseBytes<'a> {
+enum CertifyKeyResponseBytes {
     #[cfg(feature = "p256")]
-    P256(&'a mut crate::response::CertifyKeyP256Resp),
+    P256,
     #[cfg(feature = "p384")]
-    P384(&'a mut crate::response::CertifyKeyP384Resp),
+    P384,
     #[cfg(feature = "ml-dsa")]
-    Mldsa87(&'a mut crate::response::CertifyKeyMldsa87Resp),
+    Mldsa87,
 }
 
-impl CertifyKeyResponseBytes<'_> {
-    fn cert_mut(&mut self) -> &mut [u8] {
+impl CertifyKeyResponseBytes {
+    fn hdr_size(&self) -> usize {
         match self {
             #[cfg(feature = "p256")]
-            CertifyKeyResponseBytes::P256(resp) => &mut resp.cert,
+            Self::P256 => core::mem::size_of::<crate::response::CertifyKeyP256RespHdr>(),
             #[cfg(feature = "p384")]
-            CertifyKeyResponseBytes::P384(resp) => &mut resp.cert,
+            Self::P384 => core::mem::size_of::<crate::response::CertifyKeyP384RespHdr>(),
             #[cfg(feature = "ml-dsa")]
-            CertifyKeyResponseBytes::Mldsa87(resp) => &mut resp.cert,
+            Self::Mldsa87 => core::mem::size_of::<crate::response::CertifyKeyMldsa87RespHdr>(),
         }
     }
 
-    fn set_handle(&mut self, handle: ContextHandle) {
-        match self {
+    fn write_header(
+        &self,
+        out: &mut dyn ResponseBuffer,
+        dpe: &mut DpeInstance,
+        result: &CreateDpeCertResult,
+        new_handle: ContextHandle,
+    ) -> Result<usize, DpeErrorCode> {
+        let cert_size = result.cert_size;
+        match (self, &result.pub_key) {
             #[cfg(feature = "p256")]
-            CertifyKeyResponseBytes::P256(resp) => resp.new_context_handle = handle,
+            (Self::P256, PubKey::Ecdsa(EcdsaPubKey::Ecdsa256(pk))) => {
+                use crate::response::CertifyKeyP256RespHdr;
+                let (pk_x, pk_y) = pk.as_slice();
+                let hdr = CertifyKeyP256RespHdr {
+                    resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+                    new_context_handle: new_handle,
+                    derived_pubkey_x: *pk_x,
+                    derived_pubkey_y: *pk_y,
+                    cert_size,
+                };
+                out.write_at(0, hdr.as_bytes())
+                    .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
+                Ok(core::mem::size_of::<CertifyKeyP256RespHdr>() + cert_size as usize)
+            }
             #[cfg(feature = "p384")]
-            CertifyKeyResponseBytes::P384(resp) => resp.new_context_handle = handle,
+            (Self::P384, PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(pk))) => {
+                use crate::response::CertifyKeyP384RespHdr;
+                let (pk_x, pk_y) = pk.as_slice();
+                let hdr = CertifyKeyP384RespHdr {
+                    resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+                    new_context_handle: new_handle,
+                    derived_pubkey_x: *pk_x,
+                    derived_pubkey_y: *pk_y,
+                    cert_size,
+                };
+                out.write_at(0, hdr.as_bytes())
+                    .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
+                Ok(core::mem::size_of::<CertifyKeyP384RespHdr>() + cert_size as usize)
+            }
             #[cfg(feature = "ml-dsa")]
-            CertifyKeyResponseBytes::Mldsa87(resp) => resp.new_context_handle = handle,
-        }
-    }
-
-    fn size(&self) -> Result<usize, DpeErrorCode> {
-        match self {
-            #[cfg(feature = "p256")]
-            CertifyKeyResponseBytes::P256(resp) => Ok(resp.as_bytes_partial()?.len()),
-            #[cfg(feature = "p384")]
-            CertifyKeyResponseBytes::P384(resp) => Ok(resp.as_bytes_partial()?.len()),
-            #[cfg(feature = "ml-dsa")]
-            CertifyKeyResponseBytes::Mldsa87(resp) => Ok(resp.as_bytes_partial()?.len()),
+            (Self::Mldsa87, PubKey::Mldsa(caliptra_dpe_crypto::ml_dsa::MldsaPublicKey(pubkey))) => {
+                use crate::response::CertifyKeyMldsa87RespHdr;
+                let hdr = CertifyKeyMldsa87RespHdr {
+                    resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+                    new_context_handle: new_handle,
+                    pubkey: *pubkey,
+                    cert_size,
+                };
+                out.write_at(0, hdr.as_bytes())
+                    .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
+                Ok(core::mem::size_of::<CertifyKeyMldsa87RespHdr>() + cert_size as usize)
+            }
+            _ => Err(DpeErrorCode::InvalidArgument),
         }
     }
 }

--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -94,14 +94,14 @@ impl CertifyKeyCommand<'_> {
         }
     }
 
-    fn response_bytes(&self) -> CertifyKeyResponseBytes {
+    fn response_header(&self) -> CertifyKeyResponseHeader {
         match self {
             #[cfg(feature = "p256")]
-            CertifyKeyCommand::P256(_) => CertifyKeyResponseBytes::P256,
+            CertifyKeyCommand::P256(_) => CertifyKeyResponseHeader::P256,
             #[cfg(feature = "p384")]
-            CertifyKeyCommand::P384(_) => CertifyKeyResponseBytes::P384,
+            CertifyKeyCommand::P384(_) => CertifyKeyResponseHeader::P384,
             #[cfg(feature = "ml-dsa")]
-            CertifyKeyCommand::Mldsa87(_) => CertifyKeyResponseBytes::Mldsa87,
+            CertifyKeyCommand::Mldsa87(_) => CertifyKeyResponseHeader::Mldsa87,
         }
     }
 }
@@ -191,8 +191,8 @@ impl CommandExecution for CertifyKeyCommand<'_> {
                 .contains(DpeFlags::MARK_DICE_EXTENSIONS_CRITICAL),
         };
 
-        let response = self.response_bytes();
-        let hdr_size = response.hdr_size();
+        let response_header = self.response_header();
+        let hdr_size = response_header.hdr_size();
         let mut cert_view = OffsetResponseBuffer::new(out, hdr_size);
         let result = Self::run_cert_format(format, &args, dpe, env, &mut cert_view)?;
 
@@ -204,7 +204,7 @@ impl CommandExecution for CertifyKeyCommand<'_> {
             ctx.handle
         };
 
-        response.write_header(out, dpe, &result, new_handle)
+        response_header.write_header(out, dpe, &result, new_handle)
     }
 }
 
@@ -336,7 +336,7 @@ impl CommandExecution for CertifyKeyMldsa87Cmd {
     }
 }
 
-enum CertifyKeyResponseBytes {
+enum CertifyKeyResponseHeader {
     #[cfg(feature = "p256")]
     P256,
     #[cfg(feature = "p384")]
@@ -345,7 +345,7 @@ enum CertifyKeyResponseBytes {
     Mldsa87,
 }
 
-impl CertifyKeyResponseBytes {
+impl CertifyKeyResponseHeader {
     fn hdr_size(&self) -> usize {
         match self {
             #[cfg(feature = "p256")]
@@ -378,8 +378,7 @@ impl CertifyKeyResponseBytes {
                     cert_size,
                 };
                 out.write_at(0, hdr.as_bytes())
-                    .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
-                Ok(core::mem::size_of::<CertifyKeyP256RespHdr>() + cert_size as usize)
+                    .map_err(|_| DpeErrorCode::InvalidResponseBuf)
             }
             #[cfg(feature = "p384")]
             (Self::P384, PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(pk))) => {
@@ -393,8 +392,7 @@ impl CertifyKeyResponseBytes {
                     cert_size,
                 };
                 out.write_at(0, hdr.as_bytes())
-                    .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
-                Ok(core::mem::size_of::<CertifyKeyP384RespHdr>() + cert_size as usize)
+                    .map_err(|_| DpeErrorCode::InvalidResponseBuf)
             }
             #[cfg(feature = "ml-dsa")]
             (Self::Mldsa87, PubKey::Mldsa(caliptra_dpe_crypto::ml_dsa::MldsaPublicKey(pubkey))) => {
@@ -406,11 +404,12 @@ impl CertifyKeyResponseBytes {
                     cert_size,
                 };
                 out.write_at(0, hdr.as_bytes())
-                    .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
-                Ok(core::mem::size_of::<CertifyKeyMldsa87RespHdr>() + cert_size as usize)
+                    .map_err(|_| DpeErrorCode::InvalidResponseBuf)
             }
             _ => Err(DpeErrorCode::InvalidArgument),
-        }
+        }?;
+
+        Ok(self.hdr_size() + cert_size as usize)
     }
 }
 

--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -776,14 +776,18 @@ mod tests {
             let pub_key = match certify_resp {
                 #[cfg(feature = "p256")]
                 CertifyKeyResp::P256(r) => PubKey::Ecdsa(
-                    EcdsaPub::from_slice(&r.derived_pubkey_x, &r.derived_pubkey_y).into(),
+                    EcdsaPub::from_slice(&r.header.derived_pubkey_x, &r.header.derived_pubkey_y)
+                        .into(),
                 ),
                 #[cfg(feature = "p384")]
                 CertifyKeyResp::P384(r) => PubKey::Ecdsa(
-                    EcdsaPub::from_slice(&r.derived_pubkey_x, &r.derived_pubkey_y).into(),
+                    EcdsaPub::from_slice(&r.header.derived_pubkey_x, &r.header.derived_pubkey_y)
+                        .into(),
                 ),
                 #[cfg(feature = "ml-dsa")]
-                CertifyKeyResp::Mldsa87(r) => PubKey::Mldsa(MldsaPublicKey::from_slice(&r.pubkey)),
+                CertifyKeyResp::Mldsa87(r) => {
+                    PubKey::Mldsa(MldsaPublicKey::from_slice(&r.header.pubkey))
+                }
             };
             env.crypto
                 .get_pubkey_serial(&pub_key, &mut subj_serial)

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -1247,11 +1247,11 @@ mod tests {
             Ok(Response::DeriveContextExportedCdi(res)) => res,
             _ => panic!("expected to get a valid DeriveContextExportedCdi response."),
         };
-        assert_eq!(res.parent_handle, ContextHandle::new_invalid());
-        assert_eq!(res.handle, ContextHandle::new_invalid());
-        assert_ne!(res.certificate_size, 0);
+        assert_eq!(res.header.parent_handle, ContextHandle::new_invalid());
+        assert_eq!(res.header.handle, ContextHandle::new_invalid());
+        assert_ne!(res.header.certificate_size, 0);
         assert_ne!(res.new_certificate, [0; MAX_CERT_SIZE]);
-        assert_ne!(res.exported_cdi, [0; MAX_EXPORTED_CDI_SIZE]);
+        assert_ne!(res.header.exported_cdi, [0; MAX_EXPORTED_CDI_SIZE]);
 
         *env.state = State::new(
             Support::AUTO_INIT | Support::INTERNAL_INFO | Support::INTERNAL_DICE | Support::X509,
@@ -1329,11 +1329,11 @@ mod tests {
             Err(e) => panic!("{:?}", e),
             _ => panic!("expected to get a valid DeriveContextExportedCdi response."),
         };
-        assert_ne!(res.parent_handle, handle);
-        assert_eq!(res.handle, ContextHandle::new_invalid());
-        assert_ne!(res.certificate_size, 0);
+        assert_ne!(res.header.parent_handle, handle);
+        assert_eq!(res.header.handle, ContextHandle::new_invalid());
+        assert_ne!(res.header.certificate_size, 0);
         assert_ne!(res.new_certificate, [0; MAX_CERT_SIZE]);
-        assert_ne!(res.exported_cdi, [0; MAX_EXPORTED_CDI_SIZE]);
+        assert_ne!(res.header.exported_cdi, [0; MAX_EXPORTED_CDI_SIZE]);
 
         // New ENV so the exported-cdi slot is clear.
         let mut state = State::new(
@@ -1361,11 +1361,11 @@ mod tests {
             Ok(Response::DeriveContextExportedCdi(res)) => res,
             _ => panic!("expected to get a valid DeriveContextExportedCdi response."),
         };
-        assert_eq!(res.parent_handle, ContextHandle::default());
-        assert_eq!(res.handle, ContextHandle::new_invalid());
-        assert_ne!(res.certificate_size, 0);
+        assert_eq!(res.header.parent_handle, ContextHandle::default());
+        assert_eq!(res.header.handle, ContextHandle::new_invalid());
+        assert_ne!(res.header.certificate_size, 0);
         assert_ne!(res.new_certificate, [0; MAX_CERT_SIZE]);
-        assert_ne!(res.exported_cdi, [0; MAX_EXPORTED_CDI_SIZE]);
+        assert_ne!(res.header.exported_cdi, [0; MAX_EXPORTED_CDI_SIZE]);
 
         // Children that did not have `DeriveContextFlags::ALLOW_NEW_CONTEXT_TO_EXPORT` should not
         // be able to use `DeriveContextFlags::EXPORT_CDI`.
@@ -1470,11 +1470,11 @@ mod tests {
             Ok(Response::DeriveContextExportedCdi(res)) => res,
             _ => panic!("expected to get a valid DeriveContextExportedCdi response."),
         };
-        assert_eq!(res.parent_handle, ContextHandle::new_invalid());
-        assert_eq!(res.handle, ContextHandle::new_invalid());
-        assert_ne!(res.certificate_size, 0);
+        assert_eq!(res.header.parent_handle, ContextHandle::new_invalid());
+        assert_eq!(res.header.handle, ContextHandle::new_invalid());
+        assert_ne!(res.header.certificate_size, 0);
         assert_ne!(res.new_certificate, [0; MAX_CERT_SIZE]);
-        assert_ne!(res.exported_cdi, [0; MAX_EXPORTED_CDI_SIZE]);
+        assert_ne!(res.header.exported_cdi, [0; MAX_EXPORTED_CDI_SIZE]);
     }
 
     #[test]
@@ -1780,11 +1780,15 @@ mod tests {
                 Response::DeriveContextExportedCdi(resp) => resp,
                 _ => panic!("Wrong response type."),
             };
-            assert_eq!(ContextHandle::new_invalid(), derive_resp.handle);
-            assert_eq!(ContextHandle::new_invalid(), derive_resp.parent_handle);
+            assert_eq!(ContextHandle::new_invalid(), derive_resp.header.handle);
+            assert_eq!(
+                ContextHandle::new_invalid(),
+                derive_resp.header.parent_handle
+            );
             let mut parser = X509CertificateParser::new().with_deep_parse_extensions(true);
             match parser.parse(
-                &derive_resp.new_certificate[..derive_resp.certificate_size.try_into().unwrap()],
+                &derive_resp.new_certificate
+                    [..derive_resp.header.certificate_size.try_into().unwrap()],
             ) {
                 Ok((_, cert)) => {
                     match cert.basic_constraints() {
@@ -1868,8 +1872,12 @@ mod tests {
                 ..
             }))
             | Ok(Response::DeriveContextExportedCdi(DeriveContextExportedCdiResp {
-                handle,
-                parent_handle,
+                header:
+                    DeriveContextExportedCdiRespHdr {
+                        handle,
+                        parent_handle,
+                        ..
+                    },
                 ..
             })) => {
                 assert_eq!(
@@ -1917,9 +1925,9 @@ mod tests {
         };
 
         let mut parser = X509CertificateParser::new().with_deep_parse_extensions(true);
-        match parser
-            .parse(&derive_resp.new_certificate[..derive_resp.certificate_size.try_into().unwrap()])
-        {
+        match parser.parse(
+            &derive_resp.new_certificate[..derive_resp.header.certificate_size.try_into().unwrap()],
+        ) {
             Ok((_, cert)) => {
                 let subject = cert.subject().to_string();
                 assert!(subject.contains("CN=DPE Exported CDI"));

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -6,17 +6,19 @@ use crate::{
     dpe_instance::{DpeEnv, DpeInstance},
     error::{DpeErrorCode, InternalErrorCode},
     mutresp, okref,
-    response::{DeriveContextExportedCdiResp, DeriveContextResp},
+    response::{DeriveContextExportedCdiRespHdr, DeriveContextResp},
     tci::TciMeasurement,
     x509::{create_exported_dpe_cert, CreateDpeCertArgs, CreateDpeCertResult},
-    DpeFlags, State,
+    AlignedBuf, DpeFlags, State,
 };
 use bitflags::bitflags;
 #[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
 #[cfg(feature = "cfi")]
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_assert_eq};
+use caliptra_dpe_response_buffer::{OffsetResponseBuffer, ResponseBuffer};
 use cfg_if::cfg_if;
+use core::mem::size_of;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 #[repr(C)]
@@ -220,7 +222,7 @@ impl CommandExecution for DeriveContextCmd {
         dpe: &mut DpeInstance,
         env: &mut dyn DpeEnv,
         locality: u32,
-        out: &mut [u8],
+        out: &mut dyn ResponseBuffer,
     ) -> Result<usize, DpeErrorCode> {
         let support = env.state().support;
         let DeriveContextCmd {
@@ -290,7 +292,8 @@ impl CommandExecution for DeriveContextCmd {
         if flags.is_recursive() {
             cfg_if! {
                 if #[cfg(not(feature = "disable_recursive"))] {
-                    let response = mutresp::<DeriveContextResp>(dpe.profile, out)?;
+                    let mut scratch = AlignedBuf::<{ size_of::<DeriveContextResp>() }>::new();
+                    let response = mutresp::<DeriveContextResp>(dpe.profile, scratch.as_mut_bytes())?;
                     let mut tmp_context = *env.state().contexts.get(parent_idx).ok_or(DpeErrorCode::from(InternalErrorCode::ContextIndexOob))?;
                     if tmp_context.tci.tci_type != tci_type {
                         return Err(DpeErrorCode::InvalidArgument);
@@ -317,7 +320,9 @@ impl CommandExecution for DeriveContextCmd {
                         parent_handle: ContextHandle::default(),
                         resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
                     };
-                    return Ok(size_of_val(response));
+                    let n = size_of_val(response);
+                    out.write_at(0, &scratch.as_bytes()[..n]).map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
+                    return Ok(n);
                 } else {
                     Err(DpeErrorCode::ArgumentNotSupported)?
                 }
@@ -357,7 +362,10 @@ impl CommandExecution for DeriveContextCmd {
         if flags.creates_certificate() && flags.exports_cdi() {
             cfg_if! {
                 if #[cfg(not(feature = "disable_export_cdi"))] {
-                    let response = mutresp::<DeriveContextExportedCdiResp>(dpe.profile, out)?;
+                    // Create a view into just the cert for serialization.
+                    let hdr_size = core::mem::size_of::<DeriveContextExportedCdiRespHdr>();
+                    let mut cert_view = OffsetResponseBuffer::new(out, hdr_size);
+
                     let ueid = &env.platform().get_ueid()?;
                     let ueid = ueid.get()?;
                     let profile_descriptor = match dpe.profile {
@@ -379,7 +387,7 @@ impl CommandExecution for DeriveContextCmd {
                         &args,
                         dpe,
                         env,
-                        &mut response.new_certificate,
+                        &mut cert_view,
                     );
                     let CreateDpeCertResult { cert_size, exported_cdi_handle, .. } = okref(&result)?;
 
@@ -394,19 +402,25 @@ impl CommandExecution for DeriveContextCmd {
                         *env.state().contexts.get_mut(parent_idx).ok_or(DpeErrorCode::from(InternalErrorCode::ContextIndexOob))? = tmp_parent_context;
                     }
 
-                    response.handle = ContextHandle::new_invalid();
-                    #[allow(clippy::indexing_slicing)] { response.parent_handle = env.state().contexts[parent_idx].handle; }
-                    response.resp_hdr = dpe.response_hdr(DpeErrorCode::NoError);
-                    response.exported_cdi = *exported_cdi_handle;
-                    response.certificate_size = *cert_size;
-                    let response_size = size_of_val(response) - size_of_val(&response.new_certificate) + *cert_size as usize;
-                    return Ok(response_size);
+                    #[allow(clippy::indexing_slicing)]
+                    let parent_handle = env.state().contexts[parent_idx].handle;
+                    let hdr = DeriveContextExportedCdiRespHdr {
+                        resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+                        handle: ContextHandle::new_invalid(),
+                        parent_handle,
+                        exported_cdi: *exported_cdi_handle,
+                        certificate_size: *cert_size,
+                    };
+                    let total = hdr_size + *cert_size as usize;
+                    out.write_at(0, hdr.as_bytes()).map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
+                    return Ok(total);
                 } else {
                     Err(DpeErrorCode::ArgumentNotSupported)?
                 }
             }
         }
-        let response = mutresp::<DeriveContextResp>(dpe.profile, out)?;
+        let mut scratch_normal = AlignedBuf::<{ size_of::<DeriveContextResp>() }>::new();
+        let response = mutresp::<DeriveContextResp>(dpe.profile, scratch_normal.as_mut_bytes())?;
 
         let child_idx = env
             .state()
@@ -469,7 +483,7 @@ impl CommandExecution for DeriveContextCmd {
 
         // At this point we cannot error out anymore, so it is safe to set the updated child and parent contexts.
         #[allow(clippy::indexing_slicing)]
-        {
+        let n = {
             env.state().contexts[child_idx] = tmp_child_context;
             env.state().contexts[parent_idx] = tmp_parent_context;
 
@@ -478,8 +492,11 @@ impl CommandExecution for DeriveContextCmd {
                 parent_handle: env.state().contexts[parent_idx].handle,
                 resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
             };
-        }
-        Ok(size_of_val(response))
+            size_of_val(response)
+        };
+        out.write_at(0, &scratch_normal.as_bytes()[..n])
+            .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
+        Ok(n)
     }
 }
 
@@ -511,7 +528,7 @@ mod tests {
         },
         context::ContextType,
         dpe_instance::tests::{DPE_PROFILE, RANDOM_HANDLE, SIMULATION_HANDLE, TEST_LOCALITIES},
-        response::{NewHandleResp, Response},
+        response::{DeriveContextExportedCdiResp, NewHandleResp, Response},
         support::Support,
         test_env,
         validation::DpeValidator,

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -4,8 +4,6 @@ use crate::{
     context::{Children, Context, ContextHandle, ContextState},
     dpe_instance::{DpeEnv, DpeInstance},
     error::{DpeErrorCode, InternalErrorCode},
-    mutresp,
-    response::ResponseHdr,
     State,
 };
 #[cfg(feature = "cfi")]
@@ -13,6 +11,8 @@ use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_cfi_lib::cfi_launder;
 #[cfg(feature = "cfi")]
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_assert_eq};
+use caliptra_dpe_response_buffer::ResponseBuffer;
+use zerocopy::IntoBytes;
 
 #[repr(C)]
 #[derive(
@@ -93,12 +93,14 @@ impl CommandExecution for DestroyCtxCmd {
         dpe: &mut DpeInstance,
         env: &mut dyn DpeEnv,
         locality: u32,
-        out: &mut [u8],
+        out: &mut dyn ResponseBuffer,
     ) -> Result<usize, DpeErrorCode> {
-        let response = mutresp::<ResponseHdr>(dpe.profile, out)?;
         destroy_context(&self.handle, env.state(), locality)?;
-        *response = dpe.response_hdr(DpeErrorCode::NoError);
-        Ok(size_of_val(response))
+        let resp = dpe.response_hdr(DpeErrorCode::NoError);
+        let bytes = resp.as_bytes();
+        out.write_at(0, bytes)
+            .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
+        Ok(bytes.len())
     }
 }
 

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -3,12 +3,13 @@ use super::CommandExecution;
 use crate::{
     dpe_instance::{DpeEnv, DpeInstance},
     error::DpeErrorCode,
-    mutresp,
     response::GetCertificateChainResp,
 };
 #[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_dpe_platform::MAX_CHUNK_SIZE;
+use caliptra_dpe_response_buffer::ResponseBuffer;
+use zerocopy::IntoBytes;
 
 #[repr(C, align(4))]
 #[derive(
@@ -33,24 +34,25 @@ impl CommandExecution for GetCertificateChainCmd {
         dpe: &mut DpeInstance,
         env: &mut dyn DpeEnv,
         _locality: u32,
-        out: &mut [u8],
+        out: &mut dyn ResponseBuffer,
     ) -> Result<usize, DpeErrorCode> {
         // Make sure the operation is supported.
         if self.size > MAX_CHUNK_SIZE as u32 {
             return Err(DpeErrorCode::InvalidArgument);
         }
-        let response = mutresp::<GetCertificateChainResp>(dpe.profile, out)?;
-
         let mut cert_chunk = [0u8; MAX_CHUNK_SIZE];
         let len = env
             .platform()
             .get_certificate_chain(self.offset, self.size, &mut cert_chunk)?;
-        *response = GetCertificateChainResp {
+        let resp = GetCertificateChainResp {
             certificate_chain: cert_chunk,
             certificate_size: len,
             resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
         };
-        Ok(size_of_val(response))
+        let bytes = resp.as_bytes();
+        out.write_at(0, bytes)
+            .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
+        Ok(bytes.len())
     }
 }
 

--- a/dpe/src/commands/get_profile.rs
+++ b/dpe/src/commands/get_profile.rs
@@ -4,11 +4,12 @@ use super::CommandExecution;
 use crate::{
     dpe_instance::{DpeEnv, DpeInstance},
     error::DpeErrorCode,
-    mutresp,
     response::GetProfileResp,
 };
 #[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
+use caliptra_dpe_response_buffer::ResponseBuffer;
+use zerocopy::IntoBytes;
 
 #[repr(C, align(4))]
 #[derive(
@@ -31,12 +32,13 @@ impl CommandExecution for GetProfileCmd {
         dpe: &mut DpeInstance,
         env: &mut dyn DpeEnv,
         _locality: u32,
-        out: &mut [u8],
+        out: &mut dyn ResponseBuffer,
     ) -> Result<usize, DpeErrorCode> {
-        let response = mutresp::<GetProfileResp>(dpe.profile, out)?;
         let support = env.state().support;
-        *response = dpe.get_profile(env.platform(), support)?;
-
-        Ok(size_of_val(response))
+        let resp: GetProfileResp = dpe.get_profile(env.platform(), support)?;
+        let bytes = resp.as_bytes();
+        out.write_at(0, bytes)
+            .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
+        Ok(bytes.len())
     }
 }

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -4,7 +4,6 @@ use crate::{
     context::{ActiveContextArgs, Context, ContextHandle, ContextType},
     dpe_instance::{DpeEnv, DpeInstance},
     error::{DpeErrorCode, InternalErrorCode},
-    mutresp,
     response::NewHandleResp,
 };
 use bitflags::bitflags;
@@ -12,7 +11,9 @@ use bitflags::bitflags;
 use caliptra_cfi_derive::cfi_impl_fn;
 #[cfg(feature = "cfi")]
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool};
+use caliptra_dpe_response_buffer::ResponseBuffer;
 use cfg_if::cfg_if;
+use zerocopy::IntoBytes;
 
 #[repr(C, align(4))]
 #[derive(
@@ -59,10 +60,8 @@ impl CommandExecution for InitCtxCmd {
         dpe: &mut DpeInstance,
         env: &mut dyn DpeEnv,
         locality: u32,
-        out: &mut [u8],
+        out: &mut dyn ResponseBuffer,
     ) -> Result<usize, DpeErrorCode> {
-        let response = mutresp::<NewHandleResp>(dpe.profile, out)?;
-
         // This function can only be called once for non-simulation contexts.
         if (self.flag_is_default() && env.state().has_initialized())
             || (self.flag_is_simulation() && !env.state().support.simulation())
@@ -120,11 +119,14 @@ impl CommandExecution for InitCtxCmd {
                 // creating a child, leaving no auditable record of the mutation.
                 allow_recursive: self.flag_is_default(),
             });
-        *response = NewHandleResp {
+        let resp = NewHandleResp {
             handle,
             resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
         };
-        Ok(size_of_val(response))
+        let bytes = resp.as_bytes();
+        out.write_at(0, bytes)
+            .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
+        Ok(bytes.len())
     }
 }
 

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub use self::sign::{SignCommand, SignFlags, SignP256Cmd, SignP384Cmd};
 pub use self::update_context_measurement::UpdateContextMeasurementCmd;
 #[cfg(feature = "cfi")]
 use caliptra_cfi_derive::{cfi_impl_fn, Launder};
+use caliptra_dpe_response_buffer::{ResponseBuffer, SliceResponseBuffer};
 
 #[cfg(feature = "ml-dsa")]
 pub use {self::certify_key::CertifyKeyMldsa87Cmd, sign::SignMldsa87Cmd, sign::SignMldsa87RawCmd};
@@ -88,7 +89,7 @@ impl Command<'_> {
     /// # Arguments
     ///
     /// * `bytes` - serialized command
-    pub fn deserialize(profile: DpeProfile, bytes: &'_ [u8]) -> Result<Command, DpeErrorCode> {
+    pub fn deserialize(profile: DpeProfile, bytes: &'_ [u8]) -> Result<Command<'_>, DpeErrorCode> {
         let header = CommandHdr::try_from_with_profile(profile, bytes)?;
         let bytes = bytes
             .get(size_of::<CommandHdr>()..)
@@ -310,7 +311,7 @@ impl CommandExecution for Command<'_> {
         dpe: &mut DpeInstance,
         env: &mut dyn DpeEnv,
         locality: u32,
-        out: &mut [u8],
+        out: &mut dyn ResponseBuffer,
     ) -> Result<usize, DpeErrorCode> {
         match self {
             Command::CertifyKey(cmd) => cmd.execute_serialized(dpe, env, locality, out),
@@ -346,7 +347,8 @@ pub trait CommandExecution {
         macro_rules! exec {
             ($resp_type:ty, $f:expr) => {{
                 let mut buf = [0u32; (size_of::<$resp_type>() + 3) / 4];
-                self.execute_serialized(dpe, env, locality, buf.as_mut_bytes())?;
+                let mut resp_buf = SliceResponseBuffer::new(buf.as_mut_bytes());
+                self.execute_serialized(dpe, env, locality, &mut resp_buf)?;
                 <$resp_type>::try_read_from_bytes(buf.as_bytes())
                     .map($f)
                     .map_err(|_| {
@@ -427,7 +429,7 @@ pub trait CommandExecution {
         dpe: &mut DpeInstance,
         env: &mut dyn DpeEnv,
         locality: u32,
-        out: &mut [u8],
+        out: &mut dyn ResponseBuffer,
     ) -> Result<usize, DpeErrorCode>;
 
     /// CFI wrapper around execute
@@ -440,7 +442,7 @@ pub trait CommandExecution {
         dpe: &mut DpeInstance,
         env: &mut dyn DpeEnv,
         locality: u32,
-        out: &mut [u8],
+        out: &mut dyn ResponseBuffer,
     ) -> Result<usize, DpeErrorCode>;
 }
 

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -4,7 +4,6 @@ use crate::{
     context::{ContextHandle, ContextState},
     dpe_instance::{DpeEnv, DpeInstance},
     error::{DpeErrorCode, InternalErrorCode},
-    mutresp,
     response::NewHandleResp,
     State,
 };
@@ -14,6 +13,8 @@ use caliptra_cfi_derive::cfi_impl_fn;
 use caliptra_cfi_lib::cfi_launder;
 #[cfg(feature = "cfi")]
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool};
+use caliptra_dpe_response_buffer::ResponseBuffer;
+use zerocopy::IntoBytes;
 
 #[repr(C, align(4))]
 #[derive(
@@ -87,7 +88,7 @@ impl CommandExecution for RotateCtxCmd {
         dpe: &mut DpeInstance,
         env: &mut dyn DpeEnv,
         locality: u32,
-        out: &mut [u8],
+        out: &mut dyn ResponseBuffer,
     ) -> Result<usize, DpeErrorCode> {
         if !env.state().support.rotate_context() {
             return Err(DpeErrorCode::InvalidCommand);
@@ -95,7 +96,6 @@ impl CommandExecution for RotateCtxCmd {
             #[cfg(feature = "cfi")]
             cfi_assert!(env.state().support.rotate_context());
         }
-        let response = mutresp::<NewHandleResp>(dpe.profile, out)?;
         let idx = env.state().get_active_context_pos(&self.handle, locality)?;
 
         // Make sure caller's locality does not already have a default context.
@@ -127,11 +127,14 @@ impl CommandExecution for RotateCtxCmd {
             .ok_or(DpeErrorCode::from(InternalErrorCode::ContextIndexOob))?
             .handle = new_handle;
 
-        *response = NewHandleResp {
+        let resp = NewHandleResp {
             handle: new_handle,
             resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
         };
-        Ok(size_of_val(response))
+        let bytes = resp.as_bytes();
+        out.write_at(0, bytes)
+            .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
+        Ok(bytes.len())
     }
 }
 

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -4,7 +4,7 @@ use crate::{
     context::{ContextHandle, ContextType},
     dpe_instance::{DpeEnv, DpeInstance},
     error::{DpeErrorCode, InternalErrorCode},
-    mutresp, okref, DpeProfile,
+    okref, DpeProfile,
 };
 use bitflags::bitflags;
 #[cfg(feature = "cfi")]
@@ -15,10 +15,10 @@ use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_assert_ne};
 #[cfg(any(feature = "p256", feature = "p384"))]
 use caliptra_dpe_crypto::ecdsa::EcdsaSignature;
 use caliptra_dpe_crypto::{SignData, Signature};
+use caliptra_dpe_response_buffer::ResponseBuffer;
 use cfg_if::cfg_if;
 #[cfg(feature = "ml-dsa")]
 use core::mem::size_of;
-use core::mem::size_of_val;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 #[repr(C, align(4))]
@@ -67,7 +67,7 @@ pub enum SignCommand<'a> {
 }
 
 impl SignCommand<'_> {
-    pub fn deserialize(profile: DpeProfile, bytes: &[u8]) -> Result<SignCommand, DpeErrorCode> {
+    pub fn deserialize(profile: DpeProfile, bytes: &[u8]) -> Result<SignCommand<'_>, DpeErrorCode> {
         match profile {
             #[cfg(feature = "p256")]
             DpeProfile::P256Sha256 => SignCommand::parse_command(SignCommand::P256, bytes),
@@ -139,7 +139,7 @@ impl CommandExecution for SignCommand<'_> {
         dpe: &mut DpeInstance,
         env: &mut dyn DpeEnv,
         locality: u32,
-        out: &mut [u8],
+        out: &mut dyn ResponseBuffer,
     ) -> Result<usize, DpeErrorCode> {
         let (handle, label, data) = match *self {
             #[cfg(feature = "p256")]
@@ -193,55 +193,58 @@ impl CommandExecution for SignCommand<'_> {
             #[cfg(feature = "p256")]
             Signature::Ecdsa(EcdsaSignature::Ecdsa256(sig)) => {
                 use crate::response::SignP256Resp;
-                let response = mutresp::<SignP256Resp>(dpe.profile, out)?;
-
                 // Rotate the handle if it isn't the default context.
                 let mut ctx = env.state().contexts[idx];
                 dpe.roll_onetime_use_handle(env, &mut ctx)?;
                 env.state().contexts[idx] = ctx;
                 let (&sig_r, &sig_s) = sig.as_slice();
-                *response = SignP256Resp {
+                let resp = SignP256Resp {
                     new_context_handle: ctx.handle,
                     sig_r,
                     sig_s,
                     resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
                 };
-                Ok(size_of_val(response))
+                let bytes = resp.as_bytes();
+                out.write_at(0, bytes)
+                    .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
+                Ok(bytes.len())
             }
             #[cfg(feature = "p384")]
             Signature::Ecdsa(EcdsaSignature::Ecdsa384(sig)) => {
                 use crate::response::SignP384Resp;
-                let response = mutresp::<SignP384Resp>(dpe.profile, out)?;
-
                 // Rotate the handle if it isn't the default context.
                 let mut ctx = env.state().contexts[idx];
                 dpe.roll_onetime_use_handle(env, &mut ctx)?;
                 env.state().contexts[idx] = ctx;
                 let (&sig_r, &sig_s) = sig.as_slice();
-                *response = SignP384Resp {
+                let resp = SignP384Resp {
                     new_context_handle: ctx.handle,
                     sig_r,
                     sig_s,
                     resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
                 };
-                Ok(size_of_val(response))
+                let bytes = resp.as_bytes();
+                out.write_at(0, bytes)
+                    .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
+                Ok(bytes.len())
             }
             #[cfg(feature = "ml-dsa")]
             Signature::Mldsa(caliptra_dpe_crypto::ml_dsa::MldsaSignature(sig)) => {
                 use crate::response::SignMlDsaResp;
-                let response = mutresp::<SignMlDsaResp>(dpe.profile, out)?;
-
                 // Rotate the handle if it isn't the default context.
                 let mut ctx = env.state().contexts[idx];
                 dpe.roll_onetime_use_handle(env, &mut ctx)?;
                 env.state().contexts[idx] = ctx;
-                *response = SignMlDsaResp {
+                let resp = SignMlDsaResp {
                     new_context_handle: ctx.handle,
                     sig: *sig,
                     _padding: [0; 1],
                     resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
                 };
-                Ok(size_of_val(response))
+                let bytes = resp.as_bytes();
+                out.write_at(0, bytes)
+                    .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
+                Ok(bytes.len())
             }
             _ => Err(DpeErrorCode::InvalidArgument)?,
         }
@@ -296,7 +299,7 @@ impl CommandExecution for SignP256Cmd {
         dpe: &mut DpeInstance,
         env: &mut dyn DpeEnv,
         locality: u32,
-        out: &mut [u8],
+        out: &mut dyn ResponseBuffer,
     ) -> Result<usize, DpeErrorCode> {
         SignCommand::P256(self).execute_serialized(dpe, env, locality, out)
     }
@@ -319,7 +322,7 @@ impl CommandExecution for SignP384Cmd {
         dpe: &mut DpeInstance,
         env: &mut dyn DpeEnv,
         locality: u32,
-        out: &mut [u8],
+        out: &mut dyn ResponseBuffer,
     ) -> Result<usize, DpeErrorCode> {
         SignCommand::P384(self).execute_serialized(dpe, env, locality, out)
     }
@@ -343,7 +346,7 @@ impl CommandExecution for SignMldsa87Cmd {
         dpe: &mut DpeInstance,
         env: &mut dyn DpeEnv,
         locality: u32,
-        out: &mut [u8],
+        out: &mut dyn ResponseBuffer,
     ) -> Result<usize, DpeErrorCode> {
         SignCommand::Mldsa87(self).execute_serialized(dpe, env, locality, out)
     }
@@ -357,7 +360,7 @@ impl CommandExecution for SignMldsa87RawCmd {
         dpe: &mut DpeInstance,
         env: &mut dyn DpeEnv,
         locality: u32,
-        out: &mut [u8],
+        out: &mut dyn ResponseBuffer,
     ) -> Result<usize, DpeErrorCode> {
         SignCommand::Mldsa87Raw(self).execute_serialized(dpe, env, locality, out)
     }

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -325,6 +325,7 @@ impl CommandExecution for SignP384Cmd {
     }
 }
 
+#[cfg(feature = "ml-dsa")]
 #[repr(C, align(4))]
 #[derive(Debug, PartialEq, Eq, IntoBytes, FromBytes, Immutable, KnownLayout)]
 pub struct SignMldsa87Cmd {
@@ -573,7 +574,7 @@ mod tests {
                     ml_dsa::Signature::decode(&encoded_sig).expect("Error decoding signature");
 
                 let key_bytes = match certify_resp {
-                    CertifyKeyResp::Mldsa87(resp) => resp.pubkey,
+                    CertifyKeyResp::Mldsa87(resp) => resp.header.pubkey,
                     _ => panic!("Expected Mldsa87 CertifyKeyResp"),
                 };
 
@@ -713,7 +714,7 @@ mod tests {
         let sig = ml_dsa::Signature::decode(&encoded_sig).expect("Error decoding signature");
 
         let key_bytes = match certify_resp {
-            CertifyKeyResp::Mldsa87(resp) => resp.pubkey,
+            CertifyKeyResp::Mldsa87(resp) => resp.header.pubkey,
             _ => panic!("Expected Mldsa87 CertifyKeyResp"),
         };
 

--- a/dpe/src/commands/update_context_measurement.rs
+++ b/dpe/src/commands/update_context_measurement.rs
@@ -13,13 +13,12 @@ use crate::{
     context::ContextState,
     dpe_instance::{DpeEnv, DpeInstance},
     error::{DpeErrorCode, InternalErrorCode},
-    mutresp,
     response::UpdateContextMeasurementResp,
     tci::TciMeasurement,
 };
 #[cfg(feature = "cfi")]
 use caliptra_cfi_derive::cfi_impl_fn;
-use core::mem::size_of_val;
+use caliptra_dpe_response_buffer::ResponseBuffer;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 /// ABI input structure for UpdateContextMeasurement.
@@ -56,7 +55,7 @@ impl CommandExecution for UpdateContextMeasurementCmd {
         dpe: &mut DpeInstance,
         env: &mut dyn DpeEnv,
         locality: u32,
-        out: &mut [u8],
+        out: &mut dyn ResponseBuffer,
     ) -> Result<usize, DpeErrorCode> {
         // PARENT_CONTEXT_HANDLE must not be the default (null) handle.
         if self.parent_handle.is_default() {
@@ -91,8 +90,6 @@ impl CommandExecution for UpdateContextMeasurementCmd {
             })
             .ok_or(DpeErrorCode::InvalidArgument)?;
 
-        let response = mutresp::<UpdateContextMeasurementResp>(dpe.profile, out)?;
-
         // Copy the child context for mutation to avoid touching internal state on error.
         let mut tmp_child = *env
             .state()
@@ -126,12 +123,15 @@ impl CommandExecution for UpdateContextMeasurementCmd {
             .get_mut(child_idx)
             .ok_or(DpeErrorCode::from(InternalErrorCode::ChildIndexOob))? = tmp_child;
 
-        *response = UpdateContextMeasurementResp {
+        let resp = UpdateContextMeasurementResp {
             resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
             new_context_handle: tmp_child.handle,
             new_parent_context_handle: tmp_parent.handle,
         };
-        Ok(size_of_val(response))
+        let bytes = resp.as_bytes();
+        out.write_at(0, bytes)
+            .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
+        Ok(bytes.len())
     }
 }
 

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -24,6 +24,7 @@ use caliptra_dpe_crypto::{CryptoSuite, Digest};
 use caliptra_dpe_platform::Platform;
 #[cfg(not(feature = "disable_internal_dice"))]
 use caliptra_dpe_platform::MAX_CHUNK_SIZE;
+use caliptra_dpe_response_buffer::SliceResponseBuffer;
 use cfg_if::cfg_if;
 use zerocopy::IntoBytes;
 
@@ -81,11 +82,12 @@ impl DpeInstance {
         if env.state().support.auto_init() {
             let locality = env.platform().get_auto_init_locality()?;
             let mut buf = AlignedBuf::<{ size_of::<NewHandleResp>() }>::new();
+            let mut resp_buf = SliceResponseBuffer::new(buf.as_mut_bytes());
             InitCtxCmd::new_use_default().execute_serialized(
                 &mut dpe,
                 env,
                 locality,
-                buf.as_mut_bytes(),
+                &mut resp_buf,
             )?;
         } else {
             #[cfg(feature = "cfi")]

--- a/dpe/src/response.rs
+++ b/dpe/src/response.rs
@@ -268,17 +268,13 @@ pub struct UpdateContextMeasurementResp {
 #[repr(C, align(4))]
 #[derive(Debug, PartialEq, Eq, IntoBytes, TryFromBytes, Immutable, KnownLayout)]
 pub struct DeriveContextExportedCdiResp {
-    pub resp_hdr: ResponseHdr,
-    pub handle: ContextHandle,
-    pub parent_handle: ContextHandle,
-    pub exported_cdi: [u8; MAX_EXPORTED_CDI_SIZE],
-    pub certificate_size: u32,
+    pub header: DeriveContextExportedCdiRespHdr,
     pub new_certificate: [u8; MAX_CERT_SIZE],
 }
 
 impl DeriveContextExportedCdiResp {
     pub fn as_bytes_partial(&self) -> Result<&[u8], DpeErrorCode> {
-        let len = size_of::<Self>() - MAX_CERT_SIZE + self.certificate_size as usize;
+        let len = size_of::<Self>() - MAX_CERT_SIZE + self.header.certificate_size as usize;
         self.as_bytes()
             .get(..len)
             .ok_or(DpeErrorCode::from(InternalErrorCode::DeriveCtxRespSliceOob))
@@ -300,22 +296,22 @@ impl CertifyKeyResp {
     pub fn set_handle(&mut self, handle: &ContextHandle) {
         match self {
             #[cfg(feature = "p256")]
-            CertifyKeyResp::P256(resp) => resp.new_context_handle = *handle,
+            CertifyKeyResp::P256(resp) => resp.header.new_context_handle = *handle,
             #[cfg(feature = "p384")]
-            CertifyKeyResp::P384(resp) => resp.new_context_handle = *handle,
+            CertifyKeyResp::P384(resp) => resp.header.new_context_handle = *handle,
             #[cfg(feature = "ml-dsa")]
-            CertifyKeyResp::Mldsa87(resp) => resp.new_context_handle = *handle,
+            CertifyKeyResp::Mldsa87(resp) => resp.header.new_context_handle = *handle,
         }
     }
 
     pub fn resp_hdr(&self) -> &ResponseHdr {
         match self {
             #[cfg(feature = "p256")]
-            CertifyKeyResp::P256(resp) => &resp.resp_hdr,
+            CertifyKeyResp::P256(resp) => &resp.header.resp_hdr,
             #[cfg(feature = "p384")]
-            CertifyKeyResp::P384(resp) => &resp.resp_hdr,
+            CertifyKeyResp::P384(resp) => &resp.header.resp_hdr,
             #[cfg(feature = "ml-dsa")]
-            CertifyKeyResp::Mldsa87(resp) => &resp.resp_hdr,
+            CertifyKeyResp::Mldsa87(resp) => &resp.header.resp_hdr,
         }
     }
 
@@ -344,11 +340,11 @@ impl CertifyKeyResp {
     pub fn cert(&self) -> Result<&[u8], DpeErrorCode> {
         let (buf, size) = match self {
             #[cfg(feature = "p256")]
-            CertifyKeyResp::P256(r) => (&r.cert, r.cert_size),
+            CertifyKeyResp::P256(r) => (&r.cert, r.header.cert_size),
             #[cfg(feature = "p384")]
-            CertifyKeyResp::P384(r) => (&r.cert, r.cert_size),
+            CertifyKeyResp::P384(r) => (&r.cert, r.header.cert_size),
             #[cfg(feature = "ml-dsa")]
-            CertifyKeyResp::Mldsa87(r) => (&r.cert, r.cert_size),
+            CertifyKeyResp::Mldsa87(r) => (&r.cert, r.header.cert_size),
         };
         buf.get(..size as usize).ok_or(DpeErrorCode::from(
             InternalErrorCode::CertifyKeyCertSliceOob,
@@ -359,17 +355,13 @@ impl CertifyKeyResp {
 #[repr(C, align(4))]
 #[derive(Debug, PartialEq, Eq, IntoBytes, TryFromBytes, Immutable, KnownLayout)]
 pub struct CertifyKeyP256Resp {
-    pub resp_hdr: ResponseHdr,
-    pub new_context_handle: ContextHandle,
-    pub derived_pubkey_x: [u8; EcdsaAlgorithm::Bit256.curve_size()],
-    pub derived_pubkey_y: [u8; EcdsaAlgorithm::Bit256.curve_size()],
-    pub cert_size: u32,
+    pub header: CertifyKeyP256RespHdr,
     pub cert: [u8; MAX_CERT_SIZE],
 }
 
 impl CertifyKeyP256Resp {
     pub fn as_bytes_partial(&self) -> Result<&[u8], DpeErrorCode> {
-        let len = size_of::<Self>() - MAX_CERT_SIZE + self.cert_size as usize;
+        let len = size_of::<Self>() - MAX_CERT_SIZE + self.header.cert_size as usize;
         self.as_bytes().get(..len).ok_or(DpeErrorCode::from(
             InternalErrorCode::CertifyKeyP256RespSliceOob,
         ))
@@ -379,17 +371,13 @@ impl CertifyKeyP256Resp {
 #[repr(C, align(4))]
 #[derive(Debug, PartialEq, Eq, IntoBytes, TryFromBytes, Immutable, KnownLayout)]
 pub struct CertifyKeyP384Resp {
-    pub resp_hdr: ResponseHdr,
-    pub new_context_handle: ContextHandle,
-    pub derived_pubkey_x: [u8; EcdsaAlgorithm::Bit384.curve_size()],
-    pub derived_pubkey_y: [u8; EcdsaAlgorithm::Bit384.curve_size()],
-    pub cert_size: u32,
+    pub header: CertifyKeyP384RespHdr,
     pub cert: [u8; MAX_CERT_SIZE],
 }
 
 impl CertifyKeyP384Resp {
     pub fn as_bytes_partial(&self) -> Result<&[u8], DpeErrorCode> {
-        let len = size_of::<Self>() - MAX_CERT_SIZE + self.cert_size as usize;
+        let len = size_of::<Self>() - MAX_CERT_SIZE + self.header.cert_size as usize;
         self.as_bytes().get(..len).ok_or(DpeErrorCode::from(
             InternalErrorCode::CertifyKeyP384RespSliceOob,
         ))
@@ -400,21 +388,58 @@ impl CertifyKeyP384Resp {
 #[derive(Debug, PartialEq, Eq, IntoBytes, TryFromBytes, Immutable, KnownLayout)]
 #[cfg(feature = "ml-dsa")]
 pub struct CertifyKeyMldsa87Resp {
-    pub resp_hdr: ResponseHdr,
-    pub new_context_handle: ContextHandle,
-    pub pubkey: [u8; MldsaAlgorithm::Mldsa87.public_key_size()],
-    pub cert_size: u32,
+    pub header: CertifyKeyMldsa87RespHdr,
     pub cert: [u8; MAX_CERT_SIZE],
 }
 
 #[cfg(feature = "ml-dsa")]
 impl CertifyKeyMldsa87Resp {
     pub fn as_bytes_partial(&self) -> Result<&[u8], DpeErrorCode> {
-        let len = size_of::<Self>() - MAX_CERT_SIZE + self.cert_size as usize;
+        let len = size_of::<Self>() - MAX_CERT_SIZE + self.header.cert_size as usize;
         self.as_bytes().get(..len).ok_or(DpeErrorCode::from(
             InternalErrorCode::CertifyKeyMldsa87RespSliceOob,
         ))
     }
+}
+
+#[repr(C, align(4))]
+#[derive(Debug, PartialEq, Eq, IntoBytes, TryFromBytes, Immutable, KnownLayout)]
+pub struct CertifyKeyP256RespHdr {
+    pub resp_hdr: ResponseHdr,
+    pub new_context_handle: ContextHandle,
+    pub derived_pubkey_x: [u8; EcdsaAlgorithm::Bit256.curve_size()],
+    pub derived_pubkey_y: [u8; EcdsaAlgorithm::Bit256.curve_size()],
+    pub cert_size: u32,
+}
+
+#[repr(C, align(4))]
+#[derive(Debug, PartialEq, Eq, IntoBytes, TryFromBytes, Immutable, KnownLayout)]
+pub struct CertifyKeyP384RespHdr {
+    pub resp_hdr: ResponseHdr,
+    pub new_context_handle: ContextHandle,
+    pub derived_pubkey_x: [u8; EcdsaAlgorithm::Bit384.curve_size()],
+    pub derived_pubkey_y: [u8; EcdsaAlgorithm::Bit384.curve_size()],
+    pub cert_size: u32,
+}
+
+#[cfg(feature = "ml-dsa")]
+#[repr(C, align(4))]
+#[derive(Debug, PartialEq, Eq, IntoBytes, TryFromBytes, Immutable, KnownLayout)]
+pub struct CertifyKeyMldsa87RespHdr {
+    pub resp_hdr: ResponseHdr,
+    pub new_context_handle: ContextHandle,
+    pub pubkey: [u8; MldsaAlgorithm::Mldsa87.public_key_size()],
+    pub cert_size: u32,
+}
+
+#[repr(C, align(4))]
+#[derive(Debug, PartialEq, Eq, IntoBytes, TryFromBytes, Immutable, KnownLayout)]
+pub struct DeriveContextExportedCdiRespHdr {
+    pub resp_hdr: ResponseHdr,
+    pub handle: ContextHandle,
+    pub parent_handle: ContextHandle,
+    pub exported_cdi: [u8; MAX_EXPORTED_CDI_SIZE],
+    pub certificate_size: u32,
 }
 
 #[derive(PartialEq, Debug, Eq)]

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -35,6 +35,21 @@ use zerocopy::IntoBytes;
 #[cfg(feature = "ml-dsa")]
 use caliptra_dpe_crypto::ml_dsa::{MldsaPublicKey, MldsaSignature};
 
+/// Signing callback passed to cert and CSR encoding functions.
+///
+/// Arguments: `(buf, range, use_derived)` where `range` is the byte span of
+/// the payload to sign within `buf`, and `use_derived` selects the derived key
+/// (`true`) or the alias key (`false`).
+pub trait SignCallback:
+    FnMut(&dyn ResponseBuffer, core::ops::Range<usize>, bool) -> Result<Signature, CryptoError>
+{
+}
+
+impl<F> SignCallback for F where
+    F: FnMut(&dyn ResponseBuffer, core::ops::Range<usize>, bool) -> Result<Signature, CryptoError>
+{
+}
+
 /// Max amount of backtracks during encoding.
 /// Currently the deepest backtrack path is 7.
 const MAX_BACKTRACKS: usize = 10;
@@ -2149,12 +2164,7 @@ impl CertWriter<'_> {
     #[allow(clippy::identity_op)]
     fn encode_encapsulated_content_info(
         &mut self,
-        sign_cb: &mut (impl FnMut(
-            &dyn ResponseBuffer,
-            core::ops::Range<usize>,
-            bool,
-        ) -> Result<Signature, CryptoError>
-                  + ?Sized),
+        sign_cb: &mut dyn SignCallback,
         pub_key: &PubKey,
         subject_name: &Name,
         measurements: &MeasurementData,
@@ -2303,12 +2313,7 @@ impl CertWriter<'_> {
     #[allow(clippy::too_many_arguments)]
     pub fn encode_certificate(
         &mut self,
-        sign_cb: &mut (impl FnMut(
-            &dyn ResponseBuffer,
-            core::ops::Range<usize>,
-            bool,
-        ) -> Result<Signature, CryptoError>
-                  + ?Sized),
+        sign_cb: &mut dyn SignCallback,
         serial_number: &[u8],
         issuer_name: &[u8],
         subject_name: &Name,
@@ -2345,12 +2350,7 @@ impl CertWriter<'_> {
     #[cfg(any(not(feature = "disable_x509"), not(feature = "disable_csr")))]
     fn encode_signed_payload(
         &mut self,
-        sign_cb: &mut (impl FnMut(
-            &dyn ResponseBuffer,
-            core::ops::Range<usize>,
-            bool,
-        ) -> Result<Signature, CryptoError>
-                  + ?Sized),
+        sign_cb: &mut dyn SignCallback,
         payload: SignedPayload,
     ) -> Result<usize, DpeErrorCode> {
         let mut prefix_bytes_written = self.encode_tag_field(Self::SEQUENCE_TAG);
@@ -2482,12 +2482,7 @@ impl CertWriter<'_> {
     #[cfg(not(feature = "disable_csr"))]
     pub fn encode_csr(
         &mut self,
-        sign_cb: &mut (impl FnMut(
-            &dyn ResponseBuffer,
-            core::ops::Range<usize>,
-            bool,
-        ) -> Result<Signature, CryptoError>
-                  + ?Sized),
+        sign_cb: &mut dyn SignCallback,
         pub_key: &PubKey,
         subject_name: &Name,
         measurements: &MeasurementData,
@@ -2515,12 +2510,7 @@ impl CertWriter<'_> {
     #[allow(clippy::identity_op)]
     pub fn encode_cms(
         &mut self,
-        sign_cb: &mut (impl FnMut(
-            &dyn ResponseBuffer,
-            core::ops::Range<usize>,
-            bool,
-        ) -> Result<Signature, CryptoError>
-                  + ?Sized),
+        sign_cb: &mut dyn SignCallback,
         pub_key: &PubKey,
         subject_name: &Name,
         measurements: &MeasurementData,
@@ -2562,12 +2552,7 @@ impl CertWriter<'_> {
         bytes_written +=
             self.encode_encapsulated_content_info(sign_cb, pub_key, subject_name, measurements)?;
 
-        let (csr_start, csr_end) = {
-            let Some(r) = self.csr_range else {
-                Err(DpeErrorCode::X509CsrUnset)?
-            };
-            r
-        };
+        let (csr_start, csr_end) = self.csr_range.ok_or(DpeErrorCode::X509CsrUnset)?;
         let csr_len = csr_end - csr_start;
 
         let sig = sign_cb(&*self.certificate, (csr_start)..(csr_end), false)?;
@@ -2796,11 +2781,7 @@ fn generate_cert_or_csr(
     subject_name: &Name,
     pub_key: &PubKey,
     measurements: &MeasurementData,
-    sign_cb: &mut dyn FnMut(
-        &dyn ResponseBuffer,
-        core::ops::Range<usize>,
-        bool,
-    ) -> Result<Signature, CryptoError>,
+    sign_cb: &mut dyn SignCallback,
     output_cert_or_csr: &mut dyn ResponseBuffer,
 ) -> Result<u32, DpeErrorCode> {
     match format_specific_args {

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -29,6 +29,7 @@ use caliptra_dpe_platform::{
     ArrayVec, OtherName, PlatformError, SubjectAltName, MAX_ISSUER_NAME_SIZE,
     MAX_KEY_IDENTIFIER_SIZE,
 };
+use caliptra_dpe_response_buffer::ResponseBuffer;
 use zerocopy::IntoBytes;
 
 #[cfg(feature = "ml-dsa")]
@@ -108,7 +109,7 @@ impl<'a> TciNodes<'a> {
         }
     }
 
-    fn iter(&self) -> Result<ChildToRootIter, DpeErrorCode> {
+    fn iter(&self) -> Result<ChildToRootIter<'_>, DpeErrorCode> {
         ChildToRootIter::new(self.start_idx, self.contexts)
     }
 
@@ -139,7 +140,7 @@ pub struct MeasurementData<'a> {
 }
 
 pub struct CertWriter<'a> {
-    certificate: &'a mut [u8],
+    certificate: &'a mut dyn ResponseBuffer,
     profile: DpeProfile,
     offset: usize,
     crit_dice: bool,
@@ -255,7 +256,11 @@ impl CertWriter<'_> {
     ///
     /// If `crit_dice`, all tcg-dice-* extensions will be marked as critical.
     /// Else they will be marked as non-critical.
-    pub fn new(cert: &mut [u8], profile: DpeProfile, crit_dice: bool) -> CertWriter {
+    pub fn new(
+        cert: &mut dyn ResponseBuffer,
+        profile: DpeProfile,
+        crit_dice: bool,
+    ) -> CertWriter<'_> {
         CertWriter {
             certificate: cert,
             profile,
@@ -948,7 +953,7 @@ impl CertWriter<'_> {
     #[cfg(not(feature = "disable_csr"))]
     fn get_signed_data_size(
         &self,
-        csr: &[u8],
+        csr_len: usize,
         sig: &Signature,
         sid: &SignerIdentifier,
         tagged: bool,
@@ -959,7 +964,7 @@ impl CertWriter<'_> {
                 self.get_hash_alg_id_size(/*tagged=*/ true)?,
                 /*tagged=*/ true,
             )
-            + Self::get_encap_content_info_size(csr.len(), /*tagged=*/ true)
+            + Self::get_encap_content_info_size(csr_len, /*tagged=*/ true)
             + Self::get_structure_size(
                 self.get_signer_info_size(sig, sid, /*tagged=*/ true)?,
                 /*tagged=*/ true,
@@ -1097,12 +1102,10 @@ impl CertWriter<'_> {
     /// Write all of `bytes` to the certificate buffer.
     fn encode_bytes(&mut self, bytes: &[u8]) -> usize {
         let size = bytes.len();
-        match self.certificate.get_mut(self.offset..self.offset + size) {
-            Some(s) => s.copy_from_slice(bytes),
-            // Buffer full: skip the write. The overflow is reported by the
-            // post-serialization `check_not_truncated()` in the public encoders.
-            None => {}
-        }
+        // This could error if `write_at` prevents an overwrite and returns an error.  That is
+        // detected by the offset surpassing the certificate length at the end of an encode run,
+        // and thus the error reporting is elided here to save instruction space.
+        let _ = self.certificate.write_at(self.offset, bytes);
 
         // Note: Increment the offset regardless of whether the write occurred to allow detection
         // of encoding overflows.
@@ -1112,12 +1115,10 @@ impl CertWriter<'_> {
 
     /// Write a single `byte` to the certificate buffer.
     fn encode_byte(&mut self, byte: u8) -> usize {
-        match self.certificate.get_mut(self.offset) {
-            Some(b) => *b = byte,
-            // Buffer full: skip the write. The overflow is reported by the
-            // post-serialization `check_not_truncated()` in the public encoders.
-            None => {}
-        }
+        // This could error if `write_at` prevents an overwrite and returns an error.  That is
+        // detected by the offset surpassing the certificate length at the end of an encode run,
+        // and thus the error reporting is elided here to save instruction space.
+        let _ = self.certificate.write_at(self.offset, &[byte]);
 
         // Note: Increment the offset regardless of whether the write occurred to allow detection
         // of encoding overflows.
@@ -1150,9 +1151,10 @@ impl CertWriter<'_> {
     /// past the buffer end means the output was silently truncated. Public
     /// encoders call this before returning so a too-small buffer fails loudly.
     fn check_not_truncated(&self) -> Result<(), DpeErrorCode> {
-        if self.offset > self.certificate.len() {
+        if self.offset > self.certificate.capacity() {
             return Err(InternalErrorCode::CertSizeOverflow.into());
         }
+
         Ok(())
     }
 
@@ -2147,7 +2149,12 @@ impl CertWriter<'_> {
     #[allow(clippy::identity_op)]
     fn encode_encapsulated_content_info(
         &mut self,
-        sign_cb: &mut (impl FnMut(&[u8], bool) -> Result<Signature, CryptoError> + ?Sized),
+        sign_cb: &mut (impl FnMut(
+            &dyn ResponseBuffer,
+            core::ops::Range<usize>,
+            bool,
+        ) -> Result<Signature, CryptoError>
+                  + ?Sized),
         pub_key: &PubKey,
         subject_name: &Name,
         measurements: &MeasurementData,
@@ -2296,7 +2303,12 @@ impl CertWriter<'_> {
     #[allow(clippy::too_many_arguments)]
     pub fn encode_certificate(
         &mut self,
-        sign_cb: &mut (impl FnMut(&[u8], bool) -> Result<Signature, CryptoError> + ?Sized),
+        sign_cb: &mut (impl FnMut(
+            &dyn ResponseBuffer,
+            core::ops::Range<usize>,
+            bool,
+        ) -> Result<Signature, CryptoError>
+                  + ?Sized),
         serial_number: &[u8],
         issuer_name: &[u8],
         subject_name: &Name,
@@ -2325,7 +2337,7 @@ impl CertWriter<'_> {
     /// both an X.509 `Certificate` (TBSCertificate + signature) and a PKCS #10
     /// `CertificateRequest` (CertificationRequestInfo + signature).
     ///
-    /// The payload is encoded first, signed via `sign_cb`, and the signature
+    /// The payload is encoded, signed via `sign_cb`, and the signature
     /// appended; the outer SEQUENCE length is backfilled once both sizes are
     /// known.
     ///
@@ -2333,14 +2345,17 @@ impl CertWriter<'_> {
     #[cfg(any(not(feature = "disable_x509"), not(feature = "disable_csr")))]
     fn encode_signed_payload(
         &mut self,
-        sign_cb: &mut (impl FnMut(&[u8], bool) -> Result<Signature, CryptoError> + ?Sized),
+        sign_cb: &mut (impl FnMut(
+            &dyn ResponseBuffer,
+            core::ops::Range<usize>,
+            bool,
+        ) -> Result<Signature, CryptoError>
+                  + ?Sized),
         payload: SignedPayload,
     ) -> Result<usize, DpeErrorCode> {
         let mut prefix_bytes_written = self.encode_tag_field(Self::SEQUENCE_TAG);
         let offset = self.push_backtrack(SIZE_TAG_OFFSET)?;
 
-        // Encode the payload. `is_csr` selects the domain separation passed to
-        // the signing callback (PKCS #10 requests are signed differently).
         let (payload_bytes_written, is_csr) = match payload {
             #[cfg(not(feature = "disable_x509"))]
             SignedPayload::Tbs {
@@ -2373,11 +2388,9 @@ impl CertWriter<'_> {
         };
 
         let sig = {
-            let signed = self
-                .certificate
-                .get(offset..payload_bytes_written + offset)
-                .ok_or(DpeErrorCode::from(InternalErrorCode::TbsSliceOob))?;
-            sign_cb(signed, is_csr)
+            let abs_start = offset;
+            let abs_end = offset + payload_bytes_written;
+            sign_cb(&*self.certificate, abs_start..abs_end, is_csr)
         };
         let sig = okref(&sig)?;
 
@@ -2469,7 +2482,12 @@ impl CertWriter<'_> {
     #[cfg(not(feature = "disable_csr"))]
     pub fn encode_csr(
         &mut self,
-        sign_cb: &mut (impl FnMut(&[u8], bool) -> Result<Signature, CryptoError> + ?Sized),
+        sign_cb: &mut (impl FnMut(
+            &dyn ResponseBuffer,
+            core::ops::Range<usize>,
+            bool,
+        ) -> Result<Signature, CryptoError>
+                  + ?Sized),
         pub_key: &PubKey,
         subject_name: &Name,
         measurements: &MeasurementData,
@@ -2497,7 +2515,12 @@ impl CertWriter<'_> {
     #[allow(clippy::identity_op)]
     pub fn encode_cms(
         &mut self,
-        sign_cb: &mut (impl FnMut(&[u8], bool) -> Result<Signature, CryptoError> + ?Sized),
+        sign_cb: &mut (impl FnMut(
+            &dyn ResponseBuffer,
+            core::ops::Range<usize>,
+            bool,
+        ) -> Result<Signature, CryptoError>
+                  + ?Sized),
         pub_key: &PubKey,
         subject_name: &Name,
         measurements: &MeasurementData,
@@ -2539,23 +2562,22 @@ impl CertWriter<'_> {
         bytes_written +=
             self.encode_encapsulated_content_info(sign_cb, pub_key, subject_name, measurements)?;
 
-        let csr = {
-            let Some(csr_range) = self.csr_range else {
+        let (csr_start, csr_end) = {
+            let Some(r) = self.csr_range else {
                 Err(DpeErrorCode::X509CsrUnset)?
             };
-            self.certificate
-                .get(csr_range.0..csr_range.1)
-                .ok_or(DpeErrorCode::from(InternalErrorCode::CmsCsrRangeOob))?
+            r
         };
+        let csr_len = csr_end - csr_start;
 
-        let sig = sign_cb(csr, false)?;
+        let sig = sign_cb(&*self.certificate, (csr_start)..(csr_end), false)?;
 
         let signed_data_field_0 = self.get_signed_data_size(
-            csr, &sig, sid, /*tagged=*/ true, /*explicit=*/ false,
+            csr_len, &sig, sid, /*tagged=*/ true, /*explicit=*/ false,
         )?;
 
         let signed_data_field_1 = self.get_signed_data_size(
-            csr, &sig, sid, /*tagged=*/ false, /*explicit=*/ false,
+            csr_len, &sig, sid, /*tagged=*/ false, /*explicit=*/ false,
         )?;
 
         // signerInfos
@@ -2687,7 +2709,7 @@ pub(crate) fn create_exported_dpe_cert(
     args: &CreateDpeCertArgs,
     dpe: &mut DpeInstance,
     env: &mut dyn DpeEnv,
-    cert: &mut [u8],
+    cert: &mut dyn ResponseBuffer,
 ) -> Result<CreateDpeCertResult, DpeErrorCode> {
     create_dpe_cert_or_csr(
         args,
@@ -2703,7 +2725,7 @@ pub(crate) fn create_dpe_cert(
     args: &CreateDpeCertArgs,
     dpe: &mut DpeInstance,
     env: &mut dyn DpeEnv,
-    cert: &mut [u8],
+    cert: &mut dyn ResponseBuffer,
 ) -> Result<CreateDpeCertResult, DpeErrorCode> {
     create_dpe_cert_or_csr(
         args,
@@ -2720,7 +2742,7 @@ pub(crate) fn create_dpe_csr(
     args: &CreateDpeCertArgs,
     dpe: &mut DpeInstance,
     env: &mut dyn DpeEnv,
-    csr: &mut [u8],
+    csr: &mut dyn ResponseBuffer,
 ) -> Result<CreateDpeCertResult, DpeErrorCode> {
     create_dpe_cert_or_csr(
         args,
@@ -2734,7 +2756,7 @@ pub(crate) fn create_dpe_csr(
 
 /// The signed payload variants handled by [`CertWriter::encode_signed_payload`]:
 /// an X.509 TBSCertificate or a PKCS #10 CertificationRequestInfo.
-enum SignedPayload<'a> {
+pub(crate) enum SignedPayload<'a> {
     #[cfg(not(feature = "disable_x509"))]
     Tbs {
         serial_number: &'a [u8],
@@ -2774,8 +2796,12 @@ fn generate_cert_or_csr(
     subject_name: &Name,
     pub_key: &PubKey,
     measurements: &MeasurementData,
-    sign_cb: &mut dyn FnMut(&[u8], bool) -> Result<Signature, CryptoError>,
-    output_cert_or_csr: &mut [u8],
+    sign_cb: &mut dyn FnMut(
+        &dyn ResponseBuffer,
+        core::ops::Range<usize>,
+        bool,
+    ) -> Result<Signature, CryptoError>,
+    output_cert_or_csr: &mut dyn ResponseBuffer,
 ) -> Result<u32, DpeErrorCode> {
     match format_specific_args {
         CertOrCsrArgs::Cert {
@@ -2834,7 +2860,7 @@ fn create_dpe_cert_or_csr(
     env: &mut dyn DpeEnv,
     cert_format: CertificateFormat,
     cert_type: CertificateType,
-    output_cert_or_csr: &mut [u8],
+    output_cert_or_csr: &mut dyn ResponseBuffer,
 ) -> Result<CreateDpeCertResult, DpeErrorCode> {
     let digest = get_dpe_measurement_digest(dpe, env, args.handle, args.locality)?;
     let (crypto, platform, state) = env.get();
@@ -2899,7 +2925,9 @@ fn create_dpe_cert_or_csr(
         subject_alt_name,
     };
 
-    let mut sign_cb = |data: &[u8], use_derived: bool| {
+    let mut sign_cb = |buf: &dyn ResponseBuffer,
+                       range: core::ops::Range<usize>,
+                       use_derived: bool| {
         if use_derived {
             match cert_type {
                 CertificateType::Exported => {
@@ -2907,18 +2935,18 @@ fn create_dpe_cert_or_csr(
                         exported_cdi_handle.ok_or(CryptoError::CryptoLibError(0))?;
                     crypto
                         .derive_key_pair_exported(&exported_handle, args.key_label, args.context)?
-                        .sign(&SignData::Raw(data))
+                        .sign(&SignData::ResponseBuffer(buf, range))
                 }
                 CertificateType::Leaf => crypto.sign_with_derived(
                     &digest,
                     args.cdi_label,
                     args.key_label,
                     args.context,
-                    &SignData::Raw(data),
+                    &SignData::ResponseBuffer(buf, range),
                 ),
             }
         } else {
-            crypto.sign_with_alias(&SignData::Raw(data))
+            crypto.sign_with_alias(&SignData::ResponseBuffer(buf, range))
         }
     };
 
@@ -2990,6 +3018,7 @@ pub(crate) mod tests {
         ArrayVec, CertValidity, OtherName, SignerIdentifier, SubjectAltName,
         MAX_KEY_IDENTIFIER_SIZE, MAX_OTHER_NAME_SIZE, MAX_SN_SIZE, MAX_UEID_SIZE,
     };
+    use caliptra_dpe_response_buffer::{ResponseBuffer, SliceResponseBuffer};
     #[cfg(not(feature = "disable_csr"))]
     use cms::content_info::CmsVersion;
     #[cfg(not(feature = "disable_csr"))]
@@ -3069,7 +3098,8 @@ pub(crate) mod tests {
 
         for c in buffer_cases {
             let mut cert = [0u8; 128];
-            let mut w = CertWriter::new(&mut cert, DPE_PROFILE, true);
+            let mut cert_buf = SliceResponseBuffer::new(&mut cert);
+            let mut w = CertWriter::new(&mut cert_buf, DPE_PROFILE, true);
             let byte_count = w.encode_integer_bytes(&c, true);
             let n = asn1::parse_single::<u64>(&cert[..byte_count]).unwrap();
             assert_eq!(n, u64::from_be_bytes(c));
@@ -3079,8 +3109,9 @@ pub(crate) mod tests {
         let integer_cases = [0xFFFFFFFF00000000, 0x0102030405060708, 0x2];
 
         for c in integer_cases {
-            let mut cert = [0; 128];
-            let mut w = CertWriter::new(&mut cert, DPE_PROFILE, true);
+            let mut cert = [0u8; 128];
+            let mut cert_buf = SliceResponseBuffer::new(&mut cert);
+            let mut w = CertWriter::new(&mut cert_buf, DPE_PROFILE, true);
             let byte_count = w.encode_integer(c, true);
             let n = asn1::parse_single::<u64>(&cert[..byte_count]).unwrap();
             assert_eq!(n, c);
@@ -3096,7 +3127,8 @@ pub(crate) mod tests {
             serial: DirectoryString::PrintableString(&[0x0u8; DPE_PROFILE.hash_size() * 2]),
         };
 
-        let mut w = CertWriter::new(&mut cert, DPE_PROFILE, true);
+        let mut cert_buf = SliceResponseBuffer::new(&mut cert);
+        let mut w = CertWriter::new(&mut cert_buf, DPE_PROFILE, true);
         let bytes_written = w.encode_rdn(&test_name).unwrap();
 
         let name = match X509Name::from_der(&cert[..bytes_written]) {
@@ -3128,12 +3160,17 @@ pub(crate) mod tests {
         F: FnMut(&mut CertWriter) -> Result<usize, DpeErrorCode>,
     {
         let mut big = vec![0u8; 16384];
-        let exact = encode(&mut CertWriter::new(&mut big, DPE_PROFILE, true))
+        let mut sbuf = SliceResponseBuffer::new(&mut big);
+        let exact = encode(&mut CertWriter::new(&mut sbuf, DPE_PROFILE, true))
             .expect("encoding into a large buffer should succeed");
 
         let mut buf = vec![0u8; exact];
         assert_eq!(
-            encode(&mut CertWriter::new(&mut buf, DPE_PROFILE, true)),
+            encode(&mut CertWriter::new(
+                &mut SliceResponseBuffer::new(&mut buf),
+                DPE_PROFILE,
+                true
+            )),
             Ok(exact),
             "exact-fit buffer ({exact}) should succeed",
         );
@@ -3146,7 +3183,11 @@ pub(crate) mod tests {
             let mut backing = vec![CANARY; len + CANARY_LEN];
             let (writable, canary) = backing.split_at_mut(len);
             assert_eq!(
-                encode(&mut CertWriter::new(writable, DPE_PROFILE, true)),
+                encode(&mut CertWriter::new(
+                    &mut SliceResponseBuffer::new(writable),
+                    DPE_PROFILE,
+                    true
+                )),
                 Err(DpeErrorCode::InternalError(
                     InternalErrorCode::CertSizeOverflow
                 )),
@@ -3165,7 +3206,8 @@ pub(crate) mod tests {
     fn test_pub_fn_buffer_overflow_is_detected() {
         // ----- shared inputs (mirror build_test_cert_*) -----
         let mut issuer_der = [0u8; 1024];
-        let issuer_len = CertWriter::new(&mut issuer_der, DPE_PROFILE, true)
+        let mut ibuf = SliceResponseBuffer::new(&mut issuer_der);
+        let issuer_len = CertWriter::new(&mut ibuf, DPE_PROFILE, true)
             .encode_rdn(&TEST_ISSUER_NAME)
             .unwrap();
         let issuer = &issuer_der[..issuer_len];
@@ -3240,7 +3282,9 @@ pub(crate) mod tests {
             )
         };
 
-        let mut sign_cb = |_data: &[u8], _use_derived: bool| Ok(test_sig.clone());
+        let mut sign_cb = |_buf: &dyn ResponseBuffer,
+                           _range: core::ops::Range<usize>,
+                           _use_derived: bool| Ok(test_sig.clone());
 
         // SubjectKeyIdentifier keeps the SignerIdentifier setup simple.
         let mut ski = ArrayVec::new();
@@ -3294,13 +3338,16 @@ pub(crate) mod tests {
         let mut cert = [0u8; 384];
         let test_key = EcdsaPubKey::Ecdsa384(EcdsaPub::default());
 
-        let mut w = CertWriter::new(&mut cert, DPE_PROFILE, true);
+        let mut cert_buf = SliceResponseBuffer::new(&mut cert);
+        let mut w = CertWriter::new(&mut cert_buf, DPE_PROFILE, true);
         let bytes_written = w.encode_ecdsa_subject_pubkey_info(&test_key).unwrap();
 
         SubjectPublicKeyInfo::from_der(&cert[..bytes_written]).unwrap();
 
+        let mut empty: [u8; 0] = [];
+        let mut ebuf = SliceResponseBuffer::new(&mut empty);
         assert_eq!(
-            CertWriter::new(&mut [], DPE_PROFILE, true)
+            CertWriter::new(&mut ebuf, DPE_PROFILE, true)
                 .get_ecdsa_subject_pubkey_info_size(&test_key, true)
                 .unwrap(),
             bytes_written
@@ -3313,13 +3360,16 @@ pub(crate) mod tests {
         let mut cert = [0u8; 4096];
         let test_key = MldsaPublicKey([0; MldsaAlgorithm::Mldsa87.public_key_size()]);
 
-        let mut w = CertWriter::new(&mut cert, DPE_PROFILE, true);
+        let mut cert_buf = SliceResponseBuffer::new(&mut cert);
+        let mut w = CertWriter::new(&mut cert_buf, DPE_PROFILE, true);
         let bytes_written = w.encode_mldsa_subject_pubkey_info(&test_key).unwrap();
 
         SubjectPublicKeyInfo::from_der(&cert[..bytes_written]).unwrap();
 
+        let mut empty: [u8; 0] = [];
+        let mut ebuf = SliceResponseBuffer::new(&mut empty);
         assert_eq!(
-            CertWriter::new(&mut [], DPE_PROFILE, true)
+            CertWriter::new(&mut ebuf, DPE_PROFILE, true)
                 .get_mldsa_subject_pubkey_info_size(&test_key, true)
                 .unwrap(),
             bytes_written
@@ -3337,11 +3387,13 @@ pub(crate) mod tests {
         node.svn = 0xFFFFFFFF;
 
         let mut cert = [0u8; 256];
-        let mut w = CertWriter::new(&mut cert, DPE_PROFILE, true);
         let mut supports_recursive = true;
+        let mut cert_buf = SliceResponseBuffer::new(&mut cert);
+        let mut w = CertWriter::new(&mut cert_buf, DPE_PROFILE, true);
         let mut bytes_written = w.encode_tcb_info(&node, supports_recursive).unwrap();
-
-        let checker = CertWriter::new(&mut [], DPE_PROFILE, true);
+        let mut empty: [u8; 0] = [];
+        let mut ebuf = SliceResponseBuffer::new(&mut empty);
+        let checker = CertWriter::new(&mut ebuf, DPE_PROFILE, true);
         let mut parsed_tcb_info = asn1::parse_single::<TcbInfo>(&cert[..bytes_written]).unwrap();
 
         assert_eq!(
@@ -3373,7 +3425,8 @@ pub(crate) mod tests {
 
         // test tbs_info with supports_recursive = false
         supports_recursive = false;
-        w = CertWriter::new(&mut cert, DPE_PROFILE, true);
+        let mut cert_buf = SliceResponseBuffer::new(&mut cert);
+        let mut w = CertWriter::new(&mut cert_buf, DPE_PROFILE, true);
         bytes_written = w.encode_tcb_info(&node, supports_recursive).unwrap();
 
         parsed_tcb_info = asn1::parse_single::<TcbInfo>(&cert[..bytes_written]).unwrap();
@@ -3394,7 +3447,8 @@ pub(crate) mod tests {
 
     fn get_key_usage(is_ca: bool) -> KeyUsage {
         let mut cert = [0u8; 32];
-        let mut w = CertWriter::new(&mut cert, DPE_PROFILE, true);
+        let mut cert_buf = SliceResponseBuffer::new(&mut cert);
+        let mut w = CertWriter::new(&mut cert_buf, DPE_PROFILE, true);
         let bytes_written = w.encode_key_usage(is_ca);
         assert_eq!(
             bytes_written,
@@ -3438,7 +3492,8 @@ pub(crate) mod tests {
     #[cfg(not(feature = "ml-dsa"))]
     fn build_test_cert_ecdsa(is_ca: bool, cert_buf: &mut [u8]) -> (usize, X509Certificate<'_>) {
         let mut issuer_der = [0u8; 1024];
-        let mut issuer_writer = CertWriter::new(&mut issuer_der, DPE_PROFILE, true);
+        let mut ibuf = SliceResponseBuffer::new(&mut issuer_der);
+        let mut issuer_writer = CertWriter::new(&mut ibuf, DPE_PROFILE, true);
         let issuer_len = issuer_writer.encode_rdn(&TEST_ISSUER_NAME).unwrap();
 
         let test_pub = EcdsaPub::from_slice(&[0xAA; ECC_INT_SIZE], &[0xBB; ECC_INT_SIZE]);
@@ -3519,9 +3574,12 @@ pub(crate) mod tests {
             _ => panic!("Missing signature"),
         };
 
-        let mut sign_cb = |_data: &[u8], _use_derived: bool| Ok(test_sig.clone());
+        let mut sign_cb = |_buf: &dyn ResponseBuffer,
+                           _range: core::ops::Range<usize>,
+                           _use_derived: bool| Ok(test_sig.clone());
 
-        let mut w = CertWriter::new(cert_buf, DPE_PROFILE, true);
+        let mut cbuf = SliceResponseBuffer::new(cert_buf);
+        let mut w = CertWriter::new(&mut cbuf, DPE_PROFILE, true);
         let bytes_written = w
             .encode_certificate(
                 &mut sign_cb,
@@ -3557,7 +3615,8 @@ pub(crate) mod tests {
     #[cfg(feature = "ml-dsa")]
     fn build_test_cert_mldsa(is_ca: bool, cert_buf: &mut [u8]) -> (usize, X509Certificate<'_>) {
         let mut issuer_der = [0u8; 1024];
-        let mut issuer_writer = CertWriter::new(&mut issuer_der, DPE_PROFILE, true);
+        let mut ibuf = SliceResponseBuffer::new(&mut issuer_der);
+        let mut issuer_writer = CertWriter::new(&mut ibuf, DPE_PROFILE, true);
         let issuer_len = issuer_writer.encode_rdn(&TEST_ISSUER_NAME).unwrap();
 
         const ALGORITHM: MldsaAlgorithm = match DPE_PROFILE.alg() {
@@ -3626,9 +3685,12 @@ pub(crate) mod tests {
             _ => panic!("Missing signature"),
         };
 
-        let mut sign_cb = |_data: &[u8], _use_derived: bool| Ok(test_sig.clone());
+        let mut sign_cb = |_buf: &dyn ResponseBuffer,
+                           _range: core::ops::Range<usize>,
+                           _use_derived: bool| Ok(test_sig.clone());
 
-        let mut w = CertWriter::new(cert_buf, DPE_PROFILE, true);
+        let mut cbuf = SliceResponseBuffer::new(cert_buf);
+        let mut w = CertWriter::new(&mut cbuf, DPE_PROFILE, true);
         let bytes_written = w
             .encode_certificate(
                 &mut sign_cb,
@@ -3861,7 +3923,8 @@ pub(crate) mod tests {
         let measurements = build_test_measurements(&contexts, true);
 
         let mut buf = [0u8; 1024];
-        let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
+        let mut sbuf = SliceResponseBuffer::new(&mut buf);
+        let mut w = CertWriter::new(&mut sbuf, DPE_PROFILE, true);
         let n = w.encode_multi_tcb_info(&measurements).unwrap();
 
         let expected: &[u8] = match DPE_PROFILE {
@@ -3944,7 +4007,8 @@ pub(crate) mod tests {
         let measurements = build_test_measurements(&contexts, true);
 
         let mut buf = [0u8; 1024];
-        let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
+        let mut sbuf = SliceResponseBuffer::new(&mut buf);
+        let mut w = CertWriter::new(&mut sbuf, DPE_PROFILE, true);
         let n = w.encode_ueid(&measurements);
 
         let expected: &[u8] = &[
@@ -3965,7 +4029,8 @@ pub(crate) mod tests {
         let measurements = build_test_measurements(&contexts, true);
 
         let mut buf = [0u8; 1024];
-        let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
+        let mut sbuf = SliceResponseBuffer::new(&mut buf);
+        let mut w = CertWriter::new(&mut sbuf, DPE_PROFILE, true);
         let n = w.encode_basic_constraints(&measurements);
 
         let expected: &[u8] = &[
@@ -3982,7 +4047,8 @@ pub(crate) mod tests {
     #[test]
     fn test_encode_key_usage_bytes() {
         let mut buf = [0u8; 1024];
-        let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
+        let mut sbuf = SliceResponseBuffer::new(&mut buf);
+        let mut w = CertWriter::new(&mut sbuf, DPE_PROFILE, true);
         let n = w.encode_key_usage(true);
 
         let expected: &[u8] = &[
@@ -4002,7 +4068,8 @@ pub(crate) mod tests {
         let measurements = build_test_measurements(&contexts, true);
 
         let mut buf = [0u8; 1024];
-        let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
+        let mut sbuf = SliceResponseBuffer::new(&mut buf);
+        let mut w = CertWriter::new(&mut sbuf, DPE_PROFILE, true);
         let n = w.encode_extended_key_usage(&measurements);
 
         let expected: &[u8] = &[
@@ -4031,7 +4098,8 @@ pub(crate) mod tests {
         measurements.subject_alt_name = Some(san);
 
         let mut buf = [0u8; 1024];
-        let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
+        let mut sbuf = SliceResponseBuffer::new(&mut buf);
+        let mut w = CertWriter::new(&mut sbuf, DPE_PROFILE, true);
         let n = w.encode_subject_alt_name_extension(&measurements);
 
         let expected: &[u8] = &[
@@ -4053,7 +4121,8 @@ pub(crate) mod tests {
         let measurements = build_test_measurements(&contexts, true);
 
         let mut buf = [0u8; 1024];
-        let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
+        let mut sbuf = SliceResponseBuffer::new(&mut buf);
+        let mut w = CertWriter::new(&mut sbuf, DPE_PROFILE, true);
         let n = w.encode_authority_key_identifier_extension(&measurements, true);
 
         let expected: &[u8] = &[
@@ -4076,7 +4145,8 @@ pub(crate) mod tests {
         let measurements = build_test_measurements(&contexts, true);
 
         let mut buf = [0u8; 1024];
-        let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
+        let mut sbuf = SliceResponseBuffer::new(&mut buf);
+        let mut w = CertWriter::new(&mut sbuf, DPE_PROFILE, true);
         let n = w.encode_subject_key_identifier_extension(&measurements, true);
 
         let expected: &[u8] = &[
@@ -4095,7 +4165,8 @@ pub(crate) mod tests {
     #[cfg(not(feature = "ml-dsa"))]
     fn test_encode_cms_rejects_unresolved_backtrack() {
         let mut buf = [0u8; 4096];
-        let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
+        let mut sbuf = SliceResponseBuffer::new(&mut buf);
+        let mut w = CertWriter::new(&mut sbuf, DPE_PROFILE, true);
 
         // Pre-push one extra backtrack to simulate a push/pop imbalance.
         // encode_cms pushes 3 and pops 3; this extra entry survives those
@@ -4126,7 +4197,9 @@ pub(crate) mod tests {
             ),
             _ => panic!("unsupported algorithm"),
         };
-        let mut sign_cb = |_data: &[u8], _use_derived: bool| Ok(test_sig.clone());
+        let mut sign_cb = |_buf: &dyn ResponseBuffer,
+                           _range: core::ops::Range<usize>,
+                           _use_derived: bool| Ok(test_sig.clone());
 
         let context = Context {
             state: ContextState::Active,
@@ -4192,7 +4265,8 @@ pub(crate) mod tests {
             serial: DirectoryString::PrintableString(&sn),
         };
         let mut buf = vec![0u8; 1024];
-        let n = CertWriter::new(&mut buf, DPE_PROFILE, true)
+        let mut sbuf = SliceResponseBuffer::new(&mut buf);
+        let n = CertWriter::new(&mut sbuf, DPE_PROFILE, true)
             .encode_rdn(&name)
             .unwrap();
         buf.truncate(n);
@@ -4287,7 +4361,8 @@ pub(crate) mod tests {
         let validity = make_validity(max_size);
 
         let mut buf = vec![0u8; 65536];
-        let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
+        let mut sbuf = SliceResponseBuffer::new(&mut buf);
+        let mut w = CertWriter::new(&mut sbuf, DPE_PROFILE, true);
         let n = w
             .encode_tbs(
                 &serial,
@@ -4398,7 +4473,8 @@ pub(crate) mod tests {
         let validity = make_validity(max_size);
 
         let mut buf = vec![0u8; 65536];
-        let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
+        let mut sbuf = SliceResponseBuffer::new(&mut buf);
+        let mut w = CertWriter::new(&mut sbuf, DPE_PROFILE, true);
         let n = w
             .encode_tbs(
                 &serial,
@@ -4509,7 +4585,8 @@ pub(crate) mod tests {
         };
 
         let mut buf = vec![0u8; 65536];
-        let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
+        let mut sbuf = SliceResponseBuffer::new(&mut buf);
+        let mut w = CertWriter::new(&mut sbuf, DPE_PROFILE, true);
         let n = w
             .encode_certification_request_info(&pub_key, &TEST_SUBJECT_NAME, &measurements)
             .unwrap();
@@ -4603,7 +4680,8 @@ pub(crate) mod tests {
         };
 
         let mut buf = vec![0u8; 65536];
-        let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
+        let mut sbuf = SliceResponseBuffer::new(&mut buf);
+        let mut w = CertWriter::new(&mut sbuf, DPE_PROFILE, true);
         let n = w
             .encode_certification_request_info(&pub_key, &TEST_SUBJECT_NAME, &measurements)
             .unwrap();
@@ -4661,7 +4739,9 @@ pub(crate) mod tests {
             ),
             _ => panic!("not an ECDSA profile"),
         };
-        let mut sign_cb = |_data: &[u8], _use_derived: bool| Ok(test_sig.clone());
+        let mut sign_cb = |_buf: &dyn ResponseBuffer,
+                           _range: core::ops::Range<usize>,
+                           _use_derived: bool| Ok(test_sig.clone());
 
         let label_bytes: Vec<u8> = if max_size {
             vec![0xAB; MAX_UEID_SIZE]
@@ -4694,7 +4774,8 @@ pub(crate) mod tests {
         };
 
         let mut buf = vec![0u8; 65536];
-        let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
+        let mut sbuf = SliceResponseBuffer::new(&mut buf);
+        let mut w = CertWriter::new(&mut sbuf, DPE_PROFILE, true);
         let n = w
             .encode_csr(&mut sign_cb, &pub_key, &TEST_SUBJECT_NAME, &measurements)
             .unwrap();
@@ -4760,7 +4841,9 @@ pub(crate) mod tests {
         let test_pub = MldsaPublicKey::from_slice(&[0xAAu8; ALGORITHM.public_key_size()]);
         let pub_key = PubKey::Mldsa(test_pub);
         let test_sig = Signature::Mldsa(MldsaSignature([0xBBu8; ALGORITHM.signature_size()]));
-        let mut sign_cb = |_data: &[u8], _use_derived: bool| Ok(test_sig.clone());
+        let mut sign_cb = |_buf: &dyn ResponseBuffer,
+                           _range: core::ops::Range<usize>,
+                           _use_derived: bool| Ok(test_sig.clone());
 
         let label_bytes: Vec<u8> = if max_size {
             vec![0xAB; MAX_UEID_SIZE]
@@ -4793,7 +4876,8 @@ pub(crate) mod tests {
         };
 
         let mut buf = vec![0u8; 65536];
-        let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
+        let mut sbuf = SliceResponseBuffer::new(&mut buf);
+        let mut w = CertWriter::new(&mut sbuf, DPE_PROFILE, true);
         let n = w
             .encode_csr(&mut sign_cb, &pub_key, &TEST_SUBJECT_NAME, &measurements)
             .unwrap();
@@ -4875,7 +4959,8 @@ pub(crate) mod tests {
         };
 
         let mut buf = vec![0u8; 65536];
-        let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
+        let mut sbuf = SliceResponseBuffer::new(&mut buf);
+        let mut w = CertWriter::new(&mut sbuf, DPE_PROFILE, true);
         let n = w.encode_signer_info(&test_sig, &sid_isn).unwrap();
 
         let si = CmsSignerInfo::from_der(&buf[..n])
@@ -4917,7 +5002,8 @@ pub(crate) mod tests {
         let sid_ski = SignerIdentifier::SubjectKeyIdentifier(ski_av);
 
         let mut buf2 = vec![0u8; 65536];
-        let mut w2 = CertWriter::new(&mut buf2, DPE_PROFILE, true);
+        let mut sbuf2 = SliceResponseBuffer::new(&mut buf2);
+        let mut w2 = CertWriter::new(&mut sbuf2, DPE_PROFILE, true);
         let n2 = w2.encode_signer_info(&test_sig, &sid_ski).unwrap();
 
         let si2 = CmsSignerInfo::from_der(&buf2[..n2])
@@ -4988,7 +5074,8 @@ pub(crate) mod tests {
         };
 
         let mut buf = vec![0u8; 1_048_576]; // MLDSA sig is large
-        let mut w = CertWriter::new(&mut buf, DPE_PROFILE, true);
+        let mut sbuf = SliceResponseBuffer::new(&mut buf);
+        let mut w = CertWriter::new(&mut sbuf, DPE_PROFILE, true);
         let n = w.encode_signer_info(&test_sig, &sid_isn).unwrap();
 
         let si = CmsSignerInfo::from_der(&buf[..n])
@@ -5020,7 +5107,8 @@ pub(crate) mod tests {
         let sid_ski = SignerIdentifier::SubjectKeyIdentifier(ski_av);
 
         let mut buf2 = vec![0u8; 1_048_576];
-        let mut w2 = CertWriter::new(&mut buf2, DPE_PROFILE, true);
+        let mut sbuf2 = SliceResponseBuffer::new(&mut buf2);
+        let mut w2 = CertWriter::new(&mut sbuf2, DPE_PROFILE, true);
         let n2 = w2.encode_signer_info(&test_sig, &sid_ski).unwrap();
 
         let si2 = CmsSignerInfo::from_der(&buf2[..n2])

--- a/response-buffer/src/lib.rs
+++ b/response-buffer/src/lib.rs
@@ -103,7 +103,7 @@ impl<'a> SliceResponseBuffer<'a> {
     }
 }
 
-impl<'a> ResponseBuffer for SliceResponseBuffer<'a> {
+impl ResponseBuffer for SliceResponseBuffer<'_> {
     fn clear(&mut self) -> Result<(), ResponseBufError> {
         self.buf.fill(0);
         Ok(())

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -72,7 +72,7 @@ fn handle_request(dpe: &mut DpeInstance, env: &mut dyn DpeEnv, stream: &mut Unix
         Response::GetProfile(ref res) => res.resp_hdr.status,
         Response::InitCtx(ref res) => res.resp_hdr.status,
         Response::DeriveContext(ref res) => res.resp_hdr.status,
-        Response::DeriveContextExportedCdi(ref res) => res.resp_hdr.status,
+        Response::DeriveContextExportedCdi(ref res) => res.header.resp_hdr.status,
         Response::RotateCtx(ref res) => res.resp_hdr.status,
         Response::CertifyKey(ref res) => res.resp_hdr().status,
         Response::Sign(ref res) => res.resp_hdr().status,


### PR DESCRIPTION
Instead of having the DPE write directly into a u8 slice, abstract the access over a `ResponseBuffer`.  This allows the use of hardware buffers, like the MBOX SRAM, which have additional constraints like word aligned access.

This allows an optimization of the `caliptra-1.x` which saves significant Stack utilization allowing for the use of MLDSA libraries with in DPE invocations. 