### PR TITLE
dpe: Make signature out parameter

### DIFF
--- a/crypto/src/ecdsa/mod.rs
+++ b/crypto/src/ecdsa/mod.rs
@@ -6,7 +6,7 @@ Abstract:
 
 use crate::{DigestAlgorithm, DigestType, SignatureAlgorithm, SignatureType};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
-use zeroize::ZeroizeOnDrop;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 #[derive(Clone, FromBytes, IntoBytes, KnownLayout, Immutable, ZeroizeOnDrop)]
 #[repr(C)]
@@ -44,7 +44,7 @@ impl<const K: usize> Default for EcdsaPub<K> {
     }
 }
 
-#[derive(Clone, FromBytes, IntoBytes, KnownLayout, Immutable, ZeroizeOnDrop)]
+#[derive(Clone, FromBytes, IntoBytes, KnownLayout, Immutable, ZeroizeOnDrop, Zeroize)]
 #[repr(C)]
 pub struct EcdsaSig<const K: usize> {
     pub r: [u8; K],
@@ -181,7 +181,7 @@ impl EcdsaPubKey {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Zeroize)]
 pub enum EcdsaSignature {
     Ecdsa256(curve_256::EcdsaSignature256),
     Ecdsa384(curve_384::EcdsaSignature384),
@@ -205,6 +205,15 @@ impl EcdsaSignature {
         match self {
             Self::Ecdsa256(key) => key.curve_size(),
             Self::Ecdsa384(key) => key.curve_size(),
+        }
+    }
+
+    /// Zero-initialized signature of the given ECDSA curve. Used as a
+    /// caller-provided output buffer for sign-in-place APIs.
+    pub fn zeroed(alg: EcdsaAlgorithm) -> Self {
+        match alg {
+            EcdsaAlgorithm::Bit256 => Self::Ecdsa256(curve_256::EcdsaSignature256::default()),
+            EcdsaAlgorithm::Bit384 => Self::Ecdsa384(curve_384::EcdsaSignature384::default()),
         }
     }
 }

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -365,6 +365,20 @@ pub enum PubKey {
     Mldsa(ml_dsa::MldsaPublicKey),
 }
 
+impl Default for PubKey {
+    /// A zeroed placeholder key. Used only to pre-initialize a caller-provided
+    /// `CreateDpeCertResult` slot that the cert/CSR path overwrites before use;
+    /// the always-compiled ECDSA-384 variant keeps this independent of `ml-dsa`.
+    fn default() -> Self {
+        PubKey::Ecdsa(ecdsa::EcdsaPubKey::Ecdsa384(
+            ecdsa::curve_384::EcdsaPub384 {
+                x: [0u8; ecdsa::curve_384::CURVE_SIZE],
+                y: [0u8; ecdsa::curve_384::CURVE_SIZE],
+            },
+        ))
+    }
+}
+
 impl From<ecdsa::EcdsaPubKey> for PubKey {
     fn from(pub_key: ecdsa::EcdsaPubKey) -> Self {
         PubKey::Ecdsa(pub_key)

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -11,6 +11,7 @@ use ecdsa::EcdsaSignature;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use caliptra_dpe_response_buffer::ResponseBuffer;
+use zeroize::Zeroize;
 
 #[cfg(feature = "rustcrypto")]
 pub use crate::rustcrypto::*;
@@ -389,7 +390,7 @@ impl From<ml_dsa::MldsaPublicKey> for PubKey {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Zeroize)]
 #[allow(clippy::large_enum_variant)]
 pub enum Signature {
     Ecdsa(EcdsaSignature),
@@ -419,6 +420,20 @@ impl From<ecdsa::curve_384::EcdsaSignature384> for Signature {
 impl From<ml_dsa::MldsaSignature> for Signature {
     fn from(sig: ml_dsa::MldsaSignature) -> Self {
         Signature::Mldsa(sig)
+    }
+}
+
+impl Signature {
+    /// Zero-initialized signature of the given algorithm, used as a
+    /// caller-provided output buffer for the sign-in-place APIs so the (large)
+    /// signature lives in exactly one stack slot instead of being returned by
+    /// value and copied.
+    pub fn zeroed(alg: SignatureAlgorithm) -> Self {
+        match alg {
+            SignatureAlgorithm::Ecdsa(alg) => Signature::Ecdsa(EcdsaSignature::zeroed(alg)),
+            #[cfg(feature = "ml-dsa")]
+            SignatureAlgorithm::Mldsa(_) => Signature::Mldsa(ml_dsa::MldsaSignature([0u8; 4627])),
+        }
     }
 }
 
@@ -460,8 +475,9 @@ pub trait CryptoSuite: Crypto + SignatureType + DigestType {
 }
 
 pub trait Signer {
-    /// Sign `data` with the derived private key
-    fn sign(&mut self, data: &SignData) -> Result<Signature, CryptoError>;
+    /// Sign `data` with the derived private key, writing the signature into the
+    /// caller-provided `out` (whose variant must match this signer's algorithm).
+    fn sign(&mut self, data: &SignData, out: &mut Signature) -> Result<(), CryptoError>;
 
     /// Get the public key associated with the derived key-pair
     fn public_key(&mut self) -> Result<PubKey, CryptoError>;
@@ -503,8 +519,9 @@ pub trait CdiManager {
         label: &[u8],
         info: &[u8],
         data: &SignData,
-    ) -> Result<Signature, CryptoError> {
-        self.derive_key_pair(label, info)?.sign(data)
+        out: &mut Signature,
+    ) -> Result<(), CryptoError> {
+        self.derive_key_pair(label, info)?.sign(data, out)
     }
 
     /// Get the public key of a derived key-pair from the CDI
@@ -652,7 +669,8 @@ pub trait Crypto {
     /// # Arguments
     ///
     /// * `data` - Data to be signed.
-    fn sign_with_alias(&mut self, data: &SignData) -> Result<Signature, CryptoError>;
+    /// * `out` - A buffer to place the completed signature into.
+    fn sign_with_alias(&mut self, data: &SignData, out: &mut Signature) -> Result<(), CryptoError>;
 
     /// Sign `data` with a key derived from the current CDI and measurements.
     ///
@@ -663,6 +681,7 @@ pub trait Crypto {
     /// * `label` - Caller-supplied label to use in key derivation.
     /// * `derived_info` - Caller-supplied info string to use in key derivation.
     /// * `data` - Data to be signed.
+    /// * `out` - A buffer to place the completed signature into.
     fn sign_with_derived(
         &mut self,
         measurement: &Digest,
@@ -670,9 +689,10 @@ pub trait Crypto {
         label: &[u8],
         derived_info: &[u8],
         data: &SignData,
-    ) -> Result<Signature, CryptoError> {
+        out: &mut Signature,
+    ) -> Result<(), CryptoError> {
         self.derive_cdi(measurement, info)?
-            .sign_with_derived(label, derived_info, data)
+            .sign_with_derived(label, derived_info, data, out)
     }
 
     /// Derive the public key for a key derived from the current CDI and measurements.

--- a/crypto/src/ml_dsa.rs
+++ b/crypto/src/ml_dsa.rs
@@ -3,6 +3,7 @@
 use crate::{SignatureAlgorithm, SignatureType};
 
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+use zeroize::Zeroize;
 
 #[derive(Debug, Clone, Copy)]
 pub enum MldsaAlgorithm {
@@ -67,7 +68,7 @@ impl MldsaPublicKey {
     }
 }
 
-#[derive(Clone, FromBytes, IntoBytes, KnownLayout, Immutable)]
+#[derive(Clone, FromBytes, IntoBytes, KnownLayout, Immutable, Zeroize)]
 #[repr(C)]
 pub struct MldsaSignature(pub [u8; MldsaAlgorithm::Mldsa87.signature_size()]);
 

--- a/crypto/src/rustcrypto.rs
+++ b/crypto/src/rustcrypto.rs
@@ -150,19 +150,19 @@ pub struct RustCryptoSigner {
 }
 
 impl crate::Signer for RustCryptoSigner {
-    fn sign(&mut self, data: &SignData) -> Result<super::Signature, CryptoError> {
+    fn sign(&mut self, data: &SignData, out: &mut super::Signature) -> Result<(), CryptoError> {
         match self.signature_alg {
             SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit256) => {
                 let signing = p256::ecdsa::SigningKey::from_slice(self.priv_key.as_slice())?;
                 let sig =
                     RustCryptoImpl::ecdsa_sign_data_inner(&signing, data, self.signature_alg)?;
-                Ok(EcdsaSig::from(sig).into())
+                *out = EcdsaSig::from(sig).into();
             }
             SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit384) => {
                 let signing = p384::ecdsa::SigningKey::from_slice(self.priv_key.as_slice())?;
                 let sig =
                     RustCryptoImpl::ecdsa_sign_data_inner(&signing, data, self.signature_alg)?;
-                Ok(EcdsaSig::from(sig).into())
+                *out = EcdsaSig::from(sig).into();
             }
             #[cfg(feature = "ml-dsa")]
             SignatureAlgorithm::Mldsa(MldsaAlgorithm::Mldsa87) => {
@@ -172,9 +172,10 @@ impl crate::Signer for RustCryptoSigner {
                         .try_into()
                         .map_err(|_| RUSTCRYPTO_ML_DSA_ERROR)?,
                 );
-                RustCryptoImpl::mldsa_sign_data_inner(&kp, data)
+                *out = RustCryptoImpl::mldsa_sign_data_inner(&kp, data)?;
             }
         }
+        Ok(())
     }
 
     fn public_key(&mut self) -> Result<PubKey, CryptoError> {
@@ -480,25 +481,30 @@ impl Crypto for RustCryptoImpl {
         Err(CryptoError::InvalidExportedCdiHandle)
     }
 
-    fn sign_with_alias(&mut self, data: &SignData) -> Result<super::Signature, CryptoError> {
+    fn sign_with_alias(
+        &mut self,
+        data: &SignData,
+        out: &mut super::Signature,
+    ) -> Result<(), CryptoError> {
         use crate::artifacts;
         match self.signature_alg {
             SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit256) => {
                 let signing_key = p256::ecdsa::SigningKey::from_sec1_pem(artifacts::KEY_P256_PEM)?;
                 let sig = Self::ecdsa_sign_data_inner(&signing_key, data, self.signature_alg)?;
-                Ok(EcdsaSig::from(sig).into())
+                *out = EcdsaSig::from(sig).into();
             }
             SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit384) => {
                 let signing_key = p384::ecdsa::SigningKey::from_sec1_pem(artifacts::KEY_P384_PEM)?;
                 let sig = Self::ecdsa_sign_data_inner(&signing_key, data, self.signature_alg)?;
-                Ok(EcdsaSig::from(sig).into())
+                *out = EcdsaSig::from(sig).into();
             }
             #[cfg(feature = "ml-dsa")]
             SignatureAlgorithm::Mldsa(MldsaAlgorithm::Mldsa87) => {
                 let ml_dsa_secret =
                     SigningKey::<MlDsa87>::from_pkcs8_pem(artifacts::KEY_MLDSA_87_PEM)?;
-                Self::mldsa_sign_data_inner(&ml_dsa_secret, data)
+                *out = Self::mldsa_sign_data_inner(&ml_dsa_secret, data)?;
             }
         }
+        Ok(())
     }
 }

--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -193,7 +193,10 @@ impl CommandExecution for CertifyKeyCommand<'_> {
         let response_header = self.response_header();
         let hdr_size = response_header.hdr_size();
         let mut cert_view = OffsetResponseBuffer::new(out, hdr_size);
-        let result = Self::run_cert_format(format, &args, dpe, env, &mut cert_view)?;
+        // Single result slot, filled in place by the cert/CSR path, so only one
+        // `CreateDpeCertResult` — and thus one `PubKey` — occupies this frame.
+        let mut result = CreateDpeCertResult::default();
+        Self::run_cert_format(format, &args, dpe, env, &mut cert_view, &mut result)?;
 
         #[allow(clippy::indexing_slicing)]
         let new_handle = {
@@ -214,14 +217,15 @@ impl CertifyKeyCommand<'_> {
         dpe: &mut DpeInstance,
         env: &mut dyn DpeEnv,
         out: &mut dyn ResponseBuffer,
-    ) -> Result<CreateDpeCertResult, DpeErrorCode> {
+        out_result: &mut CreateDpeCertResult,
+    ) -> Result<(), DpeErrorCode> {
         match format {
             Self::FORMAT_X509 => {
                 cfg_if! {
                     if #[cfg(not(feature = "disable_x509"))] {
                         #[cfg(feature = "cfi")]
                         cfi_assert_eq(format, Self::FORMAT_X509);
-                        create_dpe_cert(args, dpe, env, out)
+                        create_dpe_cert(args, dpe, env, out, out_result)
                     } else {
                         Err(DpeErrorCode::ArgumentNotSupported)
                     }
@@ -232,7 +236,7 @@ impl CertifyKeyCommand<'_> {
                     if #[cfg(not(feature = "disable_csr"))] {
                         #[cfg(feature = "cfi")]
                         cfi_assert_eq(format, Self::FORMAT_CSR);
-                        crate::x509::create_dpe_csr(args, dpe, env, out)
+                        crate::x509::create_dpe_csr(args, dpe, env, out, out_result)
                     } else {
                         Err(DpeErrorCode::ArgumentNotSupported)
                     }
@@ -395,14 +399,29 @@ impl CertifyKeyResponseHeader {
             }
             #[cfg(feature = "ml-dsa")]
             (Self::Mldsa87, PubKey::Mldsa(caliptra_dpe_crypto::ml_dsa::MldsaPublicKey(pubkey))) => {
+                // The stack space of the MLDSA operations are constrained, especially on the 1.x
+                // Core implementation.  As such, utilize a hand-written serialization of the
+                // RespHdr to avoid allocating the full struct on the stack, including an expensive
+                // MLDSA Public Key.
                 use crate::response::CertifyKeyMldsa87RespHdr;
-                let hdr = CertifyKeyMldsa87RespHdr {
-                    resp_hdr: dpe.response_hdr(DpeErrorCode::NoError),
-                    new_context_handle: new_handle,
-                    pubkey: *pubkey,
-                    cert_size,
-                };
-                out.write_at(0, hdr.as_bytes())
+                use crate::ResponseHdr;
+
+                const HANDLE_OFFSET: usize = core::mem::size_of::<ResponseHdr>();
+                const PUB_OFFSET: usize = HANDLE_OFFSET + core::mem::size_of::<ContextHandle>();
+                const CERT_SIZE_OFFSET: usize =
+                    PUB_OFFSET + size_of::<caliptra_dpe_crypto::ml_dsa::MldsaPublicKey>();
+
+                const _: () = assert!(
+                    CERT_SIZE_OFFSET + size_of::<u32>() == size_of::<CertifyKeyMldsa87RespHdr>()
+                );
+
+                out.write_at(0, dpe.response_hdr(DpeErrorCode::NoError).as_bytes())
+                    .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
+                out.write_at(HANDLE_OFFSET, new_handle.as_bytes())
+                    .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
+                out.write_at(PUB_OFFSET, pubkey)
+                    .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
+                out.write_at(CERT_SIZE_OFFSET, &cert_size.to_le_bytes())
                     .map_err(|_| DpeErrorCode::InvalidResponseBuf)
             }
             _ => Err(DpeErrorCode::InvalidArgument),

--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -404,19 +404,23 @@ impl CertifyKeyResponseHeader {
                 // RespHdr to avoid allocating the full struct on the stack, including an expensive
                 // MLDSA Public Key.
                 use crate::response::CertifyKeyMldsa87RespHdr;
-                use crate::ResponseHdr;
+                use core::mem::offset_of;
 
-                const HANDLE_OFFSET: usize = core::mem::size_of::<ResponseHdr>();
-                const PUB_OFFSET: usize = HANDLE_OFFSET + core::mem::size_of::<ContextHandle>();
-                const CERT_SIZE_OFFSET: usize =
-                    PUB_OFFSET + size_of::<caliptra_dpe_crypto::ml_dsa::MldsaPublicKey>();
+                const RESP_HDR_OFFSET: usize = offset_of!(CertifyKeyMldsa87RespHdr, resp_hdr);
+                const HANDLE_OFFSET: usize =
+                    offset_of!(CertifyKeyMldsa87RespHdr, new_context_handle);
+                const PUB_OFFSET: usize = offset_of!(CertifyKeyMldsa87RespHdr, pubkey);
+                const CERT_SIZE_OFFSET: usize = offset_of!(CertifyKeyMldsa87RespHdr, cert_size);
 
                 const _: () = assert!(
                     CERT_SIZE_OFFSET + size_of::<u32>() == size_of::<CertifyKeyMldsa87RespHdr>()
                 );
 
-                out.write_at(0, dpe.response_hdr(DpeErrorCode::NoError).as_bytes())
-                    .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
+                out.write_at(
+                    RESP_HDR_OFFSET,
+                    dpe.response_hdr(DpeErrorCode::NoError).as_bytes(),
+                )
+                .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
                 out.write_at(HANDLE_OFFSET, new_handle.as_bytes())
                     .map_err(|_| DpeErrorCode::InvalidResponseBuf)?;
                 out.write_at(PUB_OFFSET, pubkey)

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -5,7 +5,7 @@ use crate::{
     context::{ActiveContextArgs, Context, ContextHandle, ContextState, ContextType},
     dpe_instance::{DpeEnv, DpeInstance},
     error::{DpeErrorCode, InternalErrorCode},
-    mutresp, okref,
+    mutresp,
     response::{DeriveContextExportedCdiRespHdr, DeriveContextResp},
     tci::TciMeasurement,
     x509::{create_exported_dpe_cert, CreateDpeCertArgs, CreateDpeCertResult},
@@ -393,13 +393,9 @@ impl CommandExecution for DeriveContextCmd {
                         ueid,
                         dice_extensions_are_critical: env.state().flags.contains(DpeFlags::MARK_DICE_EXTENSIONS_CRITICAL),
                     };
-                    let result = create_exported_dpe_cert(
-                        &args,
-                        dpe,
-                        env,
-                        &mut cert_view,
-                    );
-                    let CreateDpeCertResult { cert_size, exported_cdi_handle, .. } = okref(&result)?;
+                    let mut result = CreateDpeCertResult::default();
+                    create_exported_dpe_cert(&args, dpe, env, &mut cert_view, &mut result)?;
+                    let CreateDpeCertResult { cert_size, exported_cdi_handle, .. } = &result;
 
                     if !flags.retains_parent() && !env.state().contexts.get(parent_idx).ok_or(DpeErrorCode::from(InternalErrorCode::ContextIndexOob))?.has_children() {
                         // When the parent is not retained and there are no other children,

--- a/dpe/src/commands/sign.rs
+++ b/dpe/src/commands/sign.rs
@@ -275,6 +275,7 @@ fn sign(
     label: &[u8],
     data: &SignData,
 ) -> Result<Signature, DpeErrorCode> {
+    let mut sig = Signature::zeroed(env.crypto().signature_algorithm());
     let cdi_digest = dpe.compute_measurement_hash(env, idx)?;
     let cdi = env.crypto().derive_cdi(&cdi_digest, b"DPE")?;
     let profile = dpe.profile;
@@ -291,7 +292,8 @@ fn sign(
         cfi_assert!(key_pair.is_err());
     }
     let signer = key_pair?;
-    Ok(signer.sign(data)?)
+    signer.sign(data, &mut sig)?;
+    Ok(sig)
 }
 
 #[repr(C, align(4))]

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -9,7 +9,6 @@ use crate::{
     context::{Context, ContextHandle, RootToChildIter},
     dpe_instance::DpeEnv,
     error::{DpeErrorCode, InternalErrorCode},
-    okref,
     tci::{TciMeasurement, TciNodeData},
     DpeInstance, DpeProfile, MAX_HANDLES,
 };
@@ -2438,6 +2437,7 @@ pub(crate) struct CreateDpeCertArgs<'a> {
 }
 
 /// Results for DPE cert or CSR creation.
+#[derive(Default)]
 pub(crate) struct CreateDpeCertResult {
     /// Size of certificate or CSR in bytes.
     pub cert_size: u32,
@@ -2509,7 +2509,8 @@ pub(crate) fn create_exported_dpe_cert(
     dpe: &mut DpeInstance,
     env: &mut dyn DpeEnv,
     cert: &mut dyn ResponseBuffer,
-) -> Result<CreateDpeCertResult, DpeErrorCode> {
+    out_result: &mut CreateDpeCertResult,
+) -> Result<(), DpeErrorCode> {
     create_dpe_cert_or_csr(
         args,
         dpe,
@@ -2517,6 +2518,7 @@ pub(crate) fn create_exported_dpe_cert(
         CertificateFormat::X509,
         CertificateType::Exported,
         cert,
+        out_result,
     )
 }
 
@@ -2525,7 +2527,8 @@ pub(crate) fn create_dpe_cert(
     dpe: &mut DpeInstance,
     env: &mut dyn DpeEnv,
     cert: &mut dyn ResponseBuffer,
-) -> Result<CreateDpeCertResult, DpeErrorCode> {
+    out_result: &mut CreateDpeCertResult,
+) -> Result<(), DpeErrorCode> {
     create_dpe_cert_or_csr(
         args,
         dpe,
@@ -2533,6 +2536,7 @@ pub(crate) fn create_dpe_cert(
         CertificateFormat::X509,
         CertificateType::Leaf,
         cert,
+        out_result,
     )
 }
 
@@ -2542,7 +2546,8 @@ pub(crate) fn create_dpe_csr(
     dpe: &mut DpeInstance,
     env: &mut dyn DpeEnv,
     csr: &mut dyn ResponseBuffer,
-) -> Result<CreateDpeCertResult, DpeErrorCode> {
+    out_result: &mut CreateDpeCertResult,
+) -> Result<(), DpeErrorCode> {
     create_dpe_cert_or_csr(
         args,
         dpe,
@@ -2550,6 +2555,7 @@ pub(crate) fn create_dpe_csr(
         CertificateFormat::Csr,
         CertificateType::Leaf,
         csr,
+        out_result,
     )
 }
 
@@ -2659,13 +2665,14 @@ fn create_dpe_cert_or_csr(
     cert_format: CertificateFormat,
     cert_type: CertificateType,
     output_cert_or_csr: &mut dyn ResponseBuffer,
-) -> Result<CreateDpeCertResult, DpeErrorCode> {
+    out_result: &mut CreateDpeCertResult,
+) -> Result<(), DpeErrorCode> {
     let digest = get_dpe_measurement_digest(dpe, env, args.handle, args.locality)?;
     let (crypto, platform, state) = env.get();
 
     let mut exported_cdi_handle = None;
 
-    let pub_key = match cert_type {
+    let pub_key_res = match cert_type {
         CertificateType::Exported => {
             let exported_handle = crypto.derive_exported_cdi(&digest, args.cdi_label)?;
             exported_cdi_handle = Some(exported_handle);
@@ -2677,17 +2684,18 @@ fn create_dpe_cert_or_csr(
             crypto.derive_pub_key(&digest, args.cdi_label, args.key_label, args.context)
         }
     };
-    let pub_key_ok = pub_key.is_ok();
+    let pub_key_ok = pub_key_res.is_ok();
     #[cfg(feature = "cfi")]
     let pub_key_ok = cfi_launder(pub_key_ok);
     if pub_key_ok {
         #[cfg(feature = "cfi")]
-        cfi_assert!(pub_key.is_ok());
+        cfi_assert!(pub_key_res.is_ok());
     } else {
         #[cfg(feature = "cfi")]
-        cfi_assert!(pub_key.is_err());
+        cfi_assert!(pub_key_res.is_err());
     }
-    let pub_key = okref(&pub_key)?;
+    out_result.pub_key = pub_key_res?;
+    let pub_key = &out_result.pub_key;
     let mut subj_serial = [0u8; MAX_HASH_SIZE * 2];
     let subject_name = get_subject_name(crypto, &cert_type, pub_key, &mut subj_serial)?;
 
@@ -2788,11 +2796,11 @@ fn create_dpe_cert_or_csr(
         &mut sig,
     )?;
 
-    Ok(CreateDpeCertResult {
-        cert_size,
-        pub_key: pub_key.clone(),
-        exported_cdi_handle: exported_cdi_handle.unwrap_or([0u8; MAX_EXPORTED_CDI_SIZE]),
-    })
+    // `out_result.pub_key` was already populated in place at derivation time.
+    out_result.cert_size = cert_size;
+    out_result.exported_cdi_handle = exported_cdi_handle.unwrap_or([0u8; MAX_EXPORTED_CDI_SIZE]);
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -41,7 +41,7 @@ use caliptra_dpe_crypto::ml_dsa::{MldsaPublicKey, MldsaSignature};
 /// Arguments: `(buf, range, use_derived)` where `range` is the byte span of
 /// the payload to sign within `buf`, and `use_derived` selects the derived key
 /// (`true`) or the alias key (`false`).  The `Signature` is the out buffer
-/// is where the signature is placed.  The callee is responsible for ensuring it
+/// where the signature is placed.  The caller is responsible for ensuring it
 /// is cleared between any sequential calls.
 pub trait SignCallback:
     FnMut(&dyn ResponseBuffer, core::ops::Range<usize>, bool, &mut Signature) -> Result<(), CryptoError>

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -32,6 +32,7 @@ use caliptra_dpe_platform::{
 };
 use caliptra_dpe_response_buffer::ResponseBuffer;
 use zerocopy::IntoBytes;
+use zeroize::Zeroize;
 
 #[cfg(feature = "ml-dsa")]
 use caliptra_dpe_crypto::ml_dsa::{MldsaPublicKey, MldsaSignature};
@@ -40,14 +41,21 @@ use caliptra_dpe_crypto::ml_dsa::{MldsaPublicKey, MldsaSignature};
 ///
 /// Arguments: `(buf, range, use_derived)` where `range` is the byte span of
 /// the payload to sign within `buf`, and `use_derived` selects the derived key
-/// (`true`) or the alias key (`false`).
+/// (`true`) or the alias key (`false`).  The `Signature` is the out buffer
+/// is where the signature is placed.  The callee is responsible for ensuring it
+/// is cleared between any sequential calls.
 pub trait SignCallback:
-    FnMut(&dyn ResponseBuffer, core::ops::Range<usize>, bool) -> Result<Signature, CryptoError>
+    FnMut(&dyn ResponseBuffer, core::ops::Range<usize>, bool, &mut Signature) -> Result<(), CryptoError>
 {
 }
 
 impl<F> SignCallback for F where
-    F: FnMut(&dyn ResponseBuffer, core::ops::Range<usize>, bool) -> Result<Signature, CryptoError>
+    F: FnMut(
+        &dyn ResponseBuffer,
+        core::ops::Range<usize>,
+        bool,
+        &mut Signature,
+    ) -> Result<(), CryptoError>
 {
 }
 
@@ -1983,6 +1991,7 @@ impl CertWriter<'_> {
         pub_key: &PubKey,
         subject_name: &Name,
         measurements: &MeasurementData,
+        sig: &mut Signature,
     ) -> Result<usize, DpeErrorCode> {
         let mut size_bytes_written = self.encode_byte(Self::SEQUENCE_TAG);
         self.push_backtrack(SIZE_TAG_OFFSET)?;
@@ -1998,7 +2007,8 @@ impl CertWriter<'_> {
         bytes_written += self.encode_byte(Self::OCTET_STRING_TAG);
         let offset = self.push_backtrack(SIZE_TAG_OFFSET)?;
 
-        let csr_bytes_written = self.encode_csr(sign_cb, pub_key, subject_name, measurements)?;
+        let csr_bytes_written =
+            self.encode_csr(sign_cb, pub_key, subject_name, measurements, sig)?;
         self.csr_range = Some((offset, offset + csr_bytes_written));
 
         let econtent_1_size = Self::get_econtent_size(
@@ -2137,6 +2147,7 @@ impl CertWriter<'_> {
         pubkey: &PubKey,
         measurements: &MeasurementData,
         validity: &CertValidity,
+        sig: &mut Signature,
     ) -> Result<usize, DpeErrorCode> {
         let bytes_written = self.encode_signed_payload(
             sign_cb,
@@ -2148,6 +2159,7 @@ impl CertWriter<'_> {
                 measurements,
                 validity,
             },
+            sig,
         )?;
 
         self.check_not_truncated()?;
@@ -2169,6 +2181,7 @@ impl CertWriter<'_> {
         &mut self,
         sign_cb: &mut dyn SignCallback,
         payload: SignedPayload,
+        sig: &mut Signature,
     ) -> Result<usize, DpeErrorCode> {
         let mut prefix_bytes_written = self.encode_tag_field(Self::SEQUENCE_TAG);
         let offset = self.push_backtrack(SIZE_TAG_OFFSET)?;
@@ -2204,14 +2217,12 @@ impl CertWriter<'_> {
             ),
         };
 
-        let sig = {
-            let abs_start = offset;
-            let abs_end = offset + payload_bytes_written;
-            sign_cb(&*self.certificate, abs_start..abs_end, is_csr)
-        };
-        let sig = okref(&sig)?;
+        let abs_start = offset;
+        let abs_end = offset + payload_bytes_written;
+        sign_cb(&*self.certificate, abs_start..abs_end, is_csr, sig)?;
 
         let sig_bytes_written = self.encode_signature_bit_string(sig);
+        sig.zeroize();
 
         let body_size = payload_bytes_written + sig_bytes_written;
 
@@ -2284,6 +2295,7 @@ impl CertWriter<'_> {
         pub_key: &PubKey,
         subject_name: &Name,
         measurements: &MeasurementData,
+        sig: &mut Signature,
     ) -> Result<usize, DpeErrorCode> {
         let bytes_written = self.encode_signed_payload(
             sign_cb,
@@ -2292,6 +2304,7 @@ impl CertWriter<'_> {
                 subject_name,
                 measurements,
             },
+            sig,
         )?;
 
         self.check_not_truncated()?;
@@ -2313,6 +2326,7 @@ impl CertWriter<'_> {
         subject_name: &Name,
         measurements: &MeasurementData,
         sid: &SignerIdentifier,
+        sig: &mut Signature,
     ) -> Result<usize, DpeErrorCode> {
         // ContentInfo SEQUENCE. This and the two nested SignedData layers reserve
         // their length fields up front (always 3 bytes) and backfill them below.
@@ -2352,18 +2366,23 @@ impl CertWriter<'_> {
         signed_data_body += self.encode_hash_alg_id();
 
         // encapContentInfo
-        signed_data_body +=
-            self.encode_encapsulated_content_info(sign_cb, pub_key, subject_name, measurements)?;
+        signed_data_body += self.encode_encapsulated_content_info(
+            sign_cb,
+            pub_key,
+            subject_name,
+            measurements,
+            sig,
+        )?;
 
         let (csr_start, csr_end) = self.csr_range.ok_or(DpeErrorCode::X509CsrUnset)?;
-        let sig = sign_cb(&*self.certificate, csr_start..csr_end, false);
-        let sig = okref(&sig)?;
+        sign_cb(&*self.certificate, csr_start..csr_end, false, sig)?;
 
         // signerInfos
         signed_data_body += self.encode_tag_field(Self::SET_OF_TAG);
         signed_data_body +=
             self.encode_size_field(self.get_signer_info_size(sig, sid, /*tagged=*/ true));
         signed_data_body += self.encode_signer_info(sig, sid)?;
+        sig.zeroize();
 
         // Each layer's size is its prefix (tag + reserved length, counted above)
         // plus its content — a plain sum, since the reserved length width is
@@ -2578,6 +2597,7 @@ fn generate_cert_or_csr(
     measurements: &MeasurementData,
     sign_cb: &mut dyn SignCallback,
     output_cert_or_csr: &mut dyn ResponseBuffer,
+    sig: &mut Signature,
 ) -> Result<u32, DpeErrorCode> {
     match format_specific_args {
         CertOrCsrArgs::Cert {
@@ -2605,6 +2625,7 @@ fn generate_cert_or_csr(
                     pub_key,
                     measurements,
                     cert_validity,
+                    sig,
                 )?;
                 u32::try_from(bytes_written)
                     .map_err(|_| DpeErrorCode::from(InternalErrorCode::CertSizeOverflow))
@@ -2623,6 +2644,7 @@ fn generate_cert_or_csr(
                 subject_name,
                 measurements,
                 signer_identifier,
+                sig,
             )?;
             u32::try_from(bytes_written)
                 .map_err(|_| DpeErrorCode::from(InternalErrorCode::CsrSizeOverflow))
@@ -2704,26 +2726,33 @@ fn create_dpe_cert_or_csr(
         subject_alt_name,
     };
 
-    let mut sign_cb =
-        |buf: &dyn ResponseBuffer, range: core::ops::Range<usize>, use_derived: bool| {
-            if use_derived {
-                if let Some(exported_handle) = exported_cdi_handle {
-                    crypto
-                        .derive_key_pair_exported(&exported_handle, args.key_label, args.context)?
-                        .sign(&SignData::ResponseBuffer(buf, range))
-                } else {
-                    crypto.sign_with_derived(
-                        &digest,
-                        args.cdi_label,
-                        args.key_label,
-                        args.context,
-                        &SignData::ResponseBuffer(buf, range),
-                    )
-                }
+    // Single signature buffer, filled in place by the sign callback and reused
+    // for each signature on the path (X509 cert, or inner CSR + outer CMS).
+    let mut sig = Signature::zeroed(crypto.signature_algorithm());
+
+    let mut sign_cb = |buf: &dyn ResponseBuffer,
+                       range: core::ops::Range<usize>,
+                       use_derived: bool,
+                       out: &mut Signature| {
+        if use_derived {
+            if let Some(exported_handle) = exported_cdi_handle {
+                crypto
+                    .derive_key_pair_exported(&exported_handle, args.key_label, args.context)?
+                    .sign(&SignData::ResponseBuffer(buf, range), out)
             } else {
-                crypto.sign_with_alias(&SignData::ResponseBuffer(buf, range))
+                crypto.sign_with_derived(
+                    &digest,
+                    args.cdi_label,
+                    args.key_label,
+                    args.context,
+                    &SignData::ResponseBuffer(buf, range),
+                    out,
+                )
             }
-        };
+        } else {
+            crypto.sign_with_alias(&SignData::ResponseBuffer(buf, range), out)
+        }
+    };
 
     let mut issuer_name = [0u8; MAX_ISSUER_NAME_SIZE];
     let cert_validity = platform.get_cert_validity()?;
@@ -2756,6 +2785,7 @@ fn create_dpe_cert_or_csr(
         &measurements,
         &mut sign_cb,
         output_cert_or_csr,
+        &mut sig,
     )?;
 
     Ok(CreateDpeCertResult {
@@ -3051,7 +3081,12 @@ pub(crate) mod tests {
 
         let mut sign_cb = |_buf: &dyn ResponseBuffer,
                            _range: core::ops::Range<usize>,
-                           _use_derived: bool| Ok(test_sig.clone());
+                           _use_derived: bool,
+                           out: &mut Signature| {
+            *out = test_sig.clone();
+            Ok(())
+        };
+        let mut sig = test_sig.clone();
 
         // SubjectKeyIdentifier keeps the SignerIdentifier setup simple.
         let mut ski = ArrayVec::new();
@@ -3083,10 +3118,17 @@ pub(crate) mod tests {
                 &pub_key,
                 &measurements,
                 &validity,
+                &mut sig,
             )
         });
         assert_overflow_detected(|w| {
-            w.encode_csr(&mut sign_cb, &pub_key, &TEST_SUBJECT_NAME, &measurements)
+            w.encode_csr(
+                &mut sign_cb,
+                &pub_key,
+                &TEST_SUBJECT_NAME,
+                &measurements,
+                &mut sig,
+            )
         });
         assert_overflow_detected(|w| {
             w.encode_cms(
@@ -3095,6 +3137,7 @@ pub(crate) mod tests {
                 &TEST_SUBJECT_NAME,
                 &measurements,
                 &sid,
+                &mut sig,
             )
         });
     }
@@ -3338,7 +3381,12 @@ pub(crate) mod tests {
 
         let mut sign_cb = |_buf: &dyn ResponseBuffer,
                            _range: core::ops::Range<usize>,
-                           _use_derived: bool| Ok(test_sig.clone());
+                           _use_derived: bool,
+                           out: &mut Signature| {
+            *out = test_sig.clone();
+            Ok(())
+        };
+        let mut sig = test_sig.clone();
 
         let mut cbuf = SliceResponseBuffer::new(cert_buf);
         let mut w = CertWriter::new(&mut cbuf, DPE_PROFILE, true);
@@ -3351,6 +3399,7 @@ pub(crate) mod tests {
                 &pub_key,
                 &measurements,
                 &validity,
+                &mut sig,
             )
             .unwrap();
 
@@ -3446,7 +3495,12 @@ pub(crate) mod tests {
 
         let mut sign_cb = |_buf: &dyn ResponseBuffer,
                            _range: core::ops::Range<usize>,
-                           _use_derived: bool| Ok(test_sig.clone());
+                           _use_derived: bool,
+                           out: &mut Signature| {
+            *out = test_sig.clone();
+            Ok(())
+        };
+        let mut sig = test_sig.clone();
 
         let mut cbuf = SliceResponseBuffer::new(cert_buf);
         let mut w = CertWriter::new(&mut cbuf, DPE_PROFILE, true);
@@ -3459,6 +3513,7 @@ pub(crate) mod tests {
                 &pub_key,
                 &measurements,
                 &validity,
+                &mut sig,
             )
             .unwrap();
 
@@ -3999,7 +4054,12 @@ pub(crate) mod tests {
         };
         let mut sign_cb = |_buf: &dyn ResponseBuffer,
                            _range: core::ops::Range<usize>,
-                           _use_derived: bool| Ok(test_sig.clone());
+                           _use_derived: bool,
+                           out: &mut Signature| {
+            *out = test_sig.clone();
+            Ok(())
+        };
+        let mut sig = test_sig.clone();
 
         let context = Context {
             state: ContextState::Active,
@@ -4028,7 +4088,8 @@ pub(crate) mod tests {
                 &pub_key,
                 &TEST_SUBJECT_NAME,
                 &measurements,
-                &sid
+                &sid,
+                &mut sig,
             ),
             Err(DpeErrorCode::X509InvalidState),
         );
@@ -4593,7 +4654,12 @@ pub(crate) mod tests {
         };
         let mut sign_cb = |_buf: &dyn ResponseBuffer,
                            _range: core::ops::Range<usize>,
-                           _use_derived: bool| Ok(test_sig.clone());
+                           _use_derived: bool,
+                           out: &mut Signature| {
+            *out = test_sig.clone();
+            Ok(())
+        };
+        let mut sig = test_sig.clone();
 
         let label_bytes: Vec<u8> = if max_size {
             vec![0xAB; MAX_UEID_SIZE]
@@ -4629,7 +4695,13 @@ pub(crate) mod tests {
         let mut sbuf = SliceResponseBuffer::new(&mut buf);
         let mut w = CertWriter::new(&mut sbuf, DPE_PROFILE, true);
         let n = w
-            .encode_csr(&mut sign_cb, &pub_key, &TEST_SUBJECT_NAME, &measurements)
+            .encode_csr(
+                &mut sign_cb,
+                &pub_key,
+                &TEST_SUBJECT_NAME,
+                &measurements,
+                &mut sig,
+            )
             .unwrap();
 
         let (_, csr) = X509CertificationRequest::from_der(&buf[..n])
@@ -4695,7 +4767,12 @@ pub(crate) mod tests {
         let test_sig = Signature::Mldsa(MldsaSignature([0xBBu8; ALGORITHM.signature_size()]));
         let mut sign_cb = |_buf: &dyn ResponseBuffer,
                            _range: core::ops::Range<usize>,
-                           _use_derived: bool| Ok(test_sig.clone());
+                           _use_derived: bool,
+                           out: &mut Signature| {
+            *out = test_sig.clone();
+            Ok(())
+        };
+        let mut sig = test_sig.clone();
 
         let label_bytes: Vec<u8> = if max_size {
             vec![0xAB; MAX_UEID_SIZE]
@@ -4731,7 +4808,13 @@ pub(crate) mod tests {
         let mut sbuf = SliceResponseBuffer::new(&mut buf);
         let mut w = CertWriter::new(&mut sbuf, DPE_PROFILE, true);
         let n = w
-            .encode_csr(&mut sign_cb, &pub_key, &TEST_SUBJECT_NAME, &measurements)
+            .encode_csr(
+                &mut sign_cb,
+                &pub_key,
+                &TEST_SUBJECT_NAME,
+                &measurements,
+                &mut sig,
+            )
             .unwrap();
 
         let (_, csr) = X509CertificationRequest::from_der(&buf[..n])

--- a/verification/panic-check/firmware/src/crypto_dummy.rs
+++ b/verification/panic-check/firmware/src/crypto_dummy.rs
@@ -74,8 +74,13 @@ impl Crypto for DummyCrypto {
         Err(CryptoError::NotImplemented)
     }
 
-    fn sign_with_alias(&mut self, data: &SignData) -> Result<crypto::Signature, CryptoError> {
+    fn sign_with_alias(
+        &mut self,
+        data: &SignData,
+        out: &mut crypto::Signature,
+    ) -> Result<(), CryptoError> {
         let _ = data;
+        let _ = out;
         Err(CryptoError::NotImplemented)
     }
 }
@@ -135,8 +140,9 @@ impl CdiManager for DummyCdiManager {
 pub struct DummySigner;
 
 impl Signer for DummySigner {
-    fn sign(&mut self, data: &SignData) -> Result<crypto::Signature, CryptoError> {
+    fn sign(&mut self, data: &SignData, out: &mut crypto::Signature) -> Result<(), CryptoError> {
         let _ = data;
+        let _ = out;
         Err(CryptoError::NotImplemented)
     }
 


### PR DESCRIPTION
Change the `sign` trait to return the signature as an out parameter instead of returning by value.

This allows the internal DPE logic to utilize a consistent buffer for signatures, saving ~9Kb of stack space for standard signing requests.

This requires a change to the public facing API as well.