### PR TITLE
dpe: call next on a fresh iter to get the first node

### DIFF
--- a/dpe/src/context.rs
+++ b/dpe/src/context.rs
@@ -393,12 +393,6 @@ impl<'a> RootToChildIter<'a> {
         self.path.is_empty()
     }
 
-    pub fn first_node(&mut self) -> Result<&'a Context, DpeErrorCode> {
-        self.contexts
-            .first()
-            .ok_or(InternalErrorCode::ContextIndexOob.into())
-    }
-
     /// Attempt to get the context at index `idx` and validate it.
     fn get_context(&mut self, idx: usize) -> Result<&'a Context, DpeErrorCode> {
         let Some(context) = self.contexts.get(idx) else {

--- a/dpe/src/x509.rs
+++ b/dpe/src/x509.rs
@@ -150,7 +150,10 @@ impl<'a> TciNodes<'a> {
     }
 
     pub fn first_node(&self) -> Result<&TciNodeData, DpeErrorCode> {
-        self.iter()?.first_node().map(|context| &context.tci)
+        self.iter()?
+            .next()
+            .ok_or(InternalErrorCode::ContextIndexOob)?
+            .map(|context| &context.tci)
     }
 }
 


### PR DESCRIPTION
Currently `TciNodes::first_node` calls `RootToChildIter::first_node` to get the first node, but the latter simply returns `context.first()`. This is fine in the current codebase since `first_node` is only called in x509 to get the size of the nodes, rather than using the actual fields. However this could confuse future readers. This commit explicitly calls `next` on a freshly created iterator.