### PR TITLE
dpe: local refactor to reduce code size

### DIFF
--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -20,6 +20,13 @@ use cfg_if::cfg_if;
 use core::mem::size_of;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
+#[cfg(feature = "ml-dsa")]
+use crate::response::SignMlDsaResp;
+#[cfg(feature = "p256")]
+use crate::response::SignP256Resp;
+#[cfg(feature = "p384")]
+use crate::response::SignP384Resp;
+
 #[repr(C, align(4))]
 #[derive(Debug, PartialEq, Eq, IntoBytes, FromBytes, Immutable, KnownLayout)]
 pub struct SignFlags(pub u32);
@@ -190,67 +197,63 @@ impl CommandExecution for SignCommand<'_> {
         }
 
         let sig = sign(dpe, env, idx, label, &data);
+        let sig_ref = okref(&sig)?;
+
+        // Rotate the handle if it isn't the default context.
+        let mut ctx = env.state().contexts[idx];
+        dpe.roll_onetime_use_handle(env, &mut ctx)?;
+        env.state().contexts[idx] = ctx;
+
         #[allow(unreachable_patterns)]
-        match okref(&sig)? {
+        match sig_ref {
             #[cfg(feature = "p256")]
             Signature::Ecdsa(EcdsaSignature::Ecdsa256(sig)) => {
-                use crate::response::SignP256Resp;
-                // Rotate the handle if it isn't the default context.
-                let mut ctx = env.state().contexts[idx];
-                dpe.roll_onetime_use_handle(env, &mut ctx)?;
-                env.state().contexts[idx] = ctx;
                 let (&sig_r, &sig_s) = sig.as_slice();
-                let resp = SignP256Resp {
-                    new_context_handle: ctx.handle,
-                    sig_r,
-                    sig_s,
-                    resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
-                };
-                let bytes = resp.as_bytes();
-                out.write_at(0, bytes)
-                    .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
-                Ok(bytes.len())
+                write_response(
+                    SignP256Resp {
+                        new_context_handle: ctx.handle,
+                        sig_r,
+                        sig_s,
+                        resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+                    }
+                    .as_bytes(),
+                    out,
+                )
             }
             #[cfg(feature = "p384")]
             Signature::Ecdsa(EcdsaSignature::Ecdsa384(sig)) => {
-                use crate::response::SignP384Resp;
-                // Rotate the handle if it isn't the default context.
-                let mut ctx = env.state().contexts[idx];
-                dpe.roll_onetime_use_handle(env, &mut ctx)?;
-                env.state().contexts[idx] = ctx;
                 let (&sig_r, &sig_s) = sig.as_slice();
-                let resp = SignP384Resp {
-                    new_context_handle: ctx.handle,
-                    sig_r,
-                    sig_s,
-                    resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
-                };
-                let bytes = resp.as_bytes();
-                out.write_at(0, bytes)
-                    .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
-                Ok(bytes.len())
+                write_response(
+                    SignP384Resp {
+                        new_context_handle: ctx.handle,
+                        sig_r,
+                        sig_s,
+                        resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
+                    }
+                    .as_bytes(),
+                    out,
+                )
             }
             #[cfg(feature = "ml-dsa")]
-            Signature::Mldsa(caliptra_dpe_crypto::ml_dsa::MldsaSignature(sig)) => {
-                use crate::response::SignMlDsaResp;
-                // Rotate the handle if it isn't the default context.
-                let mut ctx = env.state().contexts[idx];
-                dpe.roll_onetime_use_handle(env, &mut ctx)?;
-                env.state().contexts[idx] = ctx;
-                let resp = SignMlDsaResp {
+            Signature::Mldsa(caliptra_dpe_crypto::ml_dsa::MldsaSignature(sig)) => write_response(
+                SignMlDsaResp {
                     new_context_handle: ctx.handle,
                     sig: *sig,
                     _padding: [0; 1],
                     resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
-                };
-                let bytes = resp.as_bytes();
-                out.write_at(0, bytes)
-                    .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
-                Ok(bytes.len())
-            }
-            _ => Err(DpeErrorCode::InvalidArgument)?,
+                }
+                .as_bytes(),
+                out,
+            ),
+            _ => Err(DpeErrorCode::InvalidArgument),
         }
     }
+}
+
+fn write_response(bytes: &[u8], out: &mut dyn ResponseBuffer) -> Result<usize, DpeErrorCode> {
+    out.write_at(0, bytes)
+        .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
+    Ok(bytes.len())
 }
 
 /// Signs `digest` using ECDSA

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -202,10 +202,9 @@ impl CommandExecution for SignCommand<'_> {
         // Rotate the handle if it isn't the default context.
         let mut ctx = env.state().contexts[idx];
         dpe.roll_onetime_use_handle(env, &mut ctx)?;
-        env.state().contexts[idx] = ctx;
 
         #[allow(unreachable_patterns)]
-        match sig_ref {
+        let result = match sig_ref {
             #[cfg(feature = "p256")]
             Signature::Ecdsa(EcdsaSignature::Ecdsa256(sig)) => {
                 let (&sig_r, &sig_s) = sig.as_slice();
@@ -246,7 +245,12 @@ impl CommandExecution for SignCommand<'_> {
                 out,
             ),
             _ => Err(DpeErrorCode::InvalidArgument),
+        };
+
+        if result.is_ok() {
+            env.state().contexts[idx] = ctx;
         }
+        result
     }
 }
 

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -2704,30 +2704,26 @@ fn create_dpe_cert_or_csr(
         subject_alt_name,
     };
 
-    let mut sign_cb = |buf: &dyn ResponseBuffer,
-                       range: core::ops::Range<usize>,
-                       use_derived: bool| {
-        if use_derived {
-            match cert_type {
-                CertificateType::Exported => {
-                    let exported_handle =
-                        exported_cdi_handle.ok_or(CryptoError::CryptoLibError(0))?;
+    let mut sign_cb =
+        |buf: &dyn ResponseBuffer, range: core::ops::Range<usize>, use_derived: bool| {
+            if use_derived {
+                if let Some(exported_handle) = exported_cdi_handle {
                     crypto
                         .derive_key_pair_exported(&exported_handle, args.key_label, args.context)?
                         .sign(&SignData::ResponseBuffer(buf, range))
+                } else {
+                    crypto.sign_with_derived(
+                        &digest,
+                        args.cdi_label,
+                        args.key_label,
+                        args.context,
+                        &SignData::ResponseBuffer(buf, range),
+                    )
                 }
-                CertificateType::Leaf => crypto.sign_with_derived(
-                    &digest,
-                    args.cdi_label,
-                    args.key_label,
-                    args.context,
-                    &SignData::ResponseBuffer(buf, range),
-                ),
+            } else {
+                crypto.sign_with_alias(&SignData::ResponseBuffer(buf, range))
             }
-        } else {
-            crypto.sign_with_alias(&SignData::ResponseBuffer(buf, range))
-        }
-    };
+        };
 
     let mut issuer_name = [0u8; MAX_ISSUER_NAME_SIZE];
     let cert_validity = platform.get_cert_validity()?;
@@ -2762,18 +2758,10 @@ fn create_dpe_cert_or_csr(
         output_cert_or_csr,
     )?;
 
-    let exported_cdi_handle = match cert_type {
-        // If the `CertificateType::Exported` is set then we should have a valid exported_cdi_handle at this point.
-        CertificateType::Exported => exported_cdi_handle.ok_or(DpeErrorCode::from(
-            InternalErrorCode::MissingExportedCdiHandle,
-        ))?,
-        _ => [0; MAX_EXPORTED_CDI_SIZE],
-    };
-
     Ok(CreateDpeCertResult {
         cert_size,
         pub_key: pub_key.clone(),
-        exported_cdi_handle,
+        exported_cdi_handle: exported_cdi_handle.unwrap_or([0u8; MAX_EXPORTED_CDI_SIZE]),
     })
 }
 


### PR DESCRIPTION
- x509.rs: simplify check of exported_cdi_handle
- sign.rs: simplify response match arms

Reclaims 240 bytes of code size.

```
┌────────────────────────┬────────┬──────┬─────────┬───────┬────────┐
│         Binary         │  Text  │ Data │ Budget  │ Used% │  Free  │
├────────────────────────┼────────┼──────┼─────────┼───────┼────────┤
│ Runtime with ML-DSA    │ 99,564 │ 128  │ 103,684 │ 96.1% │ 3,992  │
├────────────────────────┼────────┼──────┼─────────┼───────┼────────┤
│ Runtime with ML-DSA    │ 99,324 │ 128  │ 103,684 │ 95.8% │ 4,232  │
└────────────────────────┴────────┴──────┴─────────┴───────┴────────┘
```