### PR TITLE
dpe: make public key an output argument for Signer

### DIFF
--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -365,20 +365,6 @@ pub enum PubKey {
     Mldsa(ml_dsa::MldsaPublicKey),
 }
 
-impl Default for PubKey {
-    /// A zeroed placeholder key. Used only to pre-initialize a caller-provided
-    /// `CreateDpeCertResult` slot that the cert/CSR path overwrites before use;
-    /// the always-compiled ECDSA-384 variant keeps this independent of `ml-dsa`.
-    fn default() -> Self {
-        PubKey::Ecdsa(ecdsa::EcdsaPubKey::Ecdsa384(
-            ecdsa::curve_384::EcdsaPub384 {
-                x: [0u8; ecdsa::curve_384::CURVE_SIZE],
-                y: [0u8; ecdsa::curve_384::CURVE_SIZE],
-            },
-        ))
-    }
-}
-
 impl From<ecdsa::EcdsaPubKey> for PubKey {
     fn from(pub_key: ecdsa::EcdsaPubKey) -> Self {
         PubKey::Ecdsa(pub_key)
@@ -494,7 +480,7 @@ pub trait Signer {
     fn sign(&mut self, data: &SignData, out: &mut Signature) -> Result<(), CryptoError>;
 
     /// Get the public key associated with the derived key-pair
-    fn public_key(&mut self) -> Result<PubKey, CryptoError>;
+    fn public_key(&mut self, out: &mut PubKey) -> Result<(), CryptoError>;
 }
 
 pub trait CdiManager {
@@ -544,8 +530,13 @@ pub trait CdiManager {
     ///
     /// * `label` - Caller-supplied label to use in asymmetric key derivation
     /// * `info` - Caller-supplied info string to use in asymmetric key derivation
-    fn derive_pub_key(&mut self, label: &[u8], info: &[u8]) -> Result<PubKey, CryptoError> {
-        self.derive_key_pair(label, info)?.public_key()
+    fn derive_pub_key(
+        &mut self,
+        label: &[u8],
+        info: &[u8],
+        out: &mut PubKey,
+    ) -> Result<(), CryptoError> {
+        self.derive_key_pair(label, info)?.public_key(out)
     }
 
     /// This should only be used in testing
@@ -723,8 +714,9 @@ pub trait Crypto {
         info: &[u8],
         label: &[u8],
         derived_info: &[u8],
-    ) -> Result<PubKey, CryptoError> {
+        out: &mut PubKey,
+    ) -> Result<(), CryptoError> {
         self.derive_cdi(measurement, info)?
-            .derive_pub_key(label, derived_info)
+            .derive_pub_key(label, derived_info, out)
     }
 }

--- a/crypto/src/rustcrypto.rs
+++ b/crypto/src/rustcrypto.rs
@@ -2,8 +2,9 @@
 
 use crate::{
     ecdsa::{
-        curve_256::EcdsaSignature256, curve_384::EcdsaSignature384, EcdsaAlgorithm, EcdsaPub,
-        EcdsaSig,
+        curve_256::{EcdsaPub256, EcdsaSignature256},
+        curve_384::{EcdsaPub384, EcdsaSignature384},
+        EcdsaAlgorithm, EcdsaPubKey, EcdsaSig,
     },
     hkdf::*,
     CdiManager, Crypto, CryptoError, CryptoSuite, Digest, DigestAlgorithm, DigestType,
@@ -178,31 +179,33 @@ impl crate::Signer for RustCryptoSigner {
         Ok(())
     }
 
-    fn public_key(&mut self) -> Result<PubKey, CryptoError> {
+    fn public_key(&mut self, out: &mut PubKey) -> Result<(), CryptoError> {
         match self.signature_alg {
             SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit256) => {
                 let signing = p256::ecdsa::SigningKey::from_slice(self.priv_key.as_slice())?;
                 let verifying = p256::ecdsa::VerifyingKey::from(&signing);
                 let point = verifying.to_encoded_point(false);
 
-                let mut x = [0; EcdsaAlgorithm::Bit256.curve_size()];
-                let mut y = [0; EcdsaAlgorithm::Bit256.curve_size()];
+                let PubKey::Ecdsa(EcdsaPubKey::Ecdsa256(EcdsaPub256 { x, y })) = out else {
+                    return Err(CryptoError::MismatchedAlgorithm);
+                };
                 x.clone_from_slice(point.x().ok_or(RUSTCRYPTO_ECDSA_ERROR)?.as_ref());
                 y.clone_from_slice(point.y().ok_or(RUSTCRYPTO_ECDSA_ERROR)?.as_ref());
 
-                Ok(EcdsaPub::from_slice(&x, &y).into())
+                Ok(())
             }
             SignatureAlgorithm::Ecdsa(EcdsaAlgorithm::Bit384) => {
                 let signing = p384::ecdsa::SigningKey::from_slice(self.priv_key.as_slice())?;
                 let verifying = p384::ecdsa::VerifyingKey::from(&signing);
                 let point = verifying.to_encoded_point(false);
 
-                let mut x = [0; EcdsaAlgorithm::Bit384.curve_size()];
-                let mut y = [0; EcdsaAlgorithm::Bit384.curve_size()];
+                let PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384 { x, y })) = out else {
+                    return Err(CryptoError::MismatchedAlgorithm);
+                };
                 x.clone_from_slice(point.x().ok_or(RUSTCRYPTO_ECDSA_ERROR)?.as_ref());
                 y.clone_from_slice(point.y().ok_or(RUSTCRYPTO_ECDSA_ERROR)?.as_ref());
 
-                Ok(EcdsaPub::from_slice(&x, &y).into())
+                Ok(())
             }
             #[cfg(feature = "ml-dsa")]
             SignatureAlgorithm::Mldsa(MldsaAlgorithm::Mldsa87) => {
@@ -214,10 +217,13 @@ impl crate::Signer for RustCryptoSigner {
                 );
                 let verifying = kp.verifying_key();
                 let encoded_key = verifying.encode();
-                Ok(PubKey::Mldsa(
-                    MldsaPublicKey::read_from_bytes(encoded_key.as_bytes())
-                        .map_err(|_| RUSTCRYPTO_ML_DSA_ERROR)?,
-                ))
+
+                let PubKey::Mldsa(MldsaPublicKey(pk)) = out else {
+                    return Err(CryptoError::MismatchedAlgorithm);
+                };
+                pk.copy_from_slice(encoded_key.as_bytes());
+
+                Ok(())
             }
         }
     }

--- a/dpe/src/commands/certify_key.rs
+++ b/dpe/src/commands/certify_key.rs
@@ -195,7 +195,7 @@ impl CommandExecution for CertifyKeyCommand<'_> {
         let mut cert_view = OffsetResponseBuffer::new(out, hdr_size);
         // Single result slot, filled in place by the cert/CSR path, so only one
         // `CreateDpeCertResult` — and thus one `PubKey` — occupies this frame.
-        let mut result = CreateDpeCertResult::default();
+        let mut result = CreateDpeCertResult::zeroed(dpe.profile);
         Self::run_cert_format(format, &args, dpe, env, &mut cert_view, &mut result)?;
 
         #[allow(clippy::indexing_slicing)]

--- a/dpe/src/commands/derive_context.rs
+++ b/dpe/src/commands/derive_context.rs
@@ -393,7 +393,7 @@ impl CommandExecution for DeriveContextCmd {
                         ueid,
                         dice_extensions_are_critical: env.state().flags.contains(DpeFlags::MARK_DICE_EXTENSIONS_CRITICAL),
                     };
-                    let mut result = CreateDpeCertResult::default();
+                    let mut result = CreateDpeCertResult::zeroed(dpe.profile);
                     create_exported_dpe_cert(&args, dpe, env, &mut cert_view, &mut result)?;
                     let CreateDpeCertResult { cert_size, exported_cdi_handle, .. } = &result;
 

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -15,6 +15,10 @@ use crate::{
 use bitflags::bitflags;
 #[cfg(feature = "cfi")]
 use caliptra_cfi_lib::{cfi_assert, cfi_assert_bool, cfi_launder};
+#[cfg(feature = "p256")]
+use caliptra_dpe_crypto::ecdsa::curve_256::{self, EcdsaPub256};
+#[cfg(feature = "p384")]
+use caliptra_dpe_crypto::ecdsa::curve_384::{self, EcdsaPub384};
 #[cfg(any(feature = "p256", feature = "p384"))]
 use caliptra_dpe_crypto::ecdsa::EcdsaPubKey;
 use caliptra_dpe_crypto::{
@@ -34,7 +38,7 @@ use zerocopy::IntoBytes;
 use zeroize::Zeroize;
 
 #[cfg(feature = "ml-dsa")]
-use caliptra_dpe_crypto::ml_dsa::{MldsaPublicKey, MldsaSignature};
+use caliptra_dpe_crypto::ml_dsa::{MldsaAlgorithm, MldsaPublicKey, MldsaSignature};
 
 /// Signing callback passed to cert and CSR encoding functions.
 ///
@@ -2437,7 +2441,6 @@ pub(crate) struct CreateDpeCertArgs<'a> {
 }
 
 /// Results for DPE cert or CSR creation.
-#[derive(Default)]
 pub(crate) struct CreateDpeCertResult {
     /// Size of certificate or CSR in bytes.
     pub cert_size: u32,
@@ -2446,6 +2449,32 @@ pub(crate) struct CreateDpeCertResult {
     /// If the cert_type is `CertificateType::Exported` the CDI is exchanged for a handle, and
     /// returned via `exported_cdi_handle`.
     pub exported_cdi_handle: [u8; MAX_EXPORTED_CDI_SIZE],
+}
+
+impl CreateDpeCertResult {
+    pub fn zeroed(profile: DpeProfile) -> Self {
+        let pub_key = match profile {
+            #[cfg(feature = "p256")]
+            DpeProfile::P256Sha256 => PubKey::Ecdsa(EcdsaPubKey::Ecdsa256(EcdsaPub256 {
+                x: [0u8; curve_256::CURVE_SIZE],
+                y: [0u8; curve_256::CURVE_SIZE],
+            })),
+            #[cfg(feature = "p384")]
+            DpeProfile::P384Sha384 => PubKey::Ecdsa(EcdsaPubKey::Ecdsa384(EcdsaPub384 {
+                x: [0u8; curve_384::CURVE_SIZE],
+                y: [0u8; curve_384::CURVE_SIZE],
+            })),
+            #[cfg(feature = "ml-dsa")]
+            DpeProfile::Mldsa87 => PubKey::Mldsa(MldsaPublicKey(
+                [0u8; MldsaAlgorithm::Mldsa87.public_key_size()],
+            )),
+        };
+        Self {
+            cert_size: 0,
+            pub_key,
+            exported_cdi_handle: [0u8; MAX_EXPORTED_CDI_SIZE],
+        }
+    }
 }
 
 fn get_dpe_measurement_digest(
@@ -2678,11 +2707,15 @@ fn create_dpe_cert_or_csr(
             exported_cdi_handle = Some(exported_handle);
             crypto
                 .derive_key_pair_exported(&exported_handle, args.key_label, args.context)?
-                .public_key()
+                .public_key(&mut out_result.pub_key)
         }
-        CertificateType::Leaf => {
-            crypto.derive_pub_key(&digest, args.cdi_label, args.key_label, args.context)
-        }
+        CertificateType::Leaf => crypto.derive_pub_key(
+            &digest,
+            args.cdi_label,
+            args.key_label,
+            args.context,
+            &mut out_result.pub_key,
+        ),
     };
     let pub_key_ok = pub_key_res.is_ok();
     #[cfg(feature = "cfi")]
@@ -2694,7 +2727,7 @@ fn create_dpe_cert_or_csr(
         #[cfg(feature = "cfi")]
         cfi_assert!(pub_key_res.is_err());
     }
-    out_result.pub_key = pub_key_res?;
+    pub_key_res?;
     let pub_key = &out_result.pub_key;
     let mut subj_serial = [0u8; MAX_HASH_SIZE * 2];
     let subject_name = get_subject_name(crypto, &cert_type, pub_key, &mut subj_serial)?;

--- a/verification/panic-check/firmware/src/crypto_dummy.rs
+++ b/verification/panic-check/firmware/src/crypto_dummy.rs
@@ -146,7 +146,7 @@ impl Signer for DummySigner {
         Err(CryptoError::NotImplemented)
     }
 
-    fn public_key(&mut self) -> Result<PubKey, CryptoError> {
+    fn public_key(&mut self, _out: &mut PubKey) -> Result<(), CryptoError> {
         Err(CryptoError::NotImplemented)
     }
 }


### PR DESCRIPTION
Avoid returning the public key by-value from `Signer::public_key`, saving stack space for ML-DSA signing path.

Stack size comparison before and after the change:
```
command                               bytes  % stack    command                               bytes  % stack
----------------------------------------------------    ----------------------------------------------------
CERTIFY_KEY_EXTENDED_MLDSA87          47760    54.9%    CERTIFY_KEY_EXTENDED_MLDSA87          45168    51.9%
```

Caliptra-sw runtime code size is about 100 bytes smaller. Comparison before and after this change:
```
│ Runtime with ML-DSA    │ 97,652 │ 128  │ 103,684 │ 94.2% │ 6,032 │
│ Runtime with ML-DSA    │ 97,420 │ 128  │ 103,684 │ 94.1% │ 6,136 │
```