### PR TITLE
fix clippy linting issues

### DIFF
--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -413,6 +413,7 @@ impl CertifyKeyResponseHeader {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
     #[cfg(all(feature = "ml-dsa", not(feature = "p384"), not(feature = "p256")))]
@@ -937,7 +938,7 @@ mod tests {
         // Verify we have MAX_HANDLES TCB infos
         for _ in 0..MAX_HANDLES {
             let tcb_info = parsed_tcb_infos.next().unwrap();
-            assert_eq!(tcb_info.tci_type.unwrap(), &(0 as u32).to_le_bytes());
+            assert_eq!(tcb_info.tci_type.unwrap(), &0_u32.to_le_bytes());
         }
         assert!(parsed_tcb_infos.next().is_none());
     }

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -524,6 +524,7 @@ impl Default for DeriveContextCmd {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
     #[cfg(feature = "p256")]
@@ -880,7 +881,7 @@ mod tests {
                 Response::CertifyKey(resp) => resp,
                 _ => panic!("Incorrect response type"),
             };
-            let x509 = X509::from_der(&certify_resp.cert().unwrap()).unwrap();
+            let x509 = X509::from_der(certify_resp.cert().unwrap()).unwrap();
             x509.public_key().unwrap().ec_key().unwrap()
         };
         #[cfg(feature = "ml-dsa")]
@@ -1533,9 +1534,7 @@ mod tests {
                 .count(),
             env.state.contexts.len()
         );
-        let validator = DpeValidator {
-            dpe: &mut env.state,
-        };
+        let validator = DpeValidator { dpe: env.state };
         assert!(validator.validate_dpe().is_ok());
     }
 
@@ -1564,9 +1563,7 @@ mod tests {
             panic!("expected to get a valid DeriveContextExportedCdi response.");
         };
 
-        let validator = DpeValidator {
-            dpe: &mut env.state,
-        };
+        let validator = DpeValidator { dpe: env.state };
         assert!(validator.validate_dpe().is_ok());
 
         // Parent is still valid.
@@ -1676,9 +1673,7 @@ mod tests {
         assert_eq!(env.state.contexts[root_idx].state, ContextState::Active);
         assert_eq!(env.state.contexts[root_idx].handle, parent_handle);
 
-        let validator = DpeValidator {
-            dpe: &mut env.state,
-        };
+        let validator = DpeValidator { dpe: env.state };
         assert!(validator.validate_dpe().is_ok());
     }
 
@@ -1764,9 +1759,7 @@ mod tests {
             ContextHandle::new_invalid()
         );
 
-        let validator = DpeValidator {
-            dpe: &mut env.state,
-        };
+        let validator = DpeValidator { dpe: env.state };
         assert!(validator.validate_dpe().is_ok());
     }
 

--- a/dpe/src/commands/destroy_context.rs
+++ b/dpe/src/commands/destroy_context.rs
@@ -105,6 +105,7 @@ impl CommandExecution for DestroyCtxCmd {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
     use crate::{
@@ -164,8 +165,8 @@ mod tests {
         );
 
         // create two dummy contexts at indices 0 and 1, with 1 being the child of 0
-        activate_dummy_context(&mut env.state, 0, Context::ROOT_INDEX, &TEST_HANDLE, &[1]);
-        activate_dummy_context(&mut env.state, 1, 0, &ContextHandle::default(), &[]);
+        activate_dummy_context(env.state, 0, Context::ROOT_INDEX, &TEST_HANDLE, &[1]);
+        activate_dummy_context(env.state, 1, 0, &ContextHandle::default(), &[]);
         // destroy context[1]
         assert_eq!(
             Ok(Response::DestroyCtx(
@@ -191,49 +192,49 @@ mod tests {
         assert_eq!(env.state.contexts[0].state, ContextState::Inactive);
 
         activate_dummy_context(
-            &mut env.state,
+            env.state,
             0,
             Context::ROOT_INDEX,
             &ContextHandle::default(),
             &[1, 2],
         );
         activate_dummy_context(
-            &mut env.state,
+            env.state,
             1,
             0,
             &ContextHandle([1; ContextHandle::SIZE]),
             &[3, 4],
         );
         activate_dummy_context(
-            &mut env.state,
+            env.state,
             2,
             0,
             &ContextHandle([2; ContextHandle::SIZE]),
             &[5, 6],
         );
         activate_dummy_context(
-            &mut env.state,
+            env.state,
             3,
             1,
             &ContextHandle([3; ContextHandle::SIZE]),
             &[],
         );
         activate_dummy_context(
-            &mut env.state,
+            env.state,
             4,
             1,
             &ContextHandle([4; ContextHandle::SIZE]),
             &[],
         );
         activate_dummy_context(
-            &mut env.state,
+            env.state,
             5,
             2,
             &ContextHandle([5; ContextHandle::SIZE]),
             &[],
         );
         activate_dummy_context(
-            &mut env.state,
+            env.state,
             6,
             2,
             &ContextHandle([6; ContextHandle::SIZE]),
@@ -263,21 +264,21 @@ mod tests {
         assert!(env.state.contexts[3].children.is_empty());
 
         activate_dummy_context(
-            &mut env.state,
+            env.state,
             0,
             Context::ROOT_INDEX,
             &ContextHandle::default(),
             &[1, 2],
         );
         activate_dummy_context(
-            &mut env.state,
+            env.state,
             1,
             0,
             &ContextHandle([1; ContextHandle::SIZE]),
             &[],
         );
         activate_dummy_context(
-            &mut env.state,
+            env.state,
             2,
             0,
             &ContextHandle([2; ContextHandle::SIZE]),

--- a/dpe/src/commands/get_certificate_chain.rs
+++ b/dpe/src/commands/get_certificate_chain.rs
@@ -57,6 +57,7 @@ impl CommandExecution for GetCertificateChainCmd {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
     use crate::{

--- a/dpe/src/commands/initialize_context.rs
+++ b/dpe/src/commands/initialize_context.rs
@@ -131,6 +131,7 @@ impl CommandExecution for InitCtxCmd {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
     use crate::{

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -348,7 +348,7 @@ pub trait CommandExecution {
             ($resp_type:ty, $f:expr) => {{
                 let mut buf = [0u32; size_of::<$resp_type>().div_ceil(4)];
                 let mut resp_buf = SliceResponseBuffer::new(buf.as_mut_bytes());
-                self.execute_serialized(dpe, env, locality, &mut resp_buf)?
+                self.execute_serialized(dpe, env, locality, &mut resp_buf)?;
                 <$resp_type>::try_read_from_bytes(buf.as_bytes())
                     .map($f)
                     .map_err(|_| {
@@ -502,6 +502,7 @@ impl TryFrom<&[u8]> for CommandHdr {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 pub mod tests {
     use super::*;
     use crate::dpe_instance::tests::DPE_PROFILE;

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -346,9 +346,9 @@ pub trait CommandExecution {
         // miri alignment: use u32 buffer to ensure 4-byte alignment for zerocopy
         macro_rules! exec {
             ($resp_type:ty, $f:expr) => {{
-                let mut buf = [0u32; (size_of::<$resp_type>() + 3) / 4];
+                let mut buf = [0u32; size_of::<$resp_type>().div_ceil(4)];
                 let mut resp_buf = SliceResponseBuffer::new(buf.as_mut_bytes());
-                self.execute_serialized(dpe, env, locality, &mut resp_buf)?;
+                self.execute_serialized(dpe, env, locality, &mut resp_buf)?
                 <$resp_type>::try_read_from_bytes(buf.as_bytes())
                     .map($f)
                     .map_err(|_| {

--- a/dpe/src/commands/rotate_context.rs
+++ b/dpe/src/commands/rotate_context.rs
@@ -139,6 +139,7 @@ impl CommandExecution for RotateCtxCmd {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
     use crate::{

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -67,7 +67,10 @@ pub enum SignCommand<'a> {
 }
 
 impl SignCommand<'_> {
-    pub fn deserialize(profile: DpeProfile, bytes: &[u8]) -> Result<SignCommand<'_>, DpeErrorCode> {
+    pub fn deserialize(
+        profile: DpeProfile,
+        bytes: &'_ [u8],
+    ) -> Result<SignCommand<'_>, DpeErrorCode> {
         match profile {
             #[cfg(feature = "p256")]
             DpeProfile::P256Sha256 => SignCommand::parse_command(SignCommand::P256, bytes),
@@ -79,7 +82,7 @@ impl SignCommand<'_> {
     }
 
     #[cfg(feature = "ml-dsa")]
-    fn deserialize_mldsa87(bytes: &[u8]) -> Result<SignCommand<'_>, DpeErrorCode> {
+    fn deserialize_mldsa87(bytes: &'_ [u8]) -> Result<SignCommand<'_>, DpeErrorCode> {
         // Only need the prefix to inspect the flags.
         let header = SignMldsa87Header::ref_from_prefix(bytes)
             .map_err(|_| DpeErrorCode::InvalidArgument)?
@@ -330,6 +333,7 @@ impl CommandExecution for SignP384Cmd {
 #[cfg(feature = "ml-dsa")]
 #[repr(C, align(4))]
 #[derive(Debug, PartialEq, Eq, IntoBytes, FromBytes, Immutable, KnownLayout)]
+#[allow(dead_code)]
 pub struct SignMldsa87Cmd {
     pub handle: ContextHandle,
     pub label: [u8; 48],

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -370,6 +370,7 @@ impl CommandExecution for SignMldsa87RawCmd {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
     #[cfg(any(feature = "p256", feature = "p384"))]

--- a/dpe/src/commands/update_context_measurement.rs
+++ b/dpe/src/commands/update_context_measurement.rs
@@ -136,6 +136,7 @@ impl CommandExecution for UpdateContextMeasurementCmd {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
     use crate::dpe_instance::tests::DPE_PROFILE;

--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -61,7 +61,7 @@ const _: () = assert!(
 impl Debug for Context {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Context")
-            .field("handle", &self.handle.0.get(0..2).unwrap())
+            .field("handle", &self.handle.0.get(0..2).unwrap_or(&[]))
             .field("state", &self.state)
             .field("chilren", &self.children.bits())
             .field("locality", &self.locality)
@@ -519,6 +519,7 @@ fn launder_u64(val: u64) -> u64 {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
     use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
@@ -637,12 +638,12 @@ mod tests {
         let mut contexts = [CONTEXT_INITIALIZER; MAX_HANDLES];
         let mut parent_idx = Context::ROOT_INDEX;
         let leaf_idx = 4;
-        for i in 0..=leaf_idx {
-            contexts[i].state = ContextState::Active;
-            contexts[i].parent_idx = parent_idx;
+        for (i, context) in contexts.iter_mut().enumerate().take(leaf_idx + 1) {
+            context.state = ContextState::Active;
+            context.parent_idx = parent_idx;
             parent_idx = i as u8;
             if i < leaf_idx {
-                contexts[i].children.add_child(i + 1).unwrap();
+                context.children.add_child(i + 1).unwrap();
             }
         }
 
@@ -683,8 +684,8 @@ mod tests {
             (5, 1),
             (6, 3),
         ];
-        for i in 0..=6 {
-            contexts[i].state = ContextState::Active;
+        for context in contexts.iter_mut().take(7) {
+            context.state = ContextState::Active;
         }
         for (node_idx, parent_idx) in parent_map.iter() {
             contexts[*node_idx].parent_idx = *parent_idx as u8;

--- a/dpe/src/dpe_instance.rs
+++ b/dpe/src/dpe_instance.rs
@@ -416,6 +416,7 @@ impl Iterator for FlagsIter {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 pub mod tests {
     use super::*;
     use crate::commands::tests::DEFAULT_PLATFORM;

--- a/dpe/src/lib.rs
+++ b/dpe/src/lib.rs
@@ -231,6 +231,7 @@ impl<const N: usize> AlignedBuf<N> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 pub(crate) mod tests {
     /// Convenience function to initialize logging for unit tests
     ///

--- a/dpe/src/state.rs
+++ b/dpe/src/state.rs
@@ -194,6 +194,7 @@ impl State {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
     use crate::dpe_instance::tests::SIMULATION_HANDLE;

--- a/dpe/src/support.rs
+++ b/dpe/src/support.rs
@@ -103,6 +103,7 @@ impl Support {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 pub mod test {
     use super::*;
     use crate::bitflags_join;

--- a/dpe/src/validation.rs
+++ b/dpe/src/validation.rs
@@ -347,6 +347,7 @@ impl DpeValidator<'_> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 pub mod tests {
     use crate::{
         context::{Children, Context, ContextHandle, ContextState, ContextType},

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -3003,6 +3003,7 @@ fn create_dpe_cert_or_csr(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 pub(crate) mod tests {
     use crate::context::{Context, ContextState};
     use crate::dpe_instance::tests::DPE_PROFILE;
@@ -3779,7 +3780,7 @@ pub(crate) mod tests {
             _ => (),
         }
 
-        if let Err(_) = cert.get_extension_unique(&oid!(2.5.29 .35)) {
+        if cert.get_extension_unique(&oid!(2.5.29 .35)).is_err() {
             panic!("multiple authority key identifier extensions found")
         }
 
@@ -3911,7 +3912,7 @@ pub(crate) mod tests {
         context
     }
 
-    fn build_test_measurements<'a>(contexts: &'a [Context], is_ca: bool) -> MeasurementData<'a> {
+    fn build_test_measurements(contexts: &[Context], is_ca: bool) -> MeasurementData<'_> {
         MeasurementData {
             label: &[0xAA; 4],
             tci_nodes: TciNodes::new(0, contexts).unwrap(),
@@ -4304,8 +4305,8 @@ pub(crate) mod tests {
     }
 
     fn encode_issuer_der(cn_len: usize, serial_len: usize) -> Vec<u8> {
-        let cn: Vec<u8> = std::iter::repeat(b'A').take(cn_len).collect();
-        let sn: Vec<u8> = std::iter::repeat(b'0').take(serial_len).collect();
+        let cn: Vec<u8> = std::iter::repeat_n(b'A', cn_len).collect();
+        let sn: Vec<u8> = std::iter::repeat_n(b'0', serial_len).collect();
         let name = Name {
             cn: DirectoryString::PrintableString(&cn),
             serial: DirectoryString::PrintableString(&sn),
@@ -4342,12 +4343,12 @@ pub(crate) mod tests {
         v.push(0x02);
         v.push(int_len as u8);
         v.push(0x00);
-        v.extend(std::iter::repeat(0xCC).take(ECC_INT_SIZE));
+        v.extend(std::iter::repeat_n(0xCC, ECC_INT_SIZE));
         // s
         v.push(0x02);
         v.push(int_len as u8);
         v.push(0x00);
-        v.extend(std::iter::repeat(0xDD).take(ECC_INT_SIZE));
+        v.extend(std::iter::repeat_n(0xDD, ECC_INT_SIZE));
         v
     }
 
@@ -4377,7 +4378,7 @@ pub(crate) mod tests {
         let (issuer_der, label_bytes, other_name_value) = if max_size {
             let issuer = encode_issuer_der(40, 60);
             let label = vec![0xAB; MAX_UEID_SIZE];
-            let other_name: Vec<u8> = std::iter::repeat(b'X').take(MAX_OTHER_NAME_SIZE).collect();
+            let other_name: Vec<u8> = std::iter::repeat_n(b'X', MAX_OTHER_NAME_SIZE).collect();
             (issuer, label, other_name)
         } else {
             let issuer = encode_issuer_der(14, DPE_PROFILE.hash_size() * 2);
@@ -4489,7 +4490,7 @@ pub(crate) mod tests {
         let (issuer_der, label_bytes, other_name_value) = if max_size {
             let issuer = encode_issuer_der(40, 60);
             let label = vec![0xAB; MAX_UEID_SIZE];
-            let other_name: Vec<u8> = std::iter::repeat(b'X').take(MAX_OTHER_NAME_SIZE).collect();
+            let other_name: Vec<u8> = std::iter::repeat_n(b'X', MAX_OTHER_NAME_SIZE).collect();
             (issuer, label, other_name)
         } else {
             let issuer = encode_issuer_der(14, DPE_PROFILE.hash_size() * 2);
@@ -4606,7 +4607,7 @@ pub(crate) mod tests {
             vec![0u8; DPE_PROFILE.hash_size()]
         };
         let other_name_value: Vec<u8> = if max_size {
-            std::iter::repeat(b'X').take(MAX_OTHER_NAME_SIZE).collect()
+            std::iter::repeat_n(b'X', MAX_OTHER_NAME_SIZE).collect()
         } else {
             DEFAULT_OTHER_NAME_VALUE.as_bytes().to_vec()
         };
@@ -4701,7 +4702,7 @@ pub(crate) mod tests {
             vec![0u8; DPE_PROFILE.hash_size()]
         };
         let other_name_value: Vec<u8> = if max_size {
-            std::iter::repeat(b'X').take(MAX_OTHER_NAME_SIZE).collect()
+            std::iter::repeat_n(b'X', MAX_OTHER_NAME_SIZE).collect()
         } else {
             DEFAULT_OTHER_NAME_VALUE.as_bytes().to_vec()
         };
@@ -4795,7 +4796,7 @@ pub(crate) mod tests {
             vec![0u8; DPE_PROFILE.hash_size()]
         };
         let other_name_value: Vec<u8> = if max_size {
-            std::iter::repeat(b'X').take(MAX_OTHER_NAME_SIZE).collect()
+            std::iter::repeat_n(b'X', MAX_OTHER_NAME_SIZE).collect()
         } else {
             DEFAULT_OTHER_NAME_VALUE.as_bytes().to_vec()
         };
@@ -4897,7 +4898,7 @@ pub(crate) mod tests {
             vec![0u8; DPE_PROFILE.hash_size()]
         };
         let other_name_value: Vec<u8> = if max_size {
-            std::iter::repeat(b'X').take(MAX_OTHER_NAME_SIZE).collect()
+            std::iter::repeat_n(b'X', MAX_OTHER_NAME_SIZE).collect()
         } else {
             DEFAULT_OTHER_NAME_VALUE.as_bytes().to_vec()
         };

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -1128,7 +1128,6 @@ impl CertWriter<'_> {
         // detected by the offset surpassing the certificate length at the end of an encode run,
         // and thus the error reporting is elided here to save instruction space.
         let _ = self.certificate.write_at(self.offset, bytes);
-
         // Note: Increment the offset regardless of whether the write occurred to allow detection
         // of encoding overflows.
         self.offset += size;
@@ -1141,7 +1140,6 @@ impl CertWriter<'_> {
         // detected by the offset surpassing the certificate length at the end of an encode run,
         // and thus the error reporting is elided here to save instruction space.
         let _ = self.certificate.write_at(self.offset, &[byte]);
-
         // Note: Increment the offset regardless of whether the write occurred to allow detection
         // of encoding overflows.
         self.offset += 1;

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -11,7 +11,7 @@ use clap::Parser;
 use log::{error, info, trace, warn};
 use profile::*;
 use std::fs;
-use std::io::{Error, ErrorKind, Read, Write};
+use std::io::{Error, Read, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::Path;
 use std::process;
@@ -191,12 +191,8 @@ fn main() -> std::io::Result<()> {
         platform: &mut platform,
         state: &mut state,
     };
-    let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE).map_err(|err| {
-        Error::new(
-            ErrorKind::Other,
-            format!("{err:?} while creating new DPE instance"),
-        )
-    })?;
+    let mut dpe = DpeInstance::new(&mut env, DPE_PROFILE)
+        .map_err(|err| Error::other(format!("{err:?} while creating new DPE instance")))?;
 
     info!("DPE listening to socket {SOCKET_PATH}");
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,7 +5,8 @@ use clap::{Parser, Subcommand};
 use std::path::Path;
 use std::process::Command;
 
-// TODO(clundin): Support "hybrid"
+// Note: "hybrid" is linted via the cert-size binary check in run_ci() but doesn't need
+// separate test runs since individual profiles already validate each algorithm's behavior
 const PROFILES: &[&str] = &["ml-dsa", "p256", "p384"];
 /// Pinned nightly toolchain version. Must match the version in flake.nix shellHook.
 const NIGHTLY: &str = "nightly-2025-07-08";
@@ -571,6 +572,9 @@ fn cargo_clippy(opts: &CargoOptions) -> Result<()> {
     let mut cmd = cargo().args(["clippy", "--manifest-path", opts.manifest_path]);
     if let Some(bin) = opts.bin {
         cmd = cmd.arg("--bin").arg(bin);
+    } else {
+        // Check all targets (lib, bins, tests, benches, examples) when not targeting a specific binary
+        cmd = cmd.arg("--all-targets");
     }
     if !opts.features.is_empty() {
         cmd = cmd.arg(format!("--features={}", opts.features));


### PR DESCRIPTION
Running `cargo xtask precheckin lint` resulted in errors. This PR fixes the linting issues so that the run completes successfully.

- [x] Add `cargo clippy --all-targets` as default