### PR TITLE
Allow derived signing with public key

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -675,6 +675,22 @@ pub trait Crypto {
             .sign_with_derived(label, derived_info, data)
     }
 
+    /// Sign `data` with a key derived from the current CDI and measurements,
+    /// using `pub_key` if the platform can avoid re-deriving it.
+    #[allow(clippy::too_many_arguments)]
+    fn sign_with_derived_and_pub_key(
+        &mut self,
+        measurement: &Digest,
+        info: &[u8],
+        label: &[u8],
+        derived_info: &[u8],
+        pub_key: &PubKey,
+        data: &SignData,
+    ) -> Result<Signature, CryptoError> {
+        let _ = pub_key;
+        self.sign_with_derived(measurement, info, label, derived_info, data)
+    }
+
     /// Derive the public key for a key derived from the current CDI and measurements.
     ///
     /// # Arguments

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -2918,11 +2918,12 @@ fn create_dpe_cert_or_csr(
                         .derive_key_pair_exported(&exported_handle, args.key_label, args.context)?
                         .sign(&SignData::ResponseBuffer(buf, range))
                 }
-                CertificateType::Leaf => crypto.sign_with_derived(
+                CertificateType::Leaf => crypto.sign_with_derived_and_pub_key(
                     &digest,
                     args.cdi_label,
                     args.key_label,
                     args.context,
+                    pub_key,
                     &SignData::ResponseBuffer(buf, range),
                 ),
             }


### PR DESCRIPTION
Adds a Crypto hook that receives the already-derived public key when signing DPE leaf certificates/CSRs. 
