### PR TITLE
Maintain support for `DeriveContext` without an SVN

### DIFF
--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -523,6 +523,109 @@ impl Default for DeriveContextCmd {
     }
 }
 
+#[repr(C, align(4))]
+#[derive(Debug, PartialEq, Eq, FromBytes, IntoBytes, Immutable, KnownLayout)]
+pub struct DeriveContextCmdV1 {
+    pub handle: ContextHandle,
+    pub data: TciMeasurement,
+    pub flags: DeriveContextFlags,
+    pub tci_type: u32,
+    pub target_locality: u32,
+}
+
+impl From<&DeriveContextCmdV1> for DeriveContextCmd {
+    fn from(cmd: &DeriveContextCmdV1) -> Self {
+        Self {
+            handle: cmd.handle,
+            data: cmd.data,
+            flags: cmd.flags,
+            tci_type: cmd.tci_type,
+            target_locality: cmd.target_locality,
+            svn: 0,
+        }
+    }
+}
+
+impl CommandExecution for DeriveContextCmdV1 {
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
+    #[inline(never)]
+    fn execute_serialized(
+        &self,
+        dpe: &mut DpeInstance,
+        env: &mut dyn DpeEnv,
+        locality: u32,
+        out: &mut dyn ResponseBuffer,
+    ) -> Result<usize, DpeErrorCode> {
+        let cmd_v2 = DeriveContextCmd::from(self);
+        cmd_v2.execute_serialized(dpe, env, locality, out)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum DeriveContextCommand<'a> {
+    V1(&'a DeriveContextCmdV1),
+    V2(&'a DeriveContextCmd),
+}
+
+impl<'a> DeriveContextCommand<'a> {
+    pub fn deserialize(bytes: &'a [u8]) -> Result<Self, DpeErrorCode> {
+        if bytes.len() >= size_of::<DeriveContextCmd>() {
+            let (cmd, _) = DeriveContextCmd::ref_from_prefix(bytes)
+                .map_err(|_| DpeErrorCode::InvalidArgument)?;
+            Ok(DeriveContextCommand::V2(cmd))
+        } else if bytes.len() >= size_of::<DeriveContextCmdV1>() {
+            let (cmd, _) = DeriveContextCmdV1::ref_from_prefix(bytes)
+                .map_err(|_| DpeErrorCode::InvalidArgument)?;
+            Ok(DeriveContextCommand::V1(cmd))
+        } else {
+            Err(DpeErrorCode::InvalidArgument)
+        }
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        match self {
+            DeriveContextCommand::V1(cmd) => cmd.as_bytes(),
+            DeriveContextCommand::V2(cmd) => cmd.as_bytes(),
+        }
+    }
+
+    pub fn flags(&self) -> DeriveContextFlags {
+        match self {
+            DeriveContextCommand::V1(cmd) => cmd.flags,
+            DeriveContextCommand::V2(cmd) => cmd.flags,
+        }
+    }
+}
+
+impl CommandExecution for DeriveContextCommand<'_> {
+    #[cfg_attr(feature = "cfi", cfi_impl_fn)]
+    #[inline(never)]
+    fn execute_serialized(
+        &self,
+        dpe: &mut DpeInstance,
+        env: &mut dyn DpeEnv,
+        locality: u32,
+        out: &mut dyn ResponseBuffer,
+    ) -> Result<usize, DpeErrorCode> {
+        match self {
+            DeriveContextCommand::V1(cmd) => cmd.execute_serialized(dpe, env, locality, out),
+            DeriveContextCommand::V2(cmd) => cmd.execute_serialized(dpe, env, locality, out),
+        }
+    }
+}
+
+impl<'a> From<&'a DeriveContextCmdV1> for DeriveContextCommand<'a> {
+    fn from(cmd: &'a DeriveContextCmdV1) -> Self {
+        DeriveContextCommand::V1(cmd)
+    }
+}
+
+impl<'a> From<&'a DeriveContextCmd> for DeriveContextCommand<'a> {
+    fn from(cmd: &'a DeriveContextCmd) -> Self {
+        DeriveContextCommand::V2(cmd)
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
@@ -568,6 +671,14 @@ mod tests {
         svn: 0,
     };
 
+    const TEST_DERIVE_CONTEXT_CMD_V1: DeriveContextCmdV1 = DeriveContextCmdV1 {
+        handle: SIMULATION_HANDLE,
+        data: TciMeasurement(TEST_DIGEST),
+        flags: DeriveContextFlags(0x1234_5678),
+        tci_type: 0x9876_5432,
+        target_locality: 0x10CA_1171,
+    };
+
     #[test]
     fn test_deserialize_derive_context() {
         CfiCounter::reset_for_test();
@@ -579,7 +690,29 @@ mod tests {
             command[..size_of::<CommandHdr>()].copy_from_slice(hdr.as_bytes());
             command[size_of::<CommandHdr>()..].copy_from_slice(TEST_DERIVE_CONTEXT_CMD.as_bytes());
             assert_eq!(
-                Ok(Command::DeriveContext(&TEST_DERIVE_CONTEXT_CMD)),
+                Ok(Command::DeriveContext(DeriveContextCommand::V2(
+                    &TEST_DERIVE_CONTEXT_CMD
+                ))),
+                Command::deserialize(p, command)
+            );
+        }
+    }
+
+    #[test]
+    fn test_deserialize_derive_context_v1() {
+        CfiCounter::reset_for_test();
+        for p in PROFILES {
+            let hdr = CommandHdr::new(p, Command::DERIVE_CONTEXT);
+            let mut buf =
+                AlignedBuf::<{ size_of::<CommandHdr>() + size_of::<DeriveContextCmdV1>() }>::new();
+            let command = buf.as_mut_bytes();
+            command[..size_of::<CommandHdr>()].copy_from_slice(hdr.as_bytes());
+            command[size_of::<CommandHdr>()..]
+                .copy_from_slice(TEST_DERIVE_CONTEXT_CMD_V1.as_bytes());
+            assert_eq!(
+                Ok(Command::DeriveContext(DeriveContextCommand::V1(
+                    &TEST_DERIVE_CONTEXT_CMD_V1
+                ))),
                 Command::deserialize(p, command)
             );
         }

--- a/dpe/src/commands/mod.rs
+++ b/dpe/src/commands/mod.rs
@@ -7,7 +7,9 @@ Abstract:
 pub use self::certify_key::{
     CertifyKeyCommand, CertifyKeyFlags, CertifyKeyP256Cmd, CertifyKeyP384Cmd,
 };
-pub use self::derive_context::{DeriveContextCmd, DeriveContextFlags};
+pub use self::derive_context::{
+    DeriveContextCmd, DeriveContextCmdV1, DeriveContextCommand, DeriveContextFlags,
+};
 pub use self::destroy_context::DestroyCtxCmd;
 pub use self::get_certificate_chain::GetCertificateChainCmd;
 pub use self::get_profile::GetProfileCmd;
@@ -60,7 +62,7 @@ mod update_context_measurement;
 pub enum Command<'a> {
     GetProfile(&'a GetProfileCmd),
     InitCtx(&'a InitCtxCmd),
-    DeriveContext(&'a DeriveContextCmd),
+    DeriveContext(DeriveContextCommand<'a>),
     CertifyKey(CertifyKeyCommand<'a>),
     Sign(SignCommand<'a>),
     #[cfg(not(feature = "disable_rotate_context"))]
@@ -98,7 +100,9 @@ impl Command<'_> {
         match header.cmd_id {
             Command::GET_PROFILE => Self::parse_command(Command::GetProfile, bytes),
             Command::INITIALIZE_CONTEXT => Self::parse_command(Command::InitCtx, bytes),
-            Command::DERIVE_CONTEXT => Self::parse_command(Command::DeriveContext, bytes),
+            Command::DERIVE_CONTEXT => Ok(Command::DeriveContext(
+                DeriveContextCommand::deserialize(bytes)?,
+            )),
             Command::CERTIFY_KEY => Ok(CertifyKeyCommand::deserialize(profile, bytes)?.into()),
             Command::SIGN => Ok(Command::Sign(SignCommand::deserialize(profile, bytes)?)),
             #[cfg(not(feature = "disable_rotate_context"))]
@@ -180,7 +184,28 @@ impl<'a> From<&'a InitCtxCmd> for Command<'a> {
 
 impl<'a> From<&'a DeriveContextCmd> for Command<'a> {
     fn from(cmd: &'a DeriveContextCmd) -> Command<'a> {
+        Command::DeriveContext(DeriveContextCommand::V2(cmd))
+    }
+}
+
+impl<'a> From<&'a DeriveContextCmdV1> for Command<'a> {
+    fn from(cmd: &'a DeriveContextCmdV1) -> Command<'a> {
+        Command::DeriveContext(DeriveContextCommand::V1(cmd))
+    }
+}
+
+impl<'a> From<DeriveContextCommand<'a>> for Command<'a> {
+    fn from(cmd: DeriveContextCommand<'a>) -> Self {
         Command::DeriveContext(cmd)
+    }
+}
+
+impl<'a> From<&'a DeriveContextCommand<'a>> for Command<'a> {
+    fn from(cmd: &'a DeriveContextCommand<'a>) -> Self {
+        match cmd {
+            DeriveContextCommand::V1(c) => Command::DeriveContext(DeriveContextCommand::V1(c)),
+            DeriveContextCommand::V2(c) => Command::DeriveContext(DeriveContextCommand::V2(c)),
+        }
     }
 }
 
@@ -360,7 +385,7 @@ pub trait CommandExecution {
         match Command::from(self) {
             Command::GetProfile(_) => exec!(GetProfileResp, Response::GetProfile),
             Command::InitCtx(_) => exec!(NewHandleResp, Response::InitCtx),
-            Command::DeriveContext(cmd) if cmd.flags.exports_cdi() => exec!(
+            Command::DeriveContext(cmd) if cmd.flags().exports_cdi() => exec!(
                 DeriveContextExportedCdiResp,
                 Response::DeriveContextExportedCdi
             ),

--- a/dpe/src/response.rs
+++ b/dpe/src/response.rs
@@ -5,7 +5,7 @@ Abstract:
     DPE reponses and serialization.
 --*/
 use crate::{
-    commands::{CertifyKeyCommand, Command, DeriveContextCmd, SignCommand},
+    commands::{CertifyKeyCommand, Command, SignCommand},
     context::ContextHandle,
     error::{DpeErrorCode, InternalErrorCode},
     AlignedBuf, DpeProfile, CURRENT_PROFILE_MAJOR_VERSION, CURRENT_PROFILE_MINOR_VERSION,
@@ -110,7 +110,7 @@ impl Response {
                         .0,
                 ))
             }
-            Command::DeriveContext(DeriveContextCmd { flags, .. }) if flags.exports_cdi() => {
+            Command::DeriveContext(cmd) if cmd.flags().exports_cdi() => {
                 Response::DeriveContextExportedCdi(
                     DeriveContextExportedCdiResp::try_read_from_prefix(bytes)
                         .map_err(|_| DpeErrorCode::InvalidArgument)?


### PR DESCRIPTION
To avoid the breaking change of adding the SVN to `DeriveContext` this adds support for the previous version of the struct. This effectively makes the SVN an optional parameter in the command.